### PR TITLE
Added .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+BasedOnStyle: Google
+---
+Language:                               Cpp
+PointerAlignment:                       Right
+BreakBeforeBraces:                      Attach
+AllowShortBlocksOnASingleLine:          false
+AllowShortFunctionsOnASingleLine:       Empty
+Cpp11BracedListStyle:                   true
+Standard:                               Cpp11
+---


### PR DESCRIPTION
The clang-format tool can use the coding style defined in .clang-format
Refer to https://clang.llvm.org/docs/ClangFormatStyleOptions.html for more options