### PR TITLE
add message for starting building after warning on ESD CAN

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -103,6 +103,7 @@ function apollo_build() {
   if [ -d release ];then
     rm -rf release
   fi
+  echo "Start building, please wait ..."
   generate_build_targets
   echo "Building on $MACHINE_ARCH, with targets:"
   echo "$BUILD_TARGETS"


### PR DESCRIPTION
add a message reminding developers that apollo is continuing building after the message about warning on ESD CAN.