### PR TITLE
moved how_to_contribute_code.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,3 @@ The following is a commit message example:
 >
 > Fixes #1234
 
-


### PR DESCRIPTION
GitHub only takes CONTRIBUTING.md as the contributing guidelines