### PR TITLE
Add a check against nullptr in apollo/modules/common

### DIFF
--- a/modules/common/vehicle_state/vehicle_state.cc
+++ b/modules/common/vehicle_state/vehicle_state.cc
@@ -27,7 +27,7 @@ namespace vehicle_state {
 VehicleState::VehicleState(
     const localization::LocalizationEstimate &localization) {
   ConstructExceptLinearVelocity(&localization);
-  if (localization.has_pose() && localization.pose().has_linear_velocity()) {
+  if (localization != nullptr && localization.has_pose() && localization.pose().has_linear_velocity()) {
     linear_v_ = localization.pose().linear_velocity().y();
   }
 }


### PR DESCRIPTION
In apollo/modules/common/vehicle_state/vehicle_state.cc line 30
Should check localization != nullptr before checking localization.has_pose()
though in ConstructExceptLinearVelocity we already check if localization == nullptr
but it will still cause a runtime error when executing line 30