### PR TITLE
add a setter for state covariance in kalman filter for future use

### DIFF
--- a/modules/common/math/kalman_filter.h
+++ b/modules/common/math/kalman_filter.h
@@ -121,6 +121,13 @@ class KalmanFilter {
   void SetObservationNoise(const Eigen::Matrix<T, ZN, ZN>& R) { R_ = R; }
 
   /**
+   * @brief Changes the covariance matrix of current state belief distribution.
+   *
+   * @param P New state covariance matrix
+   */
+  void SetStateCovariance(const Eigen::Matrix<T, XN, XN>& P) { P_ = P; }
+
+  /**
    * @brief Changes the control matrix in the state transition rule.
    *
    * @param B New control matrix


### PR DESCRIPTION
Add a setter to the state covariance matrix P in kalman filter. This will be used in prediction module which is still in developing.