### PR TITLE
Fix function name conflict in apollo.sh and scripts/apollo_base.sh

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -185,7 +185,7 @@ function stop() {
     fi
 }
 
-function print_usage() {
+function help() {
   echo "Usage:
   ./$0 [COMMAND]"
   echo "COMMAND:
@@ -209,7 +209,7 @@ function run() {
             stop "$2"
             ;;
         help)
-            print_usage
+            help
             ;;
         *)
             start "$2"


### PR DESCRIPTION
apollo.sh source "scripts/apollo_base.sh" which causes function name conflict.  When running "./apollo.sh" without any parameter,  it will call the function "print_usage" defined in "apollo_base.sh".