### PR TITLE
Fixing description of steering rate.

### DIFF
--- a/modules/control/proto/control_cmd.proto
+++ b/modules/control/proto/control_cmd.proto
@@ -24,10 +24,10 @@ message ControlCommand {
   // target brake in percentage [0, 100]
   optional double brake = 4;
 
-  // target steering rate, in percentage of full scale per second [-100, 100]
+  // target non-directional steering rate, in percentage of full scale per second [0, 100]
   optional double steering_rate = 6;
 
-  // target steerig angle, in percentage of full scalce [-100, 100]
+  // target steering angle, in percentage of full scale [-100, 100]
   optional double steering_target = 7;
 
   // parking brake engage. true: engaged


### PR DESCRIPTION
Fixing comment for clarity - in practice the steering rate is always 100.0 (set with a command line flag in the lateral controller), and it cannot be in [-100.0, 0.0).