### PR TITLE
HMI: Migrate to gevent from eventlet which has a known fatal bug.

### DIFF
--- a/modules/hmi/web/handlers.py
+++ b/modules/hmi/web/handlers.py
@@ -29,7 +29,7 @@ from socketio_api import SocketIOApi
 
 app = flask.Flask(__name__)
 app.secret_key = str(datetime.datetime.now())
-socketio = flask_socketio.SocketIO(app, async_mode='eventlet')
+socketio = flask_socketio.SocketIO(app)
 
 
 # Web page handlers.

--- a/modules/tools/py27_requirements.txt
+++ b/modules/tools/py27_requirements.txt
@@ -8,9 +8,9 @@ protobuf == 3.1
 python-gflags
 
 # Web utils.
-eventlet
 flask
 flask-socketio
+gevent
 requests >= 2.18
 simplejson
 


### PR DESCRIPTION
To our knowledge, new version of python, such as 2.7.13, doesn' work well with eventlet 0.21.
See https://github.com/eventlet/eventlet/issues/428
