### PR TITLE
remove timestamp in message_manager and protocol_data

### DIFF
--- a/modules/drivers/canbus/can_comm/can_receiver.h
+++ b/modules/drivers/canbus/can_comm/can_receiver.h
@@ -170,10 +170,7 @@ void CanReceiver<SensorType>::RecvThreadFunc() {
       uint8_t len = frame.len;
       uint32_t uid = frame.id;
       const uint8_t *data = frame.data;
-      struct timeval timestamp;
-      timestamp.tv_sec = frame.timestamp.tv_sec;
-      timestamp.tv_usec = frame.timestamp.tv_usec;
-      pt_manager_->Parse(uid, data, len, timestamp);
+      pt_manager_->Parse(uid, data, len);
       if (enable_log_) {
         ADEBUG << "recv_can_frame#" << frame.CanFrameString();
       }

--- a/modules/drivers/canbus/can_comm/message_manager.h
+++ b/modules/drivers/canbus/can_comm/message_manager.h
@@ -81,16 +81,6 @@ class MessageManager {
    * @param message_id the id of the message
    * @param data a pointer to the data array to be parsed
    * @param length the length of data array
-   * @param timestamp the timestamp of data
-   */
-  virtual void Parse(const uint32_t message_id, const uint8_t *data,
-                     int32_t length, struct timeval timestamp);
-
-  /**
-   * @brief parse data and store parsed info in protocol data
-   * @param message_id the id of the message
-   * @param data a pointer to the data array to be parsed
-   * @param length the length of data array
    */
   virtual void Parse(const uint32_t message_id, const uint8_t *data,
                      int32_t length);
@@ -183,49 +173,16 @@ ProtocolData<SensorType>
 
 template <typename SensorType>
 void MessageManager<SensorType>::Parse(const uint32_t message_id,
-                                       const uint8_t *data, int32_t length,
-                                       struct timeval timestamp) {
-  ProtocolData<SensorType> *protocol_data =
-      GetMutableProtocolDataById(message_id);
-  if (protocol_data == nullptr) {
-    return;
-  }
-  if (timestamp.tv_sec == static_cast<time_t>(0)) {
-    std::lock_guard<std::mutex> lock(sensor_data_mutex_);
-    protocol_data->Parse(data, length, &sensor_data_);
-  } else {
-    // TODO(Authors): only lincoln implemented this virtual function
-    std::lock_guard<std::mutex> lock(sensor_data_mutex_);
-    protocol_data->Parse(data, length, timestamp, &sensor_data_);
-  }
-  received_ids_.insert(message_id);
-  // check if need to check period
-  const auto it = check_ids_.find(message_id);
-  if (it != check_ids_.end()) {
-    const int64_t time = apollo::common::time::AsInt64<micros>(Clock::Now());
-    it->second.real_period = time - it->second.last_time;
-    // if period 1.5 large than base period, inc error_count
-    const double period_multiplier = 1.5;
-    if (it->second.real_period > (it->second.period * period_multiplier)) {
-      it->second.error_count += 1;
-    } else {
-      it->second.error_count = 0;
-    }
-    it->second.last_time = time;
-  }
-}
-
-// TODO(Authors): remove redundant code
-template <typename SensorType>
-void MessageManager<SensorType>::Parse(const uint32_t message_id,
                                        const uint8_t *data, int32_t length) {
   ProtocolData<SensorType> *protocol_data =
       GetMutableProtocolDataById(message_id);
   if (protocol_data == nullptr) {
     return;
   }
-  std::lock_guard<std::mutex> lock(sensor_data_mutex_);
-  protocol_data->Parse(data, length, &sensor_data_);
+  {
+    std::lock_guard<std::mutex> lock(sensor_data_mutex_);
+    protocol_data->Parse(data, length, &sensor_data_);
+  }
   received_ids_.insert(message_id);
   // check if need to check period
   const auto it = check_ids_.find(message_id);

--- a/modules/drivers/canbus/can_comm/message_manager_test.cc
+++ b/modules/drivers/canbus/can_comm/message_manager_test.cc
@@ -46,10 +46,9 @@ class MockMessageManager
 };
 
 TEST(MessageManagerTest, GetMutableProtocolDataById) {
-  struct timeval curr_time;
   uint8_t mock_data = 1;
   MockMessageManager manager;
-  manager.Parse(MockProtocolData::ID, &mock_data, 8, curr_time);
+  manager.Parse(MockProtocolData::ID, &mock_data, 8);
   manager.ResetSendMessages();
   EXPECT_TRUE(manager.GetMutableProtocolDataById(MockProtocolData::ID) !=
               nullptr);

--- a/modules/drivers/canbus/can_comm/protocol_data.h
+++ b/modules/drivers/canbus/can_comm/protocol_data.h
@@ -83,17 +83,6 @@ class ProtocolData {
                      SensorType *sensor_data) const;
 
   /*
-   * @brief parse received data
-   * @param bytes a pointer to the input bytes
-   * @param length the length of the input bytes
-   * @param timestamp the timestamp of input data
-   * @param sensor_data the parsed sensor_data
-   */
-  virtual void Parse(const uint8_t *bytes, int32_t length,
-                     const struct timeval &timestamp,
-                     SensorType *sensor_data) const;
-
-  /*
    * @brief update the data
    */
   virtual void UpdateData(uint8_t *data);
@@ -151,15 +140,8 @@ int32_t ProtocolData<SensorType>::GetLength() const {
 }
 
 template <typename SensorType>
-void ProtocolData<SensorType>::Parse(const uint8_t * /*bytes*/,
-                                     int32_t /*length*/,
-                                     SensorType * /*sensor_data*/) const {}
-
-template <typename SensorType>
 void ProtocolData<SensorType>::Parse(const uint8_t *bytes, int32_t length,
-                                     const struct timeval &timestamp,
                                      SensorType *sensor_data) const {
-  Parse(bytes, length, sensor_data);
 }
 
 template <typename SensorType>

--- a/modules/drivers/delphi_esr/delphi_esr_canbus.h
+++ b/modules/drivers/delphi_esr/delphi_esr_canbus.h
@@ -21,9 +21,9 @@
 #ifndef MODULES_DRIVERS_DELPHI_ESR_DELPHI_ESR_CANBUS_H_
 #define MODULES_DRIVERS_DELPHI_ESR_DELPHI_ESR_CANBUS_H_
 
+#include "modules/drivers/canbus/sensor_canbus.h"
 #include "modules/drivers/delphi_esr/delphi_esr_message_manager.h"
 #include "modules/drivers/proto/delphi_esr.pb.h"
-#include "modules/drivers/canbus/sensor_canbus.h"
 
 /**
  * @namespace apollo::drivers

--- a/modules/drivers/delphi_esr/delphi_esr_message_manager.h
+++ b/modules/drivers/delphi_esr/delphi_esr_message_manager.h
@@ -21,8 +21,8 @@
 #ifndef MODULES_DRIVERS_DELPHI_ESR_DELPHI_ESR_MESSAGE_MANAGER_H_
 #define MODULES_DRIVERS_DELPHI_ESR_DELPHI_ESR_MESSAGE_MANAGER_H_
 
-#include "modules/drivers/proto/delphi_esr.pb.h"
 #include "modules/drivers/canbus/can_comm/message_manager.h"
+#include "modules/drivers/proto/delphi_esr.pb.h"
 
 #include "modules/common/adapters/adapter_manager.h"
 #include "modules/drivers/canbus/sensor_gflags.h"
@@ -84,9 +84,8 @@ MessageManager<DelphiESR>::MessageManager() {
 }
 
 template <>
-ProtocolData<DelphiESR>
-    *MessageManager<DelphiESR>::GetMutableProtocolDataById(
-        const uint32_t message_id) {
+ProtocolData<DelphiESR> *MessageManager<DelphiESR>::GetMutableProtocolDataById(
+    const uint32_t message_id) {
   uint32_t converted_message_id = message_id;
   if (message_id >= 0x500 && message_id <= 0x539) {
     // repeated obstacle info
@@ -104,8 +103,7 @@ ProtocolData<DelphiESR>
 
 template <>
 void MessageManager<DelphiESR>::Parse(const uint32_t message_id,
-                                            const uint8_t *data,
-                                            int32_t length) {
+                                      const uint8_t *data, int32_t length) {
   ProtocolData<DelphiESR> *sensor_protocol_data =
       GetMutableProtocolDataById(message_id);
   if (sensor_protocol_data == nullptr) {

--- a/modules/drivers/delphi_esr/delphi_esr_message_manager_test.cc
+++ b/modules/drivers/delphi_esr/delphi_esr_message_manager_test.cc
@@ -21,8 +21,8 @@
 
 #include "gtest/gtest.h"
 
-#include "modules/drivers/proto/delphi_esr.pb.h"
 #include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/drivers/proto/delphi_esr.pb.h"
 
 namespace apollo {
 namespace drivers {


### PR DESCRIPTION
two versions of Parse() in message_manager and protocol_data (with and without timestamp) seem to be identical; merging into one without timestamp