### PR TITLE
planning: remove infinite wait from reference line provider in case o…

### DIFF
--- a/modules/planning/planning.cc
+++ b/modules/planning/planning.cc
@@ -164,10 +164,6 @@ Status Planning::Start() {
 
 void Planning::OnTimer(const ros::TimerEvent&) {
   RunOnce();
-  if (frame_) {
-    auto seq_num = frame_->SequenceNum();
-    FrameHistory::instance()->Add(seq_num, std::move(frame_));
-  }
 }
 
 void Planning::PublishPlanningPb(ADCTrajectory* trajectory_pb,
@@ -247,6 +243,10 @@ void Planning::RunOnce() {
       status.Save(estop.mutable_header()->mutable_status());
       PublishPlanningPb(&estop, start_timestamp);
     }
+    if (frame_) {
+      auto seq_num = frame_->SequenceNum();
+      FrameHistory::instance()->Add(seq_num, std::move(frame_));
+    }
     return;
   }
 
@@ -267,6 +267,10 @@ void Planning::RunOnce() {
     status.Save(trajectory_pb.mutable_header()->mutable_status());
     PublishPlanningPb(&trajectory_pb, start_timestamp);
     AERROR << "Planning failed";
+  }
+  if (frame_) {
+    auto seq_num = frame_->SequenceNum();
+    FrameHistory::instance()->Add(seq_num, std::move(frame_));
   }
 }
 

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -108,8 +108,9 @@ std::vector<ReferenceLine> ReferenceLineProvider::GetReferenceLines() {
   // can cover thoroughly the current adc position so that planning can be make
   // with a minimum planning distance of 100 meters ahead and 10 meters
   // backward.
-  while (reference_line_groups_.empty()) {
-    std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(20));
+  std::vector<ReferenceLine> reference_lines;
+  if (reference_line_groups_.empty()) {
+    return reference_lines;
   }
   std::lock_guard<std::mutex> lock(reference_line_groups_mutex_);
   return reference_line_groups_.back();


### PR DESCRIPTION
…f no reference line. it can cause deadlock to fail to update ADC position.