### PR TITLE
Planning: used inheritence for two different types of reference smoot…

### DIFF
--- a/modules/planning/common/BUILD
+++ b/modules/planning/common/BUILD
@@ -208,9 +208,9 @@ cc_library(
         "//modules/planning/common/trajectory:discretized_trajectory",
         "//modules/planning/common/trajectory:publishable_trajectory",
         "//modules/planning/proto:planning_proto",
-        "//modules/planning/proto:reference_line_smoother_config_proto",
+        "//modules/planning/proto:qp_spline_reference_line_smoother_config_proto",
+        "//modules/planning/reference_line:qp_spline_reference_line_smoother",
         "//modules/planning/reference_line:reference_line_provider",
-        "//modules/planning/reference_line:reference_line_smoother",
     ],
 )
 

--- a/modules/planning/common/frame.cc
+++ b/modules/planning/common/frame.cc
@@ -37,8 +37,8 @@
 #include "modules/map/hdmap/hdmap_util.h"
 #include "modules/map/pnc_map/pnc_map.h"
 #include "modules/planning/common/planning_gflags.h"
+#include "modules/planning/reference_line/qp_spline_reference_line_smoother.h"
 #include "modules/planning/reference_line/reference_line_provider.h"
-#include "modules/planning/reference_line/reference_line_smoother.h"
 
 namespace apollo {
 namespace planning {
@@ -218,7 +218,7 @@ Status Frame::Init(const PlanningConfig &config,
     AERROR << "init point is not set";
     return Status(ErrorCode::PLANNING_ERROR, "init point is not set");
   }
-  smoother_config_ = config.reference_line_smoother_config();
+  smoother_config_ = config.qp_spline_reference_line_smoother_config();
 
   ADEBUG << "Enabled align prediction time ? : " << std::boolalpha
          << FLAGS_align_prediction_time;
@@ -294,14 +294,14 @@ bool Frame::CreateReferenceLineFromRouting(
     return false;
   }
 
-  ReferenceLineSmoother smoother;
+  QpSplineReferenceLineSmoother smoother;
   std::vector<double> init_t_knots;
   Spline2dSolver spline_solver(init_t_knots, smoother_config_.spline_order());
   smoother.Init(smoother_config_, &spline_solver);
 
   SpiralReferenceLineSmoother spiral_smoother;
   double max_spiral_smoother_dev = 0.1;
-  spiral_smoother.set_max_point_deviation(max_spiral_smoother_dev);
+  spiral_smoother.Init(max_spiral_smoother_dev);
 
   for (const auto &each_segments : route_segments) {
     hdmap::Path hdmap_path;

--- a/modules/planning/common/frame.h
+++ b/modules/planning/common/frame.h
@@ -32,7 +32,7 @@
 #include "modules/planning/proto/planning.pb.h"
 #include "modules/planning/proto/planning_config.pb.h"
 #include "modules/planning/proto/planning_internal.pb.h"
-#include "modules/planning/proto/reference_line_smoother_config.pb.h"
+#include "modules/planning/proto/qp_spline_reference_line_smoother_config.pb.h"
 #include "modules/prediction/proto/prediction_obstacle.pb.h"
 #include "modules/routing/proto/routing.pb.h"
 
@@ -137,7 +137,7 @@ class Frame {
   uint32_t sequence_num_ = 0;
   localization::Pose init_pose_;
   static std::unique_ptr<hdmap::PncMap> pnc_map_;
-  ReferenceLineSmootherConfig smoother_config_;
+  QpSplineReferenceLineSmootherConfig smoother_config_;
 
   std::string collision_obstacle_id_;
 };

--- a/modules/planning/conf/planning_config.pb.txt
+++ b/modules/planning/conf/planning_config.pb.txt
@@ -127,7 +127,7 @@ em_planner_config {
     }
 }
 
-reference_line_smoother_config {
+qp_spline_reference_line_smoother_config {
     spline_order: 6
     constraint_to_knots_ratio: 5
     max_spline_length: 25.0

--- a/modules/planning/planner/em/BUILD
+++ b/modules/planning/planner/em/BUILD
@@ -26,7 +26,7 @@ cc_library(
         "//modules/planning/planner",
         "//modules/planning/proto:planning_proto",
         "//modules/planning/reference_line",
-        "//modules/planning/reference_line:reference_line_smoother",
+        "//modules/planning/reference_line:qp_spline_reference_line_smoother",
         "//modules/planning/tasks:path_optimizer",
         "//modules/planning/tasks:speed_optimizer",
         "//modules/planning/tasks:task",

--- a/modules/planning/planning.cc
+++ b/modules/planning/planning.cc
@@ -131,7 +131,7 @@ Status Planning::Init() {
   }
   if (FLAGS_enable_reference_line_provider_thread) {
     ReferenceLineProvider::instance()->Init(
-        hdmap_, config_.reference_line_smoother_config());
+        hdmap_, config_.qp_spline_reference_line_smoother_config());
   }
 
   RegisterPlanners();

--- a/modules/planning/proto/BUILD
+++ b/modules/planning/proto/BUILD
@@ -23,7 +23,7 @@ proto_library(
         ":dp_poly_path_config_proto_lib",
         ":dp_st_speed_config_proto_lib",
         ":qp_spline_path_config_proto_lib",
-        ":reference_line_smoother_config_proto_lib",
+        ":qp_spline_reference_line_smoother_config_proto_lib",
         "//modules/canbus/proto:canbus_proto_lib",
         "//modules/common/proto:common_proto_lib",
         "//modules/common/proto:error_code_proto_lib",
@@ -104,16 +104,16 @@ proto_library(
 )
 
 cc_proto_library(
-    name = "reference_line_smoother_config_proto",
+    name = "qp_spline_reference_line_smoother_config_proto",
     deps = [
-        ":reference_line_smoother_config_proto_lib",
+        ":qp_spline_reference_line_smoother_config_proto_lib",
     ],
 )
 
 proto_library(
-    name = "reference_line_smoother_config_proto_lib",
+    name = "qp_spline_reference_line_smoother_config_proto_lib",
     srcs = [
-        "reference_line_smoother_config.proto",
+        "qp_spline_reference_line_smoother_config.proto",
     ],
 )
 

--- a/modules/planning/proto/planning_config.proto
+++ b/modules/planning/proto/planning_config.proto
@@ -6,7 +6,7 @@ import "modules/planning/proto/dp_poly_path_config.proto";
 import "modules/planning/proto/dp_st_speed_config.proto";
 import "modules/planning/proto/qp_spline_path_config.proto";
 import "modules/planning/proto/qp_st_speed_config.proto";
-import "modules/planning/proto/reference_line_smoother_config.proto";
+import "modules/planning/proto/qp_spline_reference_line_smoother_config.proto";
 
 enum TaskType {
   DP_POLY_PATH_OPTIMIZER = 0;
@@ -45,6 +45,6 @@ message PlanningConfig {
   optional PlannerType planner_type = 1 [default = EM];
 
   optional EMPlannerConfig em_planner_config = 2;
-  optional apollo.planning.ReferenceLineSmootherConfig reference_line_smoother_config = 3;
+  optional apollo.planning.QpSplineReferenceLineSmootherConfig qp_spline_reference_line_smoother_config = 3;
   repeated RuleConfig rule_config = 4;
 }

--- a/modules/planning/proto/qp_spline_reference_line_smoother_config.proto
+++ b/modules/planning/proto/qp_spline_reference_line_smoother_config.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package apollo.planning;
 
-message ReferenceLineSmootherConfig {
+message QpSplineReferenceLineSmootherConfig {
   optional uint32 spline_order = 1 [default = 6];
   optional double max_spline_length = 2 [default = 25];
   optional uint32 constraint_to_knots_ratio = 3 [default = 5];

--- a/modules/planning/reference_line/BUILD
+++ b/modules/planning/reference_line/BUILD
@@ -26,22 +26,69 @@ cc_library(
 cc_library(
     name = "reference_line_smoother",
     srcs = [
-        "reference_line_smoother.cc",
     ],
     hdrs = [
+        "reference_line_smoother.h",
+    ],
+    deps = [
+        ":qp_spline_reference_line_smoother",
+        ":spiral_reference_line_smoother",
+    ],
+)
+
+cc_library(
+    name = "qp_spline_reference_line_smoother",
+    srcs = [
+        "qp_spline_reference_line_smoother.cc",
+    ],
+    hdrs = [
+        "qp_spline_reference_line_smoother.h",
         "reference_line_smoother.h",
     ],
     deps = [
         ":reference_line",
         "//modules/planning/math:curve_math",
         "//modules/planning/math:polynomial_xd",
-        "//modules/planning/math/smoothing_spline:spline_2d",
-        "//modules/planning/math/smoothing_spline:spline_2d_constraint",
-        "//modules/planning/math/smoothing_spline:spline_2d_kernel",
         "//modules/planning/math/smoothing_spline:spline_2d_solver",
         "//modules/planning/proto:planning_proto",
-        "//modules/planning/proto:reference_line_smoother_config_proto",
+        "//modules/planning/proto:qp_spline_reference_line_smoother_config_proto",
         "@eigen//:eigen",
+    ],
+)
+
+cc_library(
+    name = "spiral_reference_line_smoother",
+    srcs = [
+        "reference_line_smoother.h",
+        "spiral_problem_interface.cc",
+        "spiral_reference_line_smoother.cc",
+    ],
+    hdrs = [
+        "spiral_problem_interface.h",
+        "spiral_reference_line_smoother.h",
+    ],
+    deps = [
+        ":reference_line",
+        "//modules/common/math",
+        "//modules/planning/math/curve1d:quintic_spiral_path",
+        "//modules/planning/math/smoothing_spline:spline_2d_solver",
+        "//modules/planning/proto:planning_proto",
+        "@eigen//:eigen",
+        "@ipopt//:ipopt",
+    ],
+)
+
+cc_test(
+    name = "qp_spline_reference_line_smoother_test",
+    size = "small",
+    srcs = [
+        "qp_spline_reference_line_smoother_test.cc",
+    ],
+    data = ["//modules/planning:planning_testdata"],
+    deps = [
+        ":qp_spline_reference_line_smoother",
+        "//modules/map/hdmap",
+        "@gtest//:main",
     ],
 )
 
@@ -54,44 +101,10 @@ cc_library(
         "reference_line_provider.h",
     ],
     deps = [
+        "qp_spline_reference_line_smoother",
         "reference_line",
-        "reference_line_smoother",
         "spiral_reference_line_smoother",
         "//modules/map/pnc_map",
-    ],
-)
-
-cc_library(
-    name = "spiral_reference_line_smoother",
-    srcs = [
-        "spiral_problem_interface.cc",
-        "spiral_reference_line_smoother.cc",
-    ],
-    hdrs = [
-        "spiral_problem_interface.h",
-        "spiral_reference_line_smoother.h",
-    ],
-    deps = [
-        ":reference_line",
-        "//modules/common/math",
-        "//modules/planning/math/curve1d:quintic_spiral_path",
-        "//modules/planning/proto:planning_proto",
-        "@eigen//:eigen",
-        "@ipopt//:ipopt",
-    ],
-)
-
-cc_test(
-    name = "reference_line_smoother_test",
-    size = "small",
-    srcs = [
-        "reference_line_smoother_test.cc",
-    ],
-    data = ["//modules/planning:planning_testdata"],
-    deps = [
-        ":reference_line_smoother",
-        "//modules/map/hdmap",
-        "@gtest//:main",
     ],
 )
 

--- a/modules/planning/reference_line/qp_spline_reference_line_smoother.cc
+++ b/modules/planning/reference_line/qp_spline_reference_line_smoother.cc
@@ -35,20 +35,11 @@
 namespace apollo {
 namespace planning {
 
-void QpSplineReferenceLineSmoother::Init(const std::string& config_file,
-                                         Spline2dSolver* const spline_solver) {
-  if (!common::util::GetProtoFromFile(config_file, &smoother_config_)) {
-    AERROR << "failed to load config file " << config_file;
-    return;
-  }
-  spline_solver_ = spline_solver;
-}
-
-void QpSplineReferenceLineSmoother::Init(
+QpSplineReferenceLineSmoother::QpSplineReferenceLineSmoother(
     const QpSplineReferenceLineSmootherConfig& config,
-    Spline2dSolver* const spline_solver) {
-  smoother_config_ = config;
-  spline_solver_ = spline_solver;
+    Spline2dSolver* const spline_solver)
+    : smoother_config_(config), spline_solver_(spline_solver) {
+  CHECK_NOTNULL(spline_solver);
 }
 
 void QpSplineReferenceLineSmoother::Clear() {

--- a/modules/planning/reference_line/qp_spline_reference_line_smoother.h
+++ b/modules/planning/reference_line/qp_spline_reference_line_smoother.h
@@ -36,16 +36,12 @@
 namespace apollo {
 namespace planning {
 
-class QpSplineReferenceLineSmoother : ReferenceLineSmoother {
+class QpSplineReferenceLineSmoother : public ReferenceLineSmoother {
  public:
-  QpSplineReferenceLineSmoother() = default;
+  QpSplineReferenceLineSmoother(
+      const QpSplineReferenceLineSmootherConfig& config,
+      Spline2dSolver* const spline_solver);
   virtual ~QpSplineReferenceLineSmoother() = default;
-
-  void Init(const std::string& config_file,
-            Spline2dSolver* const spline_solver) override;
-
-  void Init(const QpSplineReferenceLineSmootherConfig& refline_smooth_config,
-            Spline2dSolver* const spline_solver) override;
 
   bool Smooth(const ReferenceLine& raw_reference_line,
               ReferenceLine* const smoothed_reference_line) override;

--- a/modules/planning/reference_line/qp_spline_reference_line_smoother.h
+++ b/modules/planning/reference_line/qp_spline_reference_line_smoother.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+ * Copyright 2017 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+/**
+ * @file qp_spline_reference_line_smoother.h
+ **/
+
+#ifndef MODULES_PLANNING_REFERENCE_LINE_QP_SPLINE_REFERENCE_LINE_SMOOTHER_H_
+#define MODULES_PLANNING_REFERENCE_LINE_QP_SPLINE_REFERENCE_LINE_SMOOTHER_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "modules/planning/proto/planning.pb.h"
+#include "modules/planning/proto/qp_spline_reference_line_smoother_config.pb.h"
+
+#include "modules/planning/math/smoothing_spline/spline_2d_solver.h"
+#include "modules/planning/reference_line/reference_line.h"
+#include "modules/planning/reference_line/reference_line_smoother.h"
+#include "modules/planning/reference_line/reference_point.h"
+
+namespace apollo {
+namespace planning {
+
+class QpSplineReferenceLineSmoother : ReferenceLineSmoother {
+ public:
+  QpSplineReferenceLineSmoother() = default;
+  virtual ~QpSplineReferenceLineSmoother() = default;
+
+  void Init(const std::string& config_file,
+            Spline2dSolver* const spline_solver) override;
+
+  void Init(const QpSplineReferenceLineSmootherConfig& refline_smooth_config,
+            Spline2dSolver* const spline_solver) override;
+
+  bool Smooth(const ReferenceLine& raw_reference_line,
+              ReferenceLine* const smoothed_reference_line) override;
+
+ private:
+  void Clear();
+
+  bool Sampling(const ReferenceLine& raw_reference_line);
+
+  bool ApplyConstraint(const ReferenceLine& raw_reference_line);
+
+  bool ApplyKernel();
+
+  bool Solve();
+
+  bool ExtractEvaluatedPoints(
+      const ReferenceLine& raw_reference_line, const std::vector<double>& vec_t,
+      std::vector<common::PathPoint>* const path_points) const;
+
+  bool GetSFromParamT(const double t, double* const s) const;
+
+  std::uint32_t FindIndex(const double t) const;
+
+ private:
+  QpSplineReferenceLineSmootherConfig smoother_config_;
+  std::vector<double> t_knots_;
+  std::vector<common::PathPoint> ref_points_;
+  Spline2dSolver* spline_solver_ = nullptr;
+};
+
+}  // namespace planning
+}  // namespace apollo
+
+#endif  // MODULES_PLANNING_REFERENCE_LINE_QP_SPLINE_REFERENCE_LINE_SMOOTHER_H_

--- a/modules/planning/reference_line/qp_spline_reference_line_smoother_test.cc
+++ b/modules/planning/reference_line/qp_spline_reference_line_smoother_test.cc
@@ -15,23 +15,24 @@
  *****************************************************************************/
 
 /**
- * @file reference_line_smooother_test.cpp
+ * @file qp_spline_reference_line_smoother_test.cc
  **/
+#include "modules/planning/reference_line/qp_spline_reference_line_smoother.h"
+
 #include "gtest/gtest.h"
 
-#include "modules/planning/proto/reference_line_smoother_config.pb.h"
+#include "modules/planning/proto/qp_spline_reference_line_smoother_config.pb.h"
 
 #include "modules/common/math/vec2d.h"
 #include "modules/map/hdmap/hdmap.h"
 #include "modules/map/hdmap/hdmap_util.h"
 #include "modules/planning/reference_line/reference_line.h"
-#include "modules/planning/reference_line/reference_line_smoother.h"
 #include "modules/planning/reference_line/reference_point.h"
 
 namespace apollo {
 namespace planning {
 
-class ReferenceLineSmootherTest : public ::testing::Test {
+class QpSplineReferenceLineSmootherTest : public ::testing::Test {
  public:
   virtual void SetUp() {
     hdmap_.LoadMapFromFile(map_file);
@@ -41,7 +42,7 @@ class ReferenceLineSmootherTest : public ::testing::Test {
       AERROR << "failed to find lane " << lane_id << " from map " << map_file;
       return;
     }
-    ReferenceLineSmootherConfig config;
+    QpSplineReferenceLineSmootherConfig config;
     smoother_.Init(config,
                    &spline_solver_);  // use the default value in config.
 
@@ -63,7 +64,7 @@ class ReferenceLineSmootherTest : public ::testing::Test {
       "modules/planning/testdata/garage_map/base_map.txt";
 
   hdmap::HDMap hdmap_;
-  ReferenceLineSmoother smoother_;
+  QpSplineReferenceLineSmoother smoother_;
   common::math::Vec2d vehicle_position_;
   std::vector<double> t_knots_;
   Spline2dSolver spline_solver_{t_knots_, 5};
@@ -71,7 +72,7 @@ class ReferenceLineSmootherTest : public ::testing::Test {
   hdmap::LaneInfoConstPtr lane_info_ptr = nullptr;
 };
 
-TEST_F(ReferenceLineSmootherTest, smooth) {
+TEST_F(QpSplineReferenceLineSmootherTest, smooth) {
   ReferenceLine smoothed_reference_line;
   EXPECT_FLOAT_EQ(153.87421, reference_line_->Length());
   EXPECT_TRUE(smoother_.Smooth(*reference_line_, &smoothed_reference_line));

--- a/modules/planning/reference_line/qp_spline_reference_line_smoother_test.cc
+++ b/modules/planning/reference_line/qp_spline_reference_line_smoother_test.cc
@@ -42,10 +42,6 @@ class QpSplineReferenceLineSmootherTest : public ::testing::Test {
       AERROR << "failed to find lane " << lane_id << " from map " << map_file;
       return;
     }
-    QpSplineReferenceLineSmootherConfig config;
-    smoother_.Init(config,
-                   &spline_solver_);  // use the default value in config.
-
     std::vector<ReferencePoint> ref_points;
     const auto& points = lane_info_ptr->points();
     const auto& headings = lane_info_ptr->headings();
@@ -64,10 +60,11 @@ class QpSplineReferenceLineSmootherTest : public ::testing::Test {
       "modules/planning/testdata/garage_map/base_map.txt";
 
   hdmap::HDMap hdmap_;
-  QpSplineReferenceLineSmoother smoother_;
   common::math::Vec2d vehicle_position_;
   std::vector<double> t_knots_;
   Spline2dSolver spline_solver_{t_knots_, 5};
+  QpSplineReferenceLineSmootherConfig config_;
+  QpSplineReferenceLineSmoother smoother_{config_, &spline_solver_};
   std::unique_ptr<ReferenceLine> reference_line_;
   hdmap::LaneInfoConstPtr lane_info_ptr = nullptr;
 };

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -42,7 +42,7 @@ ReferenceLineProvider::~ReferenceLineProvider() {
 
 void ReferenceLineProvider::Init(
     const hdmap::HDMap *hdmap_,
-    const ReferenceLineSmootherConfig &smoother_config) {
+    const QpSplineReferenceLineSmootherConfig &smoother_config) {
   pnc_map_.reset(new hdmap::PncMap(hdmap_));
   smoother_config_ = smoother_config;
   std::vector<double> init_t_knots;
@@ -145,12 +145,12 @@ bool ReferenceLineProvider::CreateReferenceLineFromRouting() {
     }
   }
 
-  ReferenceLineSmoother smoother;
+  QpSplineReferenceLineSmoother smoother;
   smoother.Init(smoother_config_, spline_solver_.get());
 
   SpiralReferenceLineSmoother spiral_smoother;
   double max_spiral_smoother_dev = 0.1;
-  spiral_smoother.set_max_point_deviation(max_spiral_smoother_dev);
+  spiral_smoother.Init(max_spiral_smoother_dev);
 
   std::vector<ReferenceLine> reference_lines;
   std::vector<hdmap::RouteSegments> segments;

--- a/modules/planning/reference_line/reference_line_provider.h
+++ b/modules/planning/reference_line/reference_line_provider.h
@@ -30,8 +30,8 @@
 #include "modules/common/util/util.h"
 #include "modules/map/pnc_map/pnc_map.h"
 #include "modules/planning/math/smoothing_spline/spline_2d_solver.h"
+#include "modules/planning/reference_line/qp_spline_reference_line_smoother.h"
 #include "modules/planning/reference_line/reference_line.h"
-#include "modules/planning/reference_line/reference_line_smoother.h"
 #include "modules/planning/reference_line/spiral_reference_line_smoother.h"
 
 /**
@@ -54,7 +54,7 @@ class ReferenceLineProvider {
   ~ReferenceLineProvider();
 
   void Init(const hdmap::HDMap* hdmap_,
-            const ReferenceLineSmootherConfig& smoother_config);
+            const QpSplineReferenceLineSmootherConfig& smoother_config);
 
   void UpdateRoutingResponse(const routing::RoutingResponse& routing);
 
@@ -86,7 +86,7 @@ class ReferenceLineProvider {
 
   bool has_routing_ = false;
 
-  ReferenceLineSmootherConfig smoother_config_;
+  QpSplineReferenceLineSmootherConfig smoother_config_;
 
   bool is_stop_ = false;
 

--- a/modules/planning/reference_line/reference_line_smoother.h
+++ b/modules/planning/reference_line/reference_line_smoother.h
@@ -21,16 +21,7 @@
 #ifndef MODULES_PLANNING_REFERENCE_LINE_REFERENCE_LINE_SMOOTHER_H_
 #define MODULES_PLANNING_REFERENCE_LINE_REFERENCE_LINE_SMOOTHER_H_
 
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "modules/planning/proto/planning.pb.h"
-#include "modules/planning/proto/qp_spline_reference_line_smoother_config.pb.h"
-
-#include "modules/planning/math/smoothing_spline/spline_2d_solver.h"
 #include "modules/planning/reference_line/reference_line.h"
-#include "modules/planning/reference_line/reference_point.h"
 
 namespace apollo {
 namespace planning {
@@ -38,12 +29,9 @@ namespace planning {
 class ReferenceLineSmoother {
  public:
   ReferenceLineSmoother() = default;
+
   virtual ~ReferenceLineSmoother() = default;
 
-  virtual void Init(const std::string&, Spline2dSolver* const) {}
-  virtual void Init(const QpSplineReferenceLineSmootherConfig&,
-                    Spline2dSolver* const) {}
-  virtual void Init(const double max_point_deviation_distance) {}
   virtual bool Smooth(const ReferenceLine&, ReferenceLine* const) = 0;
 };
 

--- a/modules/planning/reference_line/reference_line_smoother.h
+++ b/modules/planning/reference_line/reference_line_smoother.h
@@ -15,7 +15,7 @@
  *****************************************************************************/
 
 /**
- * @file reference_line_smooother.h
+ * @file qp_spline_reference_line_smoother.h
  **/
 
 #ifndef MODULES_PLANNING_REFERENCE_LINE_REFERENCE_LINE_SMOOTHER_H_
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "modules/planning/proto/planning.pb.h"
-#include "modules/planning/proto/reference_line_smoother_config.pb.h"
+#include "modules/planning/proto/qp_spline_reference_line_smoother_config.pb.h"
 
 #include "modules/planning/math/smoothing_spline/spline_2d_solver.h"
 #include "modules/planning/reference_line/reference_line.h"
@@ -38,37 +38,13 @@ namespace planning {
 class ReferenceLineSmoother {
  public:
   ReferenceLineSmoother() = default;
-  bool Init(const std::string& config_file,
-            Spline2dSolver* const spline_solver);
-  void Init(const ReferenceLineSmootherConfig& refline_smooth_config,
-            Spline2dSolver* const spline_solver);
-  bool Smooth(const ReferenceLine& raw_reference_line,
-              ReferenceLine* const smoothed_reference_line);
+  virtual ~ReferenceLineSmoother() = default;
 
- private:
-  void Clear();
-
-  bool Sampling(const ReferenceLine& raw_reference_line);
-
-  bool ApplyConstraint(const ReferenceLine& raw_reference_line);
-
-  bool ApplyKernel();
-
-  bool Solve();
-
-  bool ExtractEvaluatedPoints(
-      const ReferenceLine& raw_reference_line, const std::vector<double>& vec_t,
-      std::vector<common::PathPoint>* const path_points) const;
-
-  bool GetSFromParamT(const double t, double* const s) const;
-
-  std::uint32_t FindIndex(const double t) const;
-
- private:
-  ReferenceLineSmootherConfig smoother_config_;
-  std::vector<double> t_knots_;
-  std::vector<common::PathPoint> ref_points_;
-  Spline2dSolver* spline_solver_ = nullptr;
+  virtual void Init(const std::string&, Spline2dSolver* const) {}
+  virtual void Init(const QpSplineReferenceLineSmootherConfig&,
+                    Spline2dSolver* const) {}
+  virtual void Init(const double max_point_deviation_distance) {}
+  virtual bool Smooth(const ReferenceLine&, ReferenceLine* const) = 0;
 };
 
 }  // namespace planning

--- a/modules/planning/reference_line/spiral_reference_line_smoother.cc
+++ b/modules/planning/reference_line/spiral_reference_line_smoother.cc
@@ -34,6 +34,12 @@
 namespace apollo {
 namespace planning {
 
+SpiralReferenceLineSmoother::SpiralReferenceLineSmoother(
+    const double max_point_deviation)
+    : max_point_deviation_(max_point_deviation) {
+  CHECK(max_point_deviation >= 0.0);
+}
+
 bool SpiralReferenceLineSmoother::Smooth(
     const ReferenceLine& raw_reference_line,
     ReferenceLine* const smoothed_reference_line) {
@@ -169,11 +175,6 @@ bool SpiralReferenceLineSmoother::Smooth(
 
   return status == Ipopt::Solve_Succeeded ||
          status == Ipopt::Solved_To_Acceptable_Level;
-}
-
-void SpiralReferenceLineSmoother::Init(const double max_point_deviation) {
-  CHECK(max_point_deviation >= 0.0);
-  max_point_deviation_ = max_point_deviation;
 }
 
 std::vector<common::PathPoint> SpiralReferenceLineSmoother::to_path_points(

--- a/modules/planning/reference_line/spiral_reference_line_smoother.cc
+++ b/modules/planning/reference_line/spiral_reference_line_smoother.cc
@@ -36,7 +36,7 @@ namespace planning {
 
 bool SpiralReferenceLineSmoother::Smooth(
     const ReferenceLine& raw_reference_line,
-    ReferenceLine* const smoothed_reference_line) const {
+    ReferenceLine* const smoothed_reference_line) {
   const double piecewise_length = 10.0;
   const double length = raw_reference_line.Length();
   ADEBUG << "Length = " << length;
@@ -171,9 +171,9 @@ bool SpiralReferenceLineSmoother::Smooth(
          status == Ipopt::Solved_To_Acceptable_Level;
 }
 
-void SpiralReferenceLineSmoother::set_max_point_deviation(const double d) {
-  CHECK(d >= 0.0);
-  max_point_deviation_ = d;
+void SpiralReferenceLineSmoother::Init(const double max_point_deviation) {
+  CHECK(max_point_deviation >= 0.0);
+  max_point_deviation_ = max_point_deviation;
 }
 
 std::vector<common::PathPoint> SpiralReferenceLineSmoother::to_path_points(

--- a/modules/planning/reference_line/spiral_reference_line_smoother.h
+++ b/modules/planning/reference_line/spiral_reference_line_smoother.h
@@ -34,12 +34,11 @@
 namespace apollo {
 namespace planning {
 
-class SpiralReferenceLineSmoother : ReferenceLineSmoother {
+class SpiralReferenceLineSmoother : public ReferenceLineSmoother {
  public:
-  SpiralReferenceLineSmoother() = default;
+  explicit SpiralReferenceLineSmoother(
+      const double max_point_deviation_distance);
   virtual ~SpiralReferenceLineSmoother() = default;
-
-  void Init(const double max_point_deviation_distance) override;
 
   bool Smooth(const ReferenceLine& raw_reference_line,
               ReferenceLine* const smoothed_reference_line) override;

--- a/modules/planning/reference_line/spiral_reference_line_smoother.h
+++ b/modules/planning/reference_line/spiral_reference_line_smoother.h
@@ -28,21 +28,21 @@
 #include "modules/planning/proto/planning.pb.h"
 
 #include "modules/planning/reference_line/reference_line.h"
+#include "modules/planning/reference_line/reference_line_smoother.h"
 #include "modules/planning/reference_line/reference_point.h"
 
 namespace apollo {
 namespace planning {
 
-class SpiralReferenceLineSmoother {
+class SpiralReferenceLineSmoother : ReferenceLineSmoother {
  public:
   SpiralReferenceLineSmoother() = default;
-
   virtual ~SpiralReferenceLineSmoother() = default;
 
-  void set_max_point_deviation(const double d);
+  void Init(const double max_point_deviation_distance) override;
 
   bool Smooth(const ReferenceLine& raw_reference_line,
-              ReferenceLine* const smoothed_reference_line) const;
+              ReferenceLine* const smoothed_reference_line) override;
 
  private:
   bool Smooth(std::vector<Eigen::Vector2d> point2d,

--- a/modules/planning/tasks/st_graph/st_boundary_mapper_test.cc
+++ b/modules/planning/tasks/st_graph/st_boundary_mapper_test.cc
@@ -25,7 +25,7 @@
 #include "modules/common/log.h"
 #include "modules/map/hdmap/hdmap_util.h"
 #include "modules/planning/common/path_obstacle.h"
-#include "modules/planning/reference_line/reference_line_smoother.h"
+#include "modules/planning/reference_line/qp_spline_reference_line_smoother.h"
 
 namespace apollo {
 namespace planning {
@@ -40,7 +40,7 @@ class StBoundaryMapperTest : public ::testing::Test {
       AERROR << "failed to find lane " << lane_id << " from map " << map_file;
       return;
     }
-    ReferenceLineSmootherConfig config;
+    QpSplineReferenceLineSmootherConfig config;
 
     std::vector<ReferencePoint> ref_points;
     const auto& points = lane_info_ptr->points();
@@ -72,7 +72,7 @@ class StBoundaryMapperTest : public ::testing::Test {
   const std::string map_file =
       "modules/planning/testdata/garage_map/base_map.txt";
   hdmap::HDMap hdmap_;
-  ReferenceLineSmoother smoother_;
+  QpSplineReferenceLineSmoother smoother_;
   common::math::Vec2d vehicle_position_;
   std::unique_ptr<ReferenceLine> reference_line_;
   hdmap::LaneInfoConstPtr lane_info_ptr = nullptr;

--- a/modules/planning/tasks/st_graph/st_boundary_mapper_test.cc
+++ b/modules/planning/tasks/st_graph/st_boundary_mapper_test.cc
@@ -72,7 +72,6 @@ class StBoundaryMapperTest : public ::testing::Test {
   const std::string map_file =
       "modules/planning/testdata/garage_map/base_map.txt";
   hdmap::HDMap hdmap_;
-  QpSplineReferenceLineSmoother smoother_;
   common::math::Vec2d vehicle_position_;
   std::unique_ptr<ReferenceLine> reference_line_;
   hdmap::LaneInfoConstPtr lane_info_ptr = nullptr;


### PR DESCRIPTION
…hers. TODO: change the codes in common/frame.cc and reference_line_provider.cc to switch smoothers.