### PR TITLE
Canbus/Control: Rename FLAG to avoid redefinition when used by other …

### DIFF
--- a/modules/canbus/canbus.cc
+++ b/modules/canbus/canbus.cc
@@ -140,7 +140,7 @@ Status Canbus::Start() {
 
 void Canbus::PublishChassis() {
   Chassis chassis = vehicle_controller_->chassis();
-  AdapterManager::FillChassisHeader(FLAGS_node_name, &chassis);
+  AdapterManager::FillChassisHeader(FLAGS_canbus_node_name, &chassis);
 
   AdapterManager::PublishChassis(chassis);
   ADEBUG << chassis.ShortDebugString();

--- a/modules/canbus/common/canbus_gflags.cc
+++ b/modules/canbus/common/canbus_gflags.cc
@@ -17,7 +17,7 @@
 #include "modules/canbus/common/canbus_gflags.h"
 
 // System gflags
-DEFINE_string(node_name, "chassis", "The chassis module name in proto");
+DEFINE_string(canbus_node_name, "chassis", "The chassis module name in proto");
 DEFINE_string(hmi_name, "canbus", "Module name in HMI");
 
 DEFINE_string(adapter_config_filename, "modules/canbus/conf/adapter.conf",

--- a/modules/canbus/common/canbus_gflags.h
+++ b/modules/canbus/common/canbus_gflags.h
@@ -20,7 +20,7 @@
 #include "gflags/gflags.h"
 
 // System gflags
-DECLARE_string(node_name);
+DECLARE_string(canbus_node_name);
 DECLARE_string(hmi_name);
 
 DECLARE_string(adapter_config_filename);

--- a/modules/control/common/control_gflags.cc
+++ b/modules/control/common/control_gflags.cc
@@ -19,12 +19,12 @@
 DEFINE_string(control_conf_file, "modules/control/conf/lincoln.pb.txt",
               "default control conf data file");
 
-DEFINE_string(adapter_config_filename, "modules/control/conf/adapter.conf",
-              "The adapter config file");
+DEFINE_string(control_adapter_config_filename,
+              "modules/control/conf/adapter.conf", "The adapter config file");
 
 DEFINE_bool(enable_csv_debug, false, "True to write out csv debug file.");
 DEFINE_bool(enable_speed_station_preview, true, "enable speed/station preview");
-DEFINE_string(node_name, "control", "The control node name in proto");
+DEFINE_string(control_node_name, "control", "The control node name in proto");
 DEFINE_bool(is_control_test_mode, false, "True to run control in test mode");
 DEFINE_bool(use_preview_speed_for_table, false,
             "True to use preview speed for table lookup");

--- a/modules/control/common/control_gflags.h
+++ b/modules/control/common/control_gflags.h
@@ -22,14 +22,14 @@
 // data file
 DECLARE_string(control_conf_file);
 
-DECLARE_string(adapter_config_filename);
+DECLARE_string(control_adapter_config_filename);
 
 DECLARE_bool(enable_csv_debug);
 
 // temporary gflag for test purpose
 DECLARE_bool(enable_speed_station_preview);
 
-DECLARE_string(node_name);
+DECLARE_string(control_node_name);
 DECLARE_bool(is_control_test_mode);
 DECLARE_bool(use_preview_speed_for_table);
 

--- a/modules/control/control.cc
+++ b/modules/control/control.cc
@@ -41,7 +41,7 @@ using apollo::localization::LocalizationEstimate;
 using apollo::planning::ADCTrajectory;
 
 std::string Control::Name() const {
-  return FLAGS_node_name;
+  return FLAGS_control_node_name;
 }
 
 Status Control::Init() {
@@ -51,7 +51,7 @@ Status Control::Init() {
 
   AINFO << "Conf file: " << FLAGS_control_conf_file << " is loaded.";
 
-  AdapterManager::Init(FLAGS_adapter_config_filename);
+  AdapterManager::Init(FLAGS_control_adapter_config_filename);
 
   apollo::common::monitor::MonitorBuffer buffer(&monitor_);
 

--- a/modules/control/control_test.cc
+++ b/modules/control/control_test.cc
@@ -45,10 +45,11 @@ TEST_F(ControlTest, Init) {
       "Unable to load control conf file: " + FLAGS_control_conf_file);
   EXPECT_DEATH(control_.Init(), "Unable to load control conf file");
   FLAGS_control_conf_file = "modules/control/testdata/conf/lincoln.pb.txt";
-  FLAGS_adapter_config_filename = "";
+  FLAGS_control_adapter_config_filename = "";
   EXPECT_DEATH(control_.Init(), "Unable to parse adapter config file " +
-                                    FLAGS_adapter_config_filename);
-  FLAGS_adapter_config_filename = "modules/control/testdata/conf/adapter.conf";
+                                    FLAGS_control_adapter_config_filename);
+  FLAGS_control_adapter_config_filename =
+      "modules/control/testdata/conf/adapter.conf";
   EXPECT_EQ(common::Status::OK(), control_.Init());
 }
 

--- a/modules/control/integration_tests/control_test_base.cc
+++ b/modules/control/integration_tests/control_test_base.cc
@@ -63,7 +63,7 @@ bool ControlTestBase::test_control() {
   }
   control_.controller_agent_.Reset();
 
-  AdapterManager::Init(FLAGS_adapter_config_filename);
+  AdapterManager::Init(FLAGS_control_adapter_config_filename);
   if (!FLAGS_test_pad_file.empty()) {
     PadMessage pad_message;
     if (!apollo::common::util::GetProtoFromFile(
@@ -164,7 +164,8 @@ bool ControlTestBase::test_control(const std::string &test_case_name,
 void ControlTestBase::SetUpTestCase() {
   ros::Time::init();
   FLAGS_control_conf_file = "modules/control/testdata/conf/lincoln.pb.txt";
-  FLAGS_adapter_config_filename = "modules/control/testdata/conf/adapter.conf";
+  FLAGS_control_adapter_config_filename =
+      "modules/control/testdata/conf/adapter.conf";
   FLAGS_is_control_test_mode = true;
 }
 


### PR DESCRIPTION
…modules.