### PR TITLE
Scripts: Auto-find largest portable disk to store bag.

### DIFF
--- a/scripts/record_bag.sh
+++ b/scripts/record_bag.sh
@@ -21,40 +21,71 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "${DIR}/apollo_base.sh"
 
-if [ ! -d "${APOLLO_ROOT_DIR}/data/bag" ]; then
-    mkdir -p "${APOLLO_ROOT_DIR}/data/bag"
-fi
-
-cd "${APOLLO_ROOT_DIR}/data/bag"
-
 function start() {
-    LOG="/tmp/apollo_record.out"
-    NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
-    if [ "${NUM_PROCESSES}" -eq 0 ]; then
-        nohup rosbag record -b 2048  \
-            /apollo/sensor/gnss/gnss_status \
-            /apollo/sensor/gnss/odometry \
-            /apollo/sensor/gnss/ins_stat \
-            /apollo/sensor/gnss/corrected_imu \
-            /apollo/sensor/mobileye \
-            /apollo/sensor/delphi_esr \
-            /apollo/canbus/chassis \
-            /apollo/canbus/chassis_detail \
-            /apollo/control \
-            /apollo/control/pad \
-            /apollo/perception/obstacles \
-            /apollo/perception/traffic_light \
-            /apollo/planning \
-            /apollo/prediction \
-            /apollo/routing_request \
-            /apollo/routing_response \
-            /apollo/localization/pose \
-            /apollo/monitor </dev/null >"${LOG}" 2>&1 &
+  BAG_DIR="${APOLLO_ROOT_DIR}/data/bag"
+
+  # Record bag to the largest portable-disk.
+  if [ "$1" = "--portable-disk" ]; then
+    LARGEST_DISK="$(df | grep "/media/${DOCKER_USER}" | sort -nr -k 4 | \
+        awk '{print substr($0, index($0, $6))}')"
+    if [ ! -z "${LARGEST_DISK}" ]; then
+      REAL_BAG_DIR="/media/${DOCKER_USER}/${LARGEST_DISK}/data/bag"
+      if [ ! -d "${REAL_BAG_DIR}" ]; then
+        mkdir -p "${REAL_BAG_DIR}"
+      fi
+      BAG_DIR="${APOLLO_ROOT_DIR}/data/bag/portable"
+      rm -fr "${BAG_DIR}"
+      ln -s "${REAL_BAG_DIR}" "${BAG_DIR}"
+    else
+      echo "Cannot find portable disk."
+      echo "Please make sure your container was started AFTER inserting the disk."
+      exit 1
+    fi
+  fi
+
+  # Create and enter into bag dir.
+  if [ ! -e "${BAG_DIR}" ]; then
+    mkdir -p "${BAG_DIR}"
+  fi
+  cd "${BAG_DIR}"
+  echo "Recording bag to: $(pwd)"
+
+  # Start recording.
+  LOG="/tmp/apollo_record.out"
+  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  if [ "${NUM_PROCESSES}" -eq 0 ]; then
+    nohup rosbag record -b 2048  \
+        /apollo/sensor/gnss/gnss_status \
+        /apollo/sensor/gnss/odometry \
+        /apollo/sensor/gnss/ins_stat \
+        /apollo/sensor/gnss/corrected_imu \
+        /apollo/sensor/mobileye \
+        /apollo/sensor/delphi_esr \
+        /apollo/canbus/chassis \
+        /apollo/canbus/chassis_detail \
+        /apollo/control \
+        /apollo/control/pad \
+        /apollo/perception/obstacles \
+        /apollo/perception/traffic_light \
+        /apollo/planning \
+        /apollo/prediction \
+        /apollo/routing_request \
+        /apollo/routing_response \
+        /apollo/localization/pose \
+        /apollo/monitor </dev/null >"${LOG}" 2>&1 &
     fi
 }
 
 function stop() {
-    pkill -SIGINT -f rosbag
+  pkill -SIGINT -f rosbag
+}
+
+function help() {
+  echo "Usage:"
+  echo "$0 [start]             Record bag to data/bag."
+  echo "$0 --portable-disk     Record bag to the largest portable disk."
+  echo "$0 stop                Stop recording."
+  echo "$0 help                Show this help message."
 }
 
 case $1 in
@@ -63,6 +94,9 @@ case $1 in
     ;;
   stop)
     stop
+    ;;
+  help)
+    help
     ;;
   *)
     start


### PR DESCRIPTION
1. The default behavior doesn't change.
2. We'll test the IO performance of recording to portable disk.
