### PR TITLE
Planning: re-align time of each trajectory point so that we can use t…

### DIFF
--- a/modules/planning/common/planning_gflags.cc
+++ b/modules/planning/common/planning_gflags.cc
@@ -16,6 +16,8 @@
 
 #include "modules/planning/common/planning_gflags.h"
 
+DEFINE_bool(planning_test_mode, false, "Enable planning test mode.");
+
 DEFINE_int32(planning_loop_rate, 10, "Loop rate for planning node");
 
 DEFINE_string(planning_adapter_config_filename,

--- a/modules/planning/common/planning_gflags.h
+++ b/modules/planning/common/planning_gflags.h
@@ -19,6 +19,8 @@
 
 #include "gflags/gflags.h"
 
+DECLARE_bool(planning_test_mode);
+
 DECLARE_string(planning_config_file);
 DECLARE_string(planning_adapter_config_filename);
 DECLARE_int32(planning_loop_rate);

--- a/modules/planning/common/reference_line_info.cc
+++ b/modules/planning/common/reference_line_info.cc
@@ -156,7 +156,7 @@ PathData* ReferenceLineInfo::mutable_path_data() { return &path_data_; }
 SpeedData* ReferenceLineInfo::mutable_speed_data() { return &speed_data_; }
 
 bool ReferenceLineInfo::CombinePathAndSpeedProfile(
-    const double relative_time,
+    const double relative_time, const double start_s,
     DiscretizedTrajectory* ptr_discretized_trajectory) {
   CHECK(ptr_discretized_trajectory != nullptr);
   // use varied resolution to reduce data load but also provide enough data
@@ -186,6 +186,7 @@ bool ReferenceLineInfo::CombinePathAndSpeedProfile(
              << "path total length " << path_data_.discretized_path().Length();
       return false;
     }
+    path_point.set_s(path_point.s() + start_s);
 
     common::TrajectoryPoint trajectory_point;
     trajectory_point.mutable_path_point()->CopyFrom(path_point);

--- a/modules/planning/common/reference_line_info.h
+++ b/modules/planning/common/reference_line_info.h
@@ -88,7 +88,7 @@ class ReferenceLineInfo {
   SpeedData* mutable_speed_data();
   // aggregate final result together by some configuration
   bool CombinePathAndSpeedProfile(
-      const double relative_time,
+      const double relative_time, const double start_s,
       DiscretizedTrajectory* discretized_trajectory);
 
   const SLBoundary& AdcSlBoundary() const;

--- a/modules/planning/integration_tests/planning_test_base.cc
+++ b/modules/planning/integration_tests/planning_test_base.cc
@@ -55,6 +55,7 @@ void PlanningTestBase::SetUpTestCase() {
   FLAGS_estimate_current_vehicle_state = false;
   FLAGS_enable_reference_line_provider_thread = false;
   FLAGS_enable_trajectory_check = true;
+  FLAGS_planning_test_mode = true;
 }
 
 bool PlanningTestBase::SetUpAdapters() {

--- a/modules/planning/planner/em/em_planner.cc
+++ b/modules/planning/planner/em/em_planner.cc
@@ -146,7 +146,8 @@ Status EMPlanner::Plan(const TrajectoryPoint& planning_start_point,
   }
   DiscretizedTrajectory trajectory;
   if (!reference_line_info->CombinePathAndSpeedProfile(
-          planning_start_point.relative_time(), &trajectory)) {
+          planning_start_point.relative_time(),
+          planning_start_point.path_point().s(), &trajectory)) {
     std::string msg("Fail to aggregate planning trajectory.");
     AERROR << msg;
     return Status(ErrorCode::PLANNING_ERROR, msg);

--- a/modules/planning/planning_interface.h
+++ b/modules/planning/planning_interface.h
@@ -44,9 +44,9 @@ class PlanningInterface : public apollo::common::ApolloApp {
   /**
    * @brief Fill the header and publish the planning message.
    */
-  void Publish(const double timestamp, planning::ADCTrajectory* trajectory) {
+  void Publish(planning::ADCTrajectory* trajectory) {
     using apollo::common::adapter::AdapterManager;
-    AdapterManager::FillPlanningHeader(Name(), timestamp, trajectory);
+    AdapterManager::FillPlanningHeader(Name(), trajectory);
     AdapterManager::PublishPlanning(*trajectory);
   }
 };

--- a/modules/planning/testdata/garage_test/result_follow_0.pb.txt
+++ b/modules/planning/testdata/garage_test/result_follow_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.3256014779888403
     kappa: 0.0014390229768810811
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/garage_test/result_out_of_map_0.pb.txt
+++ b/modules/planning/testdata/garage_test/result_out_of_map_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.2867508012008013
     kappa: 0.013159962977488119
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/garage_test/result_stop_dest_0.pb.txt
+++ b/modules/planning/testdata/garage_test/result_stop_dest_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.2867508012008013
     kappa: 0.013159962977488119
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/garage_test/result_stop_over_line_0.pb.txt
+++ b/modules/planning/testdata/garage_test/result_stop_over_line_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -24,6 +25,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -38,6 +40,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -52,6 +55,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -66,6 +70,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -80,6 +85,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -94,6 +100,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -108,6 +115,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -122,6 +130,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -136,6 +145,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -150,6 +160,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -164,6 +175,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -178,6 +190,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -192,6 +205,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -206,6 +220,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -220,6 +235,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -234,6 +250,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -248,6 +265,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -262,6 +280,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -276,6 +295,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -290,6 +310,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -304,6 +325,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -318,6 +340,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -332,6 +355,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -346,6 +370,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -360,6 +385,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -374,6 +400,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -388,6 +415,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -402,6 +430,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -416,6 +445,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -430,6 +460,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -444,6 +475,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -458,6 +490,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -472,6 +505,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -486,6 +520,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -500,6 +535,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -514,6 +550,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -528,6 +565,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -542,6 +580,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -556,6 +595,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -570,6 +610,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -584,6 +625,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -598,6 +640,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -612,6 +655,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -626,6 +670,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -640,6 +685,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -654,6 +700,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -668,6 +715,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -682,6 +730,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -696,6 +745,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -710,6 +760,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -724,6 +775,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -738,6 +790,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -752,6 +805,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -766,6 +820,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -780,6 +835,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -794,6 +850,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -808,6 +865,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -822,6 +880,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -836,6 +895,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -850,6 +910,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -864,6 +925,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -878,6 +940,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -892,6 +955,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -906,6 +970,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -920,6 +985,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -934,6 +1000,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -948,6 +1015,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -962,6 +1030,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }
@@ -976,6 +1045,7 @@ trajectory_point {
     z: 0
     theta: 1.3119887988590211
     kappa: -0.0058950283300836471
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_avoid_change_left_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_avoid_change_left_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 2.8988073508285375
     kappa: 0.00010005279694497026
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_cruise_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_cruise_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 2.3560555247297881
     kappa: -0.010492345623168791
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_follow_01_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_follow_01_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -1.8912344106888197
     kappa: -0.0056713952305998414
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_follow_03_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_follow_03_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -1.827545023130303
     kappa: 0.014029947685582236
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_mission_complete_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_mission_complete_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.3202319779073468
     kappa: -0.0067364876821149541
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_nudge_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_nudge_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -1.8233679519349359
     kappa: -0.00027054333501513736
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_qp_path_failure_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_qp_path_failure_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 2.6134265853950165
     kappa: -0.041713217257917774
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_rightturn_01_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_rightturn_01_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -0.21266574936068361
     kappa: -0.0098341145237096049
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_rightturn_with_red_light_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_rightturn_with_red_light_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -0.21266574936068361
     kappa: -0.0098341145237096049
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_slowdown_01_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_slowdown_01_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: -1.7937387314394067
     kappa: 0.00083016114539450128
+    s: 0
     dkappa: 0
     ddkappa: 0
   }

--- a/modules/planning/testdata/sunnyvale_loop_test/result_stop_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_stop_0.pb.txt
@@ -10,6 +10,7 @@ trajectory_point {
     z: 0
     theta: 1.2102934925174473
     kappa: -0.030546891083324958
+    s: 0
     dkappa: 0
     ddkappa: 0
   }


### PR DESCRIPTION
…he publishing time as the timestamp for planning module -- In this way, every modules in Apollo has a consistent way in defining 'timestamp' in header.