### PR TITLE
Fix matrix size in the notice

### DIFF
--- a/docs/specs/qp_spline_path_optimizer.md
+++ b/docs/specs/qp_spline_path_optimizer.md
@@ -144,7 +144,7 @@ f'_i(s)^2 ds =\begin{vmatrix} a_{i0} & a_{i1} & a_{i2} & a_{i3} & a_{i4} & a_{i5
 $$
 </p>
 
-Please notice that we got a 10 x 10 matrix to represent the derivative cost of 5th order spline.
+Please notice that we got a 6 x 6 matrix to represent the derivative cost of 5th order spline.
 
 
 


### PR DESCRIPTION
Either I am completely mistaken and understand nothing, or the matrix always has the size (n+1)x(n+1) when representing the derivative of nth order polynom.