### PR TITLE
planning: remove multithread data copy protection for UpdateRoutingRe…

### DIFF
--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -313,28 +313,17 @@ bool ReferenceLineProvider::ExtendReferenceLine(const VehicleState &state,
                                                 ReferenceLine *reference_line) {
   RouteSegments segment_properties;
   segment_properties.SetProperties(*segments);
-  std::list<hdmap::RouteSegments> prev_route_segments;
-  std::list<ReferenceLine> prev_reference_lines;
-
-  {
-    std::lock_guard<std::mutex> lock(reference_lines_mutex_);
-    prev_route_segments = route_segments_;
-  }
-  {
-    std::lock_guard<std::mutex> lock(reference_lines_mutex_);
-    prev_reference_lines = reference_lines_;
-  }
-  auto prev_segment = prev_route_segments.begin();
-  auto prev_ref = prev_reference_lines.begin();
-  while (prev_segment != prev_route_segments.end()) {
+  auto prev_segment = route_segments_.begin();
+  auto prev_ref = reference_lines_.begin();
+  while (prev_segment != route_segments_.end()) {
     if (prev_segment->IsConnectedSegment(*segments)) {
       break;
     }
     ++prev_segment;
     ++prev_ref;
   }
-  if (prev_segment == prev_route_segments.end()) {
-    if (!prev_route_segments.empty() && segments->IsOnSegment()) {
+  if (prev_segment == route_segments_.end()) {
+    if (!route_segments_.empty() && segments->IsOnSegment()) {
       AWARN << "Current route segment is not connected with previous route "
                "segment";
     }


### PR DESCRIPTION
…sponse does not clear route_segments_ and reference_lines_ any more.