### PR TITLE
Update global_flagfile.txt

### DIFF
--- a/modules/common/data/global_flagfile.txt
+++ b/modules/common/data/global_flagfile.txt
@@ -7,4 +7,4 @@
 
 --vehicle_config_path=modules/common/data/mkz_config.pb.txt
 
---map_dir=modules/map/data/sunnyvale_loop
+--map_dir=modules/map/data/demo


### PR DESCRIPTION
Because we could not find any data about sunnyvale_l
and this would cause that we could not open the dreamview,
So I think the default value should be demo in case that other people should debug with dreamview. 