### PR TITLE
planning: avoid creating destination obstacle if only pass by

### DIFF
--- a/modules/map/pnc_map/pnc_map.h
+++ b/modules/map/pnc_map/pnc_map.h
@@ -121,6 +121,17 @@ class PncMap {
    */
   LaneWaypoint ToLaneWaypoint(const routing::LaneWaypoint &waypoint) const;
 
+  /**
+   * @brief Update routing waypoint index to the next waypoint that ADC need to
+   * pass. The logic is by comparing the current waypoint's route index with
+   * route_index and adc_waypoint_:
+   * a. If the waypoint's route_index < route_index_, ADC must have passed
+   * the waypoint.
+   * b. If the waypoint's route_index == route_index_, ADC and the waypoint
+   * is on the same lane, compare the lane_s.
+   */
+  void UpdateNextRoutingWaypointIndex();
+
  private:
   routing::RoutingResponse routing_;
   std::unordered_set<std::string> routing_lane_ids_;
@@ -129,9 +140,9 @@ class PncMap {
    */
   std::vector<LaneWaypoint> routing_waypoints_;
   /**
-   * The next routing request waypoint that the vehicle needs to drive to
+   * The next routing request waypoint that the vehicle have passed.
    */
-  int next_waypoint_index_ = 0;
+  std::size_t next_routing_waypoint_index_ = 0;
   const hdmap::HDMap *hdmap_ = nullptr;
   bool is_same_routing_ = false;
 

--- a/modules/map/pnc_map/pnc_map_test.cc
+++ b/modules/map/pnc_map/pnc_map_test.cc
@@ -169,10 +169,7 @@ TEST_F(PncMapTest, GetNeighborPassages) {
   }
   {
     auto result = pnc_map_->GetNeighborPassages(road0, 2);
-    EXPECT_EQ(3, result.size());
-    EXPECT_EQ(2, result[0]);
-    EXPECT_EQ(1, result[1]);
-    EXPECT_EQ(3, result[2]);
+    EXPECT_EQ(1, result.size());
   }
   {
     auto result = pnc_map_->GetNeighborPassages(road0, 3);

--- a/modules/map/pnc_map/route_segments.cc
+++ b/modules/map/pnc_map/route_segments.cc
@@ -117,6 +117,7 @@ void RouteSegments::SetProperties(const RouteSegments &other) {
   next_action_ = other.NextAction();
   previous_action_ = other.PreviousAction();
   id_ = other.Id();
+  stop_for_destination_ = other.StopForDestination();
 }
 
 double RouteSegments::Length(const RouteSegments &segments) {

--- a/modules/planning/common/frame.h
+++ b/modules/planning/common/frame.h
@@ -100,7 +100,13 @@ class Frame {
    */
   const Obstacle *FindCollisionObstacle() const;
 
-  const Obstacle *CreateDestinationObstacle();
+  /**
+   * @brief create destination obstacle when needed.
+   * @return < 0 if error happend;
+   * @return 0 if destination obstacle is created
+   * @return > 0 if destination obstacle should not be created now.
+   */
+  int CreateDestinationObstacle();
 
  private:
   uint32_t sequence_num_ = 0;

--- a/modules/planning/testdata/sunnyvale_loop_test/result_change_lane_0.pb.txt
+++ b/modules/planning/testdata/sunnyvale_loop_test/result_change_lane_0.pb.txt
@@ -1706,7 +1706,7 @@ decision {
   object_decision {
   }
   vehicle_signal {
-    turn_signal: TURN_NONE
+    turn_signal: TURN_LEFT
   }
 }
 routing_header {


### PR DESCRIPTION
* when there are repeated routing lanes, the vehicle may stop
when it near the destination location. With PncMap tracking the adc's
driving progress, we can distinguish whether we should stop based on
if this destination is the last stop.