### PR TITLE
Update canbus_gflags.cc bug :fix "us" to "ms"

### DIFF
--- a/modules/canbus/common/canbus_gflags.cc
+++ b/modules/canbus/common/canbus_gflags.cc
@@ -29,7 +29,7 @@ DEFINE_string(canbus_conf_file, "modules/canbus/conf/canbus_conf.pb.txt",
 
 // Canbus gflags
 DEFINE_double(chassis_freq, 100, "Chassis feedback timer frequency.");
-DEFINE_int64(min_cmd_interval, 5, "Minimum control command interval in us.");
+DEFINE_int64(min_cmd_interval, 5, "Minimum control command interval in ms.");
 
 // chassis_detail message publish
 DEFINE_bool(enable_chassis_detail_pub, false, "Chassis Detail message publish");


### PR DESCRIPTION
Due to the time is micros,so and it multiply 1000,so it should be ms.
```
void Canbus::OnControlCommand(const ControlCommand &control_command) {
  int64_t current_timestamp =
      apollo::common::time::AsInt64<common::time::micros>(Clock::Now());
  // if command coming too soon, just ignore it.
  if (current_timestamp - last_timestamp_ < FLAGS_min_cmd_interval * 1000) {
    ADEBUG << "Control command comes too soon. Ignore.\n Required "
              "FLAGS_min_cmd_interval["
           << FLAGS_min_cmd_interval << "], actual time interval["
           << current_timestamp - last_timestamp_ << "].";
    return;
  }
```
