### PR TITLE
scripts: fix docker repo when -C option is used

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -81,6 +81,10 @@ if [ -z "${DOCKER_REPO}" ]; then
     DOCKER_REPO=apolloauto/apollo
 fi
 
+if [ "$INCHINA" == "yes" ]; then
+    DOCKER_REPO=registry.docker-cn.com/apolloauto/apollo
+fi
+
 IMG=${DOCKER_REPO}:$VERSION
 APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
@@ -94,11 +98,7 @@ source ${APOLLO_ROOT_DIR}/scripts/apollo_base.sh
 
 function main(){
 
-    if [ "$INCHINA" == "yes" ]; then
-        docker pull "registry.docker-cn.com/${IMG}"
-    else
-        docker pull $IMG
-    fi
+    docker pull $IMG
 
     docker ps -a --format "{{.Names}}" | grep 'apollo_dev' 1>/dev/null
     if [ $? == 0 ]; then
@@ -165,6 +165,12 @@ function main(){
         --shm-size 512M \
         $IMG \
         /bin/bash
+
+    if [ $? -ne 0 ];then
+	error "Failed to start docker container \"apollo_dev\" based on image: $IMG"
+	exit 1
+    fi
+
     if [ "${USER}" != "root" ]; then
         docker exec apollo_dev bash -c '/apollo/scripts/docker_adduser.sh'
     fi


### PR DESCRIPTION
When -C option is used,  the repository name which pulled from local docker registry mirror is "registry.docker-cn.com/apolloauto/apollo",

So this is need to be passed to "docker run" instead of using default repo("apolloauto/apollo")
to start docker container from the right image.

~~~
$docker image ls
REPOSITORY                                 TAG                        IMAGE ID            CREATED             SIZE
registry.docker-cn.com/apolloauto/apollo   dev-x86_64-20171229_0957   532e2c8a3925        36 hours ago        11.8GB
registry.docker-cn.com/apolloauto/apollo   dev-x86_64-v2.0.0          532e2c8a3925        36 hours ago        11.8GB
apolloauto/apollo                          dev-x86_64-20171223_1501   e18241c37e87        7 days ago          11.8GB
registry.docker-cn.com/apolloauto/apollo   dev-x86_64-20171223_1501   e18241c37e87        7 days ago          11.8GB
apolloauto/apollo                          dev-x86_64-20171211_1820   095ea51a4ada        2 weeks ago         11.6GB
registry.docker-cn.com/apolloauto/apollo   dev-x86_64-20171211_1820   095ea51a4ada        2 weeks ago         11.6GB
apolloauto/apollo                          dev-x86_64-20171025_1428   8e6e829af70f        2 months ago        10.4GB
registry.docker-cn.com/apolloauto/apollo   dev-x86_64-20171025_1428   8e6e829af70f        2 months ago        10.4GB
apolloauto/apollo                          dev-x86_64-20170707_1129   151d97ef44c3        5 months ago        2.85GB
~~~