### PR TITLE
Canbus: removed the redundant definition of can_sender_ in LincolnCon…

### DIFF
--- a/modules/canbus/vehicle/lincoln/lincoln_controller.h
+++ b/modules/canbus/vehicle/lincoln/lincoln_controller.h
@@ -142,7 +142,6 @@ class LincolnController final : public VehicleController {
   Gear66 *gear_66_ = nullptr;
   Turnsignal68 *turnsignal_68_ = nullptr;
 
-  CanSender<::apollo::canbus::ChassisDetail> *can_sender_ = nullptr;
   Chassis chassis_;
   std::unique_ptr<std::thread> thread_;
   bool is_chassis_error_ = false;


### PR DESCRIPTION
…troller.