### PR TITLE
Prediction: add obstacle clusters, to keep lane graph info to avoid redundant computing

### DIFF
--- a/modules/map/hdmap/hdmap_common.cc
+++ b/modules/map/hdmap/hdmap_common.cc
@@ -587,7 +587,7 @@ void StopSignInfo::UpdateOverlaps(const HDMapImpl &map_instance) {
   }
   if (overlap_junction_ids_.size() <= 0) {
     AWARN << "stop sign " << id().id()
-	<< "has no overlap with any junction.";
+          << "has no overlap with any junction.";
   }
 }
 

--- a/modules/prediction/container/obstacles/BUILD
+++ b/modules/prediction/container/obstacles/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "//modules/common/util:lru_cache",
         "//modules/prediction/common:prediction_gflags",
         "//modules/prediction/container",
+        "//modules/prediction/container/obstacles:obstacle_clusters",
         "//modules/prediction/container/obstacles:obstacle",
         "//modules/prediction/container/pose:pose_container",
     ],
@@ -32,6 +33,7 @@ cc_library(
         "//modules/prediction/common:prediction_gflags",
         "//modules/prediction/common:prediction_map",
         "//modules/prediction/common:road_graph",
+        "//modules/prediction/container/obstacles:obstacle_clusters",
         "//modules/prediction/proto:feature_proto",
         "//modules/prediction/network/rnn_model:rnn_model",
         "@eigen//:eigen",
@@ -77,6 +79,22 @@ cc_test(
         "//modules/prediction/common:prediction_gflags",
         "//modules/prediction/container/obstacles:obstacles_container",
         "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "obstacle_clusters",
+    srcs = [
+        "obstacle_clusters.cc",
+    ],
+    hdrs = [
+        "obstacle_clusters.h",
+    ],
+    deps = [
+        "//modules/common:macro",
+        "//modules/map/hdmap:hdmap_util",
+        "//modules/prediction/proto:lane_graph_proto",
+        "//modules/prediction/common:road_graph",
     ],
 )
 

--- a/modules/prediction/container/obstacles/obstacle.h
+++ b/modules/prediction/container/obstacles/obstacle.h
@@ -34,6 +34,7 @@
 #include "modules/common/filters/digital_filter.h"
 #include "modules/perception/proto/perception_obstacle.pb.h"
 #include "modules/prediction/proto/feature.pb.h"
+#include "modules/prediction/container/obstacles/obstacle_clusters.h"
 
 #include "modules/common/math/kalman_filter.h"
 #include "modules/map/hdmap/hdmap_common.h"
@@ -67,7 +68,8 @@ class Obstacle {
    * @param timestamp The timestamp when the perception obstacle was detected.
    */
   void Insert(const perception::PerceptionObstacle& perception_obstacle,
-              const double timestamp);
+              const double timestamp,
+              ObstacleClusters* const obstacle_clusters);
 
   /**
    * @brief Get the type of perception obstacle's type.
@@ -229,7 +231,8 @@ class Obstacle {
 
   void SetNearbyLanes(Feature* feature);
 
-  void SetLaneGraphFeature(Feature* feature);
+  void SetLaneGraphFeature(Feature* feature,
+                           ObstacleClusters* const obstacle_clusters);
 
   void SetLanePoints(Feature* feature);
 

--- a/modules/prediction/container/obstacles/obstacle_clusters.cc
+++ b/modules/prediction/container/obstacles/obstacle_clusters.cc
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright 2017 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/prediction/container/obstacles/obstacle_clusters.h"
+
+#include "modules/prediction/common/road_graph.h"
+
+namespace apollo {
+namespace prediction {
+
+using apollo::hdmap::LaneInfo;
+
+void ObstacleClusters::Clear() {
+  lane_graphs_.clear();
+}
+
+void ObstacleClusters::Init() {
+  Clear();
+}
+
+const LaneGraph& ObstacleClusters::GetLaneGraph(
+    const double start_s, const double length,
+    std::shared_ptr<const LaneInfo> lane_info_ptr) {
+  std::string lane_id = lane_info_ptr->id().id();
+  if (lane_graphs_.find(lane_id) != lane_graphs_.end()) {
+    LaneGraph* lane_graph = &lane_graphs_[lane_id];
+    for (int i = 0; i < lane_graph->lane_sequence_size(); ++i) {
+      LaneSequence* lane_seq_ptr = lane_graph->mutable_lane_sequence(i);
+      if (lane_seq_ptr->lane_segment_size() == 0) {
+        continue;
+      }
+      LaneSegment* first_lane_seg_ptr = lane_seq_ptr->mutable_lane_segment(0);
+      if (first_lane_seg_ptr->lane_id() != lane_id) {
+        continue;
+      }
+      first_lane_seg_ptr->set_start_s(start_s);
+    }
+    return lane_graphs_[lane_id];
+  }
+  RoadGraph road_graph(start_s, length, lane_info_ptr);
+  LaneGraph lane_graph;
+  road_graph.BuildLaneGraph(&lane_graph);
+  lane_graphs_[lane_id] = std::move(lane_graph);
+  return lane_graphs_[lane_id];
+}
+
+}  // namespace prediction
+}  // namespace apollo

--- a/modules/prediction/container/obstacles/obstacle_clusters.h
+++ b/modules/prediction/container/obstacles/obstacle_clusters.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright 2017 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#ifndef MODULES_PREDICTION_CONTAINER_OBSTACLES_OBSTACLE_CLUSTERS_H_
+#define MODULES_PREDICTION_CONTAINER_OBSTACLES_OBSTACLE_CLUSTERS_H_
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <memory>
+
+#include "modules/common/macro.h"
+#include "modules/map/hdmap/hdmap_common.h"
+#include "modules/prediction/proto/lane_graph.pb.h"
+
+namespace apollo {
+namespace prediction {
+
+class ObstacleClusters {
+ public:
+  ObstacleClusters() = default;
+
+  void Init();
+
+  const LaneGraph& GetLaneGraph(
+      const double start_s, const double length,
+      std::shared_ptr<const apollo::hdmap::LaneInfo> lane_info_ptr);
+
+ private:
+  void Clear();
+
+ private:
+  std::unordered_map<std::string, LaneGraph> lane_graphs_;
+};
+
+}  // namespace prediction
+}  // namespace apollo
+
+#endif  // MODULES_PREDICTION_CONTAINER_OBSTACLES_OBSTACLE_CLUSTERS_H_

--- a/modules/prediction/container/obstacles/obstacles_container.cc
+++ b/modules/prediction/container/obstacles/obstacles_container.cc
@@ -51,6 +51,7 @@ void ObstaclesContainer::Insert(const ::google::protobuf::Message& message) {
 
   timestamp_ = timestamp;
   ADEBUG << "Current timestamp is [" << timestamp_ << "]";
+  clusters_.Init();
   for (const PerceptionObstacle& perception_obstacle :
        perception_obstacles.perception_obstacle()) {
     ADEBUG << "Perception obstacle [" << perception_obstacle.id() << "] "
@@ -83,10 +84,10 @@ void ObstaclesContainer::InsertPerceptionObstacle(
   }
   Obstacle* obstacle_ptr = obstacles_.GetSilently(id);
   if (obstacle_ptr != nullptr) {
-    obstacle_ptr->Insert(perception_obstacle, timestamp);
+    obstacle_ptr->Insert(perception_obstacle, timestamp, &clusters_);
   } else {
     Obstacle obstacle;
-    obstacle.Insert(perception_obstacle, timestamp);
+    obstacle.Insert(perception_obstacle, timestamp, &clusters_);
     obstacles_.Put(id, std::move(obstacle));
   }
 }

--- a/modules/prediction/container/obstacles/obstacles_container.h
+++ b/modules/prediction/container/obstacles/obstacles_container.h
@@ -22,10 +22,12 @@
 #ifndef MODULES_PREDICTION_CONTAINER_OBSTACLES_OBSTACLES_CONTAINER_H_
 #define MODULES_PREDICTION_CONTAINER_OBSTACLES_OBSTACLES_CONTAINER_H_
 
+#include "modules/common/macro.h"
 #include "modules/common/util/lru_cache.h"
 #include "modules/prediction/container/container.h"
 #include "modules/prediction/container/obstacles/obstacle.h"
 #include "modules/prediction/container/pose/pose_container.h"
+#include "modules/prediction/container/obstacles/obstacle_clusters.h"
 
 namespace apollo {
 namespace prediction {
@@ -79,6 +81,7 @@ class ObstaclesContainer : public Container {
 
  private:
   double timestamp_ = -1.0;
+  ObstacleClusters clusters_;
   common::util::LRUCache<int, Obstacle> obstacles_;
 };
 


### PR DESCRIPTION
and fix a lint error