### PR TITLE
Planning: Fix size type to avoid infinite loop when vector size > 256.

### DIFF
--- a/modules/planning/tasks/dp_poly_path/dp_road_graph.cc
+++ b/modules/planning/tasks/dp_poly_path/dp_road_graph.cc
@@ -329,7 +329,7 @@ bool DPRoadGraph::SamplePathWaypoints(
     }
     std::vector<common::SLPoint> level_points;
     planning_internal::SampleLayerDebug sample_layer_debug;
-    for (uint8_t j = 0; j < sample_l.size(); ++j) {
+    for (size_t j = 0; j < sample_l.size(); ++j) {
       const double l = sample_l[j];
       constexpr double kResonateDistance = 1e-3;
       common::SLPoint sl;


### PR DESCRIPTION
Though it won't happen according to our conf.