### PR TITLE
adding a solution to 'Ubuntu 14.04 login loop problem after installing the pre-built Apollo kernel'

### DIFF
--- a/docs/FAQs/Software_FAQs.md
+++ b/docs/FAQs/Software_FAQs.md
@@ -18,5 +18,10 @@ Refer to the How-To guide located [here](https://github.com/ApolloAuto/apollo/bl
 
 ## Ubuntu 14.04 login loop problem after installing the pre-built Apollo Kernel.
 
+Here is a solution to solve this problem:
+1. reboot ubuntu system, and press and hold 'shift' button and then enter grub menu.
+2. choose a generic and bootable item(not boot loader with apollo kernel) to boot up.
+3. press 'Ctrl+Alt+F1' and install 'NVIDIA-Linux-x86_64-375.39.run' according to the [link](https://github.com/ApolloAuto/apollo/blob/master/docs/quickstart/apollo_2_0_hardware_system_installation_guide_v1.md) 
+
 
 **More Software FAQs to follow.**

--- a/docs/FAQs/Software_FAQs.md
+++ b/docs/FAQs/Software_FAQs.md
@@ -16,4 +16,7 @@ The majority of bugs can be found through logging (using AERROR, AINFO, ADEBUG).
 
 Refer to the How-To guide located [here](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_run_offline_perception_visualizer.md).
 
+## Ubuntu 14.04 login loop problem after installing the pre-built Apollo Kernel.
+
+
 **More Software FAQs to follow.**

--- a/docs/FAQs/Software_FAQs.md
+++ b/docs/FAQs/Software_FAQs.md
@@ -16,12 +16,13 @@ The majority of bugs can be found through logging (using AERROR, AINFO, ADEBUG).
 
 Refer to the How-To guide located [here](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_run_offline_perception_visualizer.md).
 
-## Ubuntu 14.04 login loop problem after installing the pre-built Apollo Kernel.
+## Ubuntu 14.04 login loop problem after installing the pre-built Apollo kernel.
 
 Here is a solution to solve this problem:
 1. reboot ubuntu system, and press and hold 'shift' button and then enter grub menu.
-2. choose a generic and bootable item(not boot loader with apollo kernel) to boot up.
-3. press 'Ctrl+Alt+F1' and install 'NVIDIA-Linux-x86_64-375.39.run' according to the [link](https://github.com/ApolloAuto/apollo/blob/master/docs/quickstart/apollo_2_0_hardware_system_installation_guide_v1.md) 
+2. choose a generic and bootable item(not boot loader with Apollo kernel) to boot up.
+3. press 'Ctrl+Alt+F1' and install 'NVIDIA-Linux-x86_64-375.39.run' according to the [link](https://github.com/ApolloAuto/apollo/blob/master/docs/quickstart/apollo_2_0_hardware_system_installation_guide_v1.md).
+4. reboot and start computer with the default boot loader with Apollo kernel.
 
 
 **More Software FAQs to follow.**


### PR DESCRIPTION
adding a solution to 'Ubuntu 14.04 login loop problem after installing the pre-built Apollo kernel'