### PR TITLE
- issue #2702 (static_assert failure)

### DIFF
--- a/modules/common/time/time.h
+++ b/modules/common/time/time.h
@@ -55,8 +55,8 @@ using Duration = std::chrono::nanoseconds;
  */
 using Timestamp = std::chrono::time_point<std::chrono::system_clock, Duration>;
 
-static_assert(std::is_same<int64_t, Duration::rep>::value,
-              "The underlying type of the microseconds should be int64.");
+static_assert(sizeof(std::chrono::nanoseconds) >= sizeof(int64_t),
+              "The underlying type of the nanoseconds should be at least 64 bits.");
 
 using nanos = std::chrono::nanoseconds;
 using micros = std::chrono::microseconds;


### PR DESCRIPTION
- static_assert failure on underlying type check of std::chrono::nanoseconds
- The only requirement of std::chrono::nanoseconds is that it is an integral type of at least 64bits. Different implementations may have different underlying types. Therefore it is better to check whether its size is greater than or equal to sizeof(int64_t).