### PR TITLE
Reduce Adapter memory footprint

### DIFF
--- a/modules/common/adapters/adapter_manager.h
+++ b/modules/common/adapters/adapter_manager.h
@@ -113,7 +113,7 @@ namespace adapter {
     if (config.mode() != AdapterConfig::PUBLISH_ONLY && IsRos()) {             \
       name##subscriber_ =                                                      \
           node_handle_->subscribe(topic_name, config.message_history_limit(),  \
-                                  &name##Adapter::OnReceive, name##_.get());   \
+                                  &name##Adapter::RosCallback, name##_.get()); \
     }                                                                          \
     if (config.mode() != AdapterConfig::RECEIVE_ONLY && IsRos()) {             \
       name##publisher_ = node_handle_->advertise<name##Adapter::DataType>(     \

--- a/modules/common/adapters/adapter_test.cc
+++ b/modules/common/adapters/adapter_test.cc
@@ -16,8 +16,8 @@
 
 #include "modules/common/adapters/adapter.h"
 
-#include <string>
 #include <cmath>
+#include <string>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "modules/common/adapters/adapter_gflags.h"
@@ -73,7 +73,8 @@ TEST(AdapterTest, History) {
   adapter.Observe();
   {
     // Currently the history contains [2, 1].
-    std::vector<std::shared_ptr<int>> history(adapter.begin(), adapter.end());
+    std::vector<IntegerAdapter::DataPtr> history(adapter.begin(),
+                                                 adapter.end());
     EXPECT_EQ(2, history.size());
     EXPECT_EQ(2, *history[0]);
     EXPECT_EQ(1, *history[1]);
@@ -93,7 +94,8 @@ TEST(AdapterTest, History) {
   {
     // Although there are more messages, without calling Observe,
     // the history is still [2, 1].
-    std::vector<std::shared_ptr<int>> history(adapter.begin(), adapter.end());
+    std::vector<IntegerAdapter::DataPtr> history(adapter.begin(),
+                                                 adapter.end());
     EXPECT_EQ(2, history.size());
     EXPECT_EQ(2, *history[0]);
     EXPECT_EQ(1, *history[1]);
@@ -105,7 +107,8 @@ TEST(AdapterTest, History) {
     // maintain 3 elements in this adapter, 1 and 2 will be thrown out.
     //
     // History should be 5, 4, 3.
-    std::vector<std::shared_ptr<int>> history(adapter.begin(), adapter.end());
+    std::vector<IntegerAdapter::DataPtr> history(adapter.begin(),
+                                                 adapter.end());
     EXPECT_EQ(3, history.size());
     EXPECT_EQ(5, *history[0]);
     EXPECT_EQ(4, *history[1]);

--- a/modules/perception/traffic_light/base/image.cc
+++ b/modules/perception/traffic_light/base/image.cc
@@ -37,7 +37,7 @@ bool Image::Init(const double &ts, const CameraId &device_id,
   return true;
 }
 bool Image::Init(const double &ts, const CameraId &device_id,
-                 std::shared_ptr<const sensor_msgs::Image> image_data) {
+                 boost::shared_ptr<const sensor_msgs::Image> image_data) {
   contain_mat_ = false;
   contain_image_ = true;
   timestamp_ = ts, camera_id_ = device_id, image_data_ = image_data;

--- a/modules/perception/traffic_light/base/image.h
+++ b/modules/perception/traffic_light/base/image.h
@@ -67,7 +67,7 @@ class Image {
    * @param [in] raw ros image data
    */
   bool Init(const double &ts, const CameraId &device_id,
-            std::shared_ptr<const sensor_msgs::Image> image_data);
+            boost::shared_ptr<const sensor_msgs::Image> image_data);
 
   /**
    * @brief return image's timestamp
@@ -124,7 +124,7 @@ class Image {
   double timestamp_ = 0.0;                  // Image's timestamp
   CameraId camera_id_ = CameraId::UNKNOWN;  // camera's id
   cv::Mat mat_;                             // Image's data
-  std::shared_ptr<const sensor_msgs::Image> image_data_;
+  boost::shared_ptr<const sensor_msgs::Image> image_data_;
   friend std::ostream &operator<<(std::ostream &os, const Image &image);
 };
 

--- a/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.cc
+++ b/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.cc
@@ -30,6 +30,8 @@ namespace apollo {
 namespace perception {
 namespace traffic_light {
 
+using common::adapter::AdapterManager;
+
 bool TLPreprocessorSubnode::InitInternal() {
   RegisterFactoryBoundaryProjection();
   if (!InitSharedData()) {
@@ -71,13 +73,12 @@ bool TLPreprocessorSubnode::InitInternal() {
     return false;
   }
 
-  using common::adapter::AdapterManager;
   CHECK(AdapterManager::GetImageLong())
-  << "TLPreprocessorSubnode init failed.ImageLong is not initialized.";
+      << "TLPreprocessorSubnode init failed.ImageLong is not initialized.";
   AdapterManager::AddImageLongCallback(
       &TLPreprocessorSubnode::SubLongFocusCamera, this);
   CHECK(AdapterManager::GetImageShort())
-  << "TLPreprocessorSubnode init failed.ImageShort is not initialized.";
+      << "TLPreprocessorSubnode init failed.ImageShort is not initialized.";
   AdapterManager::AddImageShortCallback(
       &TLPreprocessorSubnode::SubShortFocusCamera, this);
   return true;
@@ -151,21 +152,19 @@ bool TLPreprocessorSubnode::AddDataAndPublishEvent(
 }
 
 void TLPreprocessorSubnode::SubLongFocusCamera(const sensor_msgs::Image &msg) {
-  common::adapter::AdapterManager::Observe();
-  std::shared_ptr<const sensor_msgs::Image> img =
-      common::adapter::AdapterManager::GetImageLong()->GetLatestObservedPtr();
-  SubCameraImage(img, LONG_FOCUS);
+  AdapterManager::Observe();
+  SubCameraImage(AdapterManager::GetImageLong()->GetLatestObservedPtr(),
+                 LONG_FOCUS);
 }
 
 void TLPreprocessorSubnode::SubShortFocusCamera(const sensor_msgs::Image &msg) {
-  common::adapter::AdapterManager::Observe();
-  std::shared_ptr<const sensor_msgs::Image> img =
-      common::adapter::AdapterManager::GetImageShort()->GetLatestObservedPtr();
-  SubCameraImage(img, SHORT_FOCUS);
+  AdapterManager::Observe();
+  SubCameraImage(AdapterManager::GetImageShort()->GetLatestObservedPtr(),
+                 SHORT_FOCUS);
 }
 
 void TLPreprocessorSubnode::SubCameraImage(
-    std::shared_ptr<const sensor_msgs::Image> msg, CameraId camera_id) {
+    boost::shared_ptr<const sensor_msgs::Image> msg, CameraId camera_id) {
   const double sub_camera_image_start_ts = TimeUtil::GetCurrentTime();
   PERF_FUNCTION();
   std::shared_ptr<Image> image(new Image);
@@ -177,8 +176,7 @@ void TLPreprocessorSubnode::SubCameraImage(
     image->GenerateMat();
     char filename[100];
     snprintf(filename, sizeof(filename), "%s/%lf.jpg",
-             image->camera_id_str().c_str(),
-             timestamp);
+             image->camera_id_str().c_str(), timestamp);
     cv::imwrite(filename, image->mat());
   }
   AINFO << "TLPreprocessorSubnode received a image msg"
@@ -225,7 +223,7 @@ void TLPreprocessorSubnode::SubCameraImage(
   if (fabs(image_lights->diff_image_sys_ts) > image_sys_ts_diff_threshold) {
     std::string debug_string = "";
     debug_string += ("diff_image_sys_ts:" +
-        std::to_string(image_lights->diff_image_sys_ts));
+                     std::to_string(image_lights->diff_image_sys_ts));
     debug_string += (",camera_id:" + kCameraIdToStr.at(camera_id));
     debug_string += (",camera_ts:" + std::to_string(timestamp));
 
@@ -359,4 +357,3 @@ void TLPreprocessorSubnode::CameraSelection(double ts) {
 }  // namespace traffic_light
 }  // namespace perception
 }  // namespace apollo
-

--- a/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.h
+++ b/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.h
@@ -81,7 +81,7 @@ class TLPreprocessorSubnode : public Subnode {
   // @brief sub short focus camera
   void SubShortFocusCamera(const sensor_msgs::Image &msg);
 
-  void SubCameraImage(std::shared_ptr<const sensor_msgs::Image> msg,
+  void SubCameraImage(boost::shared_ptr<const sensor_msgs::Image> msg,
                       CameraId camera_id);
 
   void CameraSelection(double ts);

--- a/modules/perception/traffic_light/visualizer/tl_visualizer.cc
+++ b/modules/perception/traffic_light/visualizer/tl_visualizer.cc
@@ -196,9 +196,9 @@ void SubDebugCallback(const TrafficLightDetection &tl_result) {
 }
 void SubImage(CameraId camera_id,
               const sensor_msgs::ImagePtr &msg) {
-  std::shared_ptr<sensor_msgs::Image> img(new sensor_msgs::Image);
+  boost::shared_ptr<sensor_msgs::Image> img(new sensor_msgs::Image);
   *img = *msg;
-  std::shared_ptr<const sensor_msgs::Image> img_msg(img);
+  boost::shared_ptr<const sensor_msgs::Image> img_msg(img);
   std::shared_ptr<Image> image(new Image);
   if (!image->Init(img_msg->header.stamp.toSec(), camera_id, img_msg)) {
     std::cerr << "tl_visualizer load image failed.";

--- a/modules/planning/tasks/st_graph/st_boundary_mapper.cc
+++ b/modules/planning/tasks/st_graph/st_boundary_mapper.cc
@@ -310,7 +310,8 @@ Status StBoundaryMapper::MapWithoutDecision(PathObstacle* path_obstacle) const {
                       .ExpandByT(boundary_t_buffer);
   boundary.SetId(path_obstacle->Id());
   const auto& prev_st_boundary = path_obstacle->st_boundary();
-  const auto& ref_line_st_boundary = path_obstacle->reference_line_st_boundary();
+  const auto& ref_line_st_boundary =
+      path_obstacle->reference_line_st_boundary();
   if (!prev_st_boundary.IsEmpty()) {
     boundary.SetBoundaryType(prev_st_boundary.boundary_type());
   } else if (!ref_line_st_boundary.IsEmpty()) {

--- a/modules/planning/tasks/traffic_decider/keep_clear.cc
+++ b/modules/planning/tasks/traffic_decider/keep_clear.cc
@@ -46,13 +46,12 @@ bool KeepClear::ApplyRule(Frame* const frame,
   const std::vector<PathOverlap>& keep_clear_overlaps =
       reference_line_info->reference_line().map_path().clear_area_overlaps();
   for (const auto& keep_clear_overlap : keep_clear_overlaps) {
-    if (BuildKeepClearObstacle(
-        frame, reference_line_info,
-        const_cast<PathOverlap*>(&keep_clear_overlap))) {
+    if (BuildKeepClearObstacle(frame, reference_line_info,
+                               const_cast<PathOverlap*>(&keep_clear_overlap))) {
       ADEBUG << "KEEP_CLAER for keep_clear_zone["
-          << keep_clear_overlap.object_id
-          << "] s[" << keep_clear_overlap.start_s
-          << ", " << keep_clear_overlap.end_s << "] BUILD";
+             << keep_clear_overlap.object_id << "] s["
+             << keep_clear_overlap.start_s << ", " << keep_clear_overlap.end_s
+             << "] BUILD";
     }
   }
 
@@ -60,12 +59,11 @@ bool KeepClear::ApplyRule(Frame* const frame,
   const std::vector<PathOverlap>& junction_overlaps =
       reference_line_info->reference_line().map_path().junction_overlaps();
   for (const auto& junction_overlap : junction_overlaps) {
-    if (BuildKeepClearObstacle(
-        frame, reference_line_info,
-        const_cast<PathOverlap*>(&junction_overlap))) {
+    if (BuildKeepClearObstacle(frame, reference_line_info,
+                               const_cast<PathOverlap*>(&junction_overlap))) {
       ADEBUG << "KEEP_CLAER for junction[" << junction_overlap.object_id
-          << "] s[" << junction_overlap.start_s
-          << ", " << junction_overlap.end_s << "] BUILD";
+             << "] s[" << junction_overlap.start_s << ", "
+             << junction_overlap.end_s << "] BUILD";
     }
   }
 
@@ -73,8 +71,7 @@ bool KeepClear::ApplyRule(Frame* const frame,
 }
 
 bool KeepClear::BuildKeepClearObstacle(
-    Frame* const frame,
-    ReferenceLineInfo* const reference_line_info,
+    Frame* const frame, ReferenceLineInfo* const reference_line_info,
     PathOverlap* const keep_clear_overlap) {
   CHECK_NOTNULL(frame);
   CHECK_NOTNULL(reference_line_info);
@@ -84,10 +81,9 @@ bool KeepClear::BuildKeepClearObstacle(
   if (adc_front_edge_s - keep_clear_overlap->start_s >
       FLAGS_keep_clear_min_pass_distance) {
     ADEBUG << "adc inside keep_clear zone[" << keep_clear_overlap->object_id
-           << "] s[" << keep_clear_overlap->start_s
-           << ", " << keep_clear_overlap->end_s
-           << "] adc_front_edge_s[" << adc_front_edge_s
-           << "]. skip this keep clear zone";
+           << "] s[" << keep_clear_overlap->start_s << ", "
+           << keep_clear_overlap->end_s << "] adc_front_edge_s["
+           << adc_front_edge_s << "]. skip this keep clear zone";
     return false;
   }
 
@@ -114,10 +110,9 @@ bool KeepClear::BuildKeepClearObstacle(
   double left_lane_width = 0.0;
   double right_lane_width = 0.0;
   if (!reference_line.GetLaneWidth(keep_clear_overlap->start_s,
-                                   &left_lane_width,
-                                   &right_lane_width)) {
-    AERROR << "Failed to get lane width at s["
-        << keep_clear_overlap->start_s << "]";
+                                   &left_lane_width, &right_lane_width)) {
+    AERROR << "Failed to get lane width at s[" << keep_clear_overlap->start_s
+           << "]";
     return false;
   }
 
@@ -126,8 +121,7 @@ bool KeepClear::BuildKeepClearObstacle(
       left_lane_width + right_lane_width};
   const auto obstacle_id =
       FLAGS_keep_clear_virtual_object_id_prefix + keep_clear_overlap->object_id;
-  auto* obstacle =
-      frame->AddStaticVirtualObstacle(obstacle_id, keep_clear_box);
+  auto* obstacle = frame->AddStaticVirtualObstacle(obstacle_id, keep_clear_box);
   if (!obstacle) {
     AERROR << "Failed to create obstacle " << obstacle_id << " in frame";
     return false;
@@ -137,7 +131,8 @@ bool KeepClear::BuildKeepClearObstacle(
     AERROR << "Failed to create path_obstacle for " << obstacle_id;
     return false;
   }
-  path_obstacle->SetReferenceLineStBoundaryType(StBoundary::BoundaryType::KEEP_CLEAR);
+  path_obstacle->SetReferenceLineStBoundaryType(
+      StBoundary::BoundaryType::KEEP_CLEAR);
 
   return true;
 }


### PR DESCRIPTION
From previous profiling, it takes a considerable amount of time in Adapter::EnqueueData, which involves copying data over to the queue.