### PR TITLE
Fix bug in turn signal command reset

### DIFF
--- a/modules/canbus/vehicle/gem/protocol/turn_cmd_63.cc
+++ b/modules/canbus/vehicle/gem/protocol/turn_cmd_63.cc
@@ -41,7 +41,7 @@ void Turncmd63::UpdateData(uint8_t* data) {
 
 void Turncmd63::Reset() {
   // TODO(QiL) :you should check this manually
-  turn_signal_cmd_ = Turn_cmd_63::TURN_SIGNAL_CMD_RIGHT;
+  turn_signal_cmd_ = Turn_cmd_63::TURN_SIGNAL_CMD_NONE;
 }
 
 Turncmd63* Turncmd63::set_turn_signal_cmd(


### PR DESCRIPTION
Prior to this commit there was a bug in the turn signal reset command. This commit fixes that issue.