### PR TITLE
Common: borrow the "std::make_unique" definition from C++14 so that it can be used both for single objects and arrays of unknown bound in C++11.

### DIFF
--- a/modules/dreamview/backend/hmi/hmi.cc
+++ b/modules/dreamview/backend/hmi/hmi.cc
@@ -40,7 +40,7 @@ using apollo::common::adapter::AdapterManager;
 using apollo::common::time::Clock;
 using apollo::common::util::FindLinkedPtrOrNull;
 using apollo::common::util::JsonUtil;
-using apollo::common::util::make_unique;
+using std::make_unique;
 using Json = WebSocketHandler::Json;
 using RLock = boost::shared_lock<boost::shared_mutex>;
 

--- a/modules/monitor/monitor.cc
+++ b/modules/monitor/monitor.cc
@@ -36,7 +36,7 @@ namespace monitor {
 
 using apollo::common::Status;
 using apollo::common::adapter::AdapterManager;
-using apollo::common::util::make_unique;
+using std::make_unique;
 
 Monitor::Monitor() : monitor_thread_(FLAGS_monitor_running_interval) {
 }

--- a/modules/planning/common/indexed_queue_test.cc
+++ b/modules/planning/common/indexed_queue_test.cc
@@ -33,12 +33,12 @@ namespace planning {
 using StringIndexedQueue = IndexedQueue<int, std::string>;
 TEST(IndexedQueue, QueueSize1) {
   StringIndexedQueue object(1);
-  ASSERT_TRUE(object.Add(1, common::util::make_unique<std::string>("one")));
+  ASSERT_TRUE(object.Add(1, std::make_unique<std::string>("one")));
   ASSERT_TRUE(object.Find(1) != nullptr);
   ASSERT_TRUE(object.Find(2) == nullptr);
-  ASSERT_FALSE(object.Add(1, common::util::make_unique<std::string>("one")));
+  ASSERT_FALSE(object.Add(1, std::make_unique<std::string>("one")));
   ASSERT_EQ("one", *object.Latest());
-  ASSERT_TRUE(object.Add(2, common::util::make_unique<std::string>("two")));
+  ASSERT_TRUE(object.Add(2, std::make_unique<std::string>("two")));
   ASSERT_TRUE(object.Find(1) == nullptr);
   ASSERT_TRUE(object.Find(2) != nullptr);
   ASSERT_EQ("two", *object.Latest());
@@ -46,16 +46,16 @@ TEST(IndexedQueue, QueueSize1) {
 
 TEST(IndexedQueue, QueueSize2) {
   StringIndexedQueue object(2);
-  ASSERT_TRUE(object.Add(1, common::util::make_unique<std::string>("one")));
+  ASSERT_TRUE(object.Add(1, std::make_unique<std::string>("one")));
   ASSERT_TRUE(object.Find(1) != nullptr);
   ASSERT_TRUE(object.Find(2) == nullptr);
-  ASSERT_FALSE(object.Add(1, common::util::make_unique<std::string>("one")));
+  ASSERT_FALSE(object.Add(1, std::make_unique<std::string>("one")));
   ASSERT_EQ("one", *object.Latest());
-  ASSERT_TRUE(object.Add(2, common::util::make_unique<std::string>("two")));
+  ASSERT_TRUE(object.Add(2, std::make_unique<std::string>("two")));
   ASSERT_TRUE(object.Find(1) != nullptr);
   ASSERT_TRUE(object.Find(2) != nullptr);
   ASSERT_EQ("two", *object.Latest());
-  ASSERT_TRUE(object.Add(3, common::util::make_unique<std::string>("three")));
+  ASSERT_TRUE(object.Add(3, std::make_unique<std::string>("three")));
   ASSERT_TRUE(object.Find(1) == nullptr);
   ASSERT_TRUE(object.Find(2) != nullptr);
   ASSERT_TRUE(object.Find(3) != nullptr);


### PR DESCRIPTION
The helper function "std::make_unique()" is defined since C++14. 
The definition of "std::make_unique()" borrowed from C++14 is given here so that it can be used in C++11.