### PR TITLE
Planning: replace "std::unique_ptr<T>(new T(...))" with "std::make_unique<T>(...)".

### DIFF
--- a/modules/planning/planning.cc
+++ b/modules/planning/planning.cc
@@ -112,8 +112,9 @@ Status Planning::Init() {
   if (!FLAGS_use_navigation_mode) {
     hdmap_ = HDMapUtil::BaseMapPtr();
     CHECK(hdmap_) << "Failed to load map";
-    reference_line_provider_ = std::unique_ptr<ReferenceLineProvider>(
-        new ReferenceLineProvider(hdmap_));
+    // Prefer "std::make_unique" to direct use of "new".
+    // Reference "https://herbsutter.com/gotw/_102/" for details.
+    reference_line_provider_ = std::make_unique<ReferenceLineProvider>(hdmap_);
   }
 
   RegisterPlanners();
@@ -220,8 +221,9 @@ void Planning::RunOnce() {
   if (FLAGS_use_navigation_mode) {
     // recreate reference line provider in every cycle
     hdmap_ = HDMapUtil::BaseMapPtr();
-    reference_line_provider_ = std::unique_ptr<ReferenceLineProvider>(
-        new ReferenceLineProvider(hdmap_));
+    // Prefer "std::make_unique" to direct use of "new".
+    // Reference "https://herbsutter.com/gotw/_102/" for details.
+    reference_line_provider_ = std::make_unique<ReferenceLineProvider>(hdmap_);
   }
 
   // localization

--- a/modules/planning/reference_line/smoother_util.cc
+++ b/modules/planning/reference_line/smoother_util.cc
@@ -81,8 +81,10 @@ class SmootherUtil {
         s += segment.length();
       }
       ReferenceLine init_ref(ref_points);
-      std::unique_ptr<ReferenceLineSmoother> smoother_ptr(
-          new QpSplineReferenceLineSmoother(config_));
+      // Prefer "std::make_unique" to direct use of "new".
+      // Reference "https://herbsutter.com/gotw/_102/" for details.
+      auto smoother_ptr =
+          std::make_unique<QpSplineReferenceLineSmoother>(config_);
       auto anchors =
           CreateAnchorPoints(init_ref.reference_points().front(), init_ref);
       smoother_ptr->SetAnchorPoints(anchors);
@@ -121,8 +123,10 @@ class SmootherUtil {
       i = j;
       ReferenceLine local_ref(ref_points);
       auto anchors = CreateAnchorPoints(ref_points.front(), local_ref);
-      std::unique_ptr<ReferenceLineSmoother> smoother_ptr(
-          new QpSplineReferenceLineSmoother(config_));
+      // Prefer "std::make_unique" to direct use of "new".
+      // Reference "https://herbsutter.com/gotw/_102/" for details.
+      auto smoother_ptr =
+          std::make_unique<QpSplineReferenceLineSmoother>(config_);
       smoother_ptr->SetAnchorPoints(anchors);
       ReferenceLine smoothed_local_ref;
       if (!smoother_ptr->Smooth(local_ref, &smoothed_local_ref)) {


### PR DESCRIPTION
Prefer "std::make_unique" to direct use of "new".
Compared to direct use of new, make functions eliminate source code duplication,
provides cleaner, concise codes, improve exception safety.
Reference "https://herbsutter.com/gotw/_102/" for details.