### PR TITLE
canbus: pass delphi_esr node name to avoid ros node name conflict wit…

### DIFF
--- a/scripts/delphi_esr.sh
+++ b/scripts/delphi_esr.sh
@@ -25,5 +25,5 @@ source "$DIR/apollo_base.sh"
 
 # run function from apollo_base.sh
 # run command_name module_name
-run_customized_path drivers/radar/delphi_esr delphi_esr "$@"
-
+run_customized_path drivers/radar/delphi_esr delphi_esr "$@" \
+    --canbus_driver_name="delphi_esr"


### PR DESCRIPTION
…h canbus.