### PR TITLE
scritps: write log to a file about the env when record bag

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -392,6 +392,19 @@ function run_customized_path() {
   esac
 }
 
+#write log to a file about the env when record a bag.
+function record_bag_env_log() {
+  TASK_ID=$(date +%Y-%m-%d-%H-%M)
+  commit=$(git log -1)
+  echo -e "Date:$(date)\n" >> Bag_Env_$TASK_ID.log
+  git branch | awk '/\*/ { print "current branch: " $2; }'  >> Bag_Env_$TASK_ID.log
+  echo -e "\nNewest commit:\n$commit"  >> Bag_Env_$TASK_ID.log
+  echo -e "\ngit diff:" >> Bag_Env_$TASK_ID.log
+  git diff >> Bag_Env_$TASK_ID.log
+  echo -e "\n\n\n\n" >> Bag_Env_$TASK_ID.log
+  echo -e "git diff --staged:" >> Bag_Env_$TASK_ID.log
+  git diff --staged >> Bag_Env_$TASK_ID.log
+}
 # run command_name module_name
 function run() {
   local module=$1

--- a/scripts/record_bag.sh
+++ b/scripts/record_bag.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then

--- a/scripts/record_bag_local.sh
+++ b/scripts/record_bag_local.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then

--- a/scripts/record_bag_navigation_perception.sh
+++ b/scripts/record_bag_navigation_perception.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then

--- a/scripts/record_bag_pnc.sh
+++ b/scripts/record_bag_pnc.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then

--- a/scripts/record_bag_sensor.sh
+++ b/scripts/record_bag_sensor.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then

--- a/scripts/record_map_data.sh
+++ b/scripts/record_map_data.sh
@@ -26,6 +26,7 @@ function start() {
   cd "${TASK_DIR}"
 
   # Start recording.
+  record_bag_env_log
   LOG="/tmp/apollo_record.out"
   NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then


### PR DESCRIPTION
if we record a log of bags,then it would be very confused what the env is 
By this,every bag would have a log with it .
the log would contain date,branch,newest commit id , git diff and git diff --staged.