### PR TITLE
optimized compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ specify either `dbg` for debug mode or `opt` for optimized code
 If you make modifications to the Dreamview frontend, then you must run `./apollo.sh build_fe`  before you run the
 full build.
 
+If the computer is very slow, you can enter the following command to limit the CPU.
+
+```
+bash apollo.sh build --local_resources 2048,1.0,1.0
+```
+
 
 ## Run Apollo
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -37,7 +37,14 @@ bash docker/scripts/dev_into.sh
 bash apollo.sh build
 ```
 
+如果编译很卡,可以在后面附加参数限制CPU
+
+```
+bash apollo.sh build --local_resources 2048,1.0,1.0
+```
+
 ## 运行Apollo
+
 请按照如下步骤启动Apollo。
 
 ### 启动Apollo

--- a/docs/howto/how_to_build_and_release.md
+++ b/docs/howto/how_to_build_and_release.md
@@ -28,7 +28,14 @@ bash docker/scripts/dev_into.sh
 ```bash
 bash apollo.sh build
 ```
+If the computer is very slow, you can enter the following command to limit the CPU.
+
+```
+bash apollo.sh build --local_resources 2048,1.0,1.0
+```
+
 ### Release binaries
+
 ```bash
 bash apollo.sh release
 ```


### PR DESCRIPTION
如果build后面不加参数,build的时候会非常卡,尤其是在机械硬盘上运行更加明显.加入参数后不仅卡顿得到优化,合理的参数编译速度也有所提升,目前已在公司多台电脑验证.
第二个参数为CPU个数,开启编译的进程为该值的2倍,但进程数不会超过5个(任务限制),经研究该数值在1.0到2.0比较合理(不同的电脑配置会有一些区别)