### PR TITLE
Used condition_variable to update the reference line for efficiency.

### DIFF
--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -92,8 +92,16 @@ ReferenceLineProvider::FutureRouteWaypoints() {
 
 void ReferenceLineProvider::UpdateVehicleState(
     const VehicleState &vehicle_state) {
-  std::lock_guard<std::mutex> lock(vehicle_state_mutex_);
-  vehicle_state_ = vehicle_state;
+  {
+    std::lock_guard<std::mutex> lock(vehicle_state_mutex_);
+    vehicle_state_ = vehicle_state;
+  }
+  // Set the flag "pending_" to true so that worker threads start processing.
+  {
+    std::lock_guard<std::mutex> lock(notify_mutex_);
+    pending_ = true;
+  }
+  cv_.notify_one();
 }
 
 bool ReferenceLineProvider::Start() {
@@ -158,11 +166,15 @@ void ReferenceLineProvider::UpdateReferenceLine(
 }
 
 void ReferenceLineProvider::GenerateThread() {
-  constexpr int32_t kSleepTime = 50;  // milliseconds
   while (!is_stop_) {
-    std::this_thread::yield();
-    std::this_thread::sleep_for(
-        std::chrono::duration<double, std::milli>(kSleepTime));
+    // Wait until UpdateRoutingResponse() or UpdateVehicleState() changes the
+    // flag of "pending_" to "true".
+    // See "http://en.cppreference.com/w/cpp/thread/condition_variable" for
+    // datails.
+    std::unique_lock<std::mutex> lock(notify_mutex_);
+    cv_.wait(lock, [this]() { return pending_; });
+    lock.unlock();
+
     double start_time = Clock::NowInSeconds();
     if (!has_routing_) {
       AERROR << "Routing is not ready.";
@@ -176,8 +188,16 @@ void ReferenceLineProvider::GenerateThread() {
     }
     UpdateReferenceLine(reference_lines, segments);
     double end_time = Clock::NowInSeconds();
-    std::lock_guard<std::mutex> lock(reference_lines_mutex_);
-    last_calculation_time_ = end_time - start_time;
+    {
+      std::lock_guard<std::mutex> rf_lock(reference_lines_mutex_);
+      last_calculation_time_ = end_time - start_time;
+    }
+
+    // Tell the main thread that the current reference line is processed.
+    lock.lock();
+    processed_ = true;
+    lock.unlock();
+    cv_.notify_one();
   }
 }
 
@@ -211,7 +231,19 @@ bool ReferenceLineProvider::GetReferenceLines(
   }
 
   if (FLAGS_enable_reference_line_provider_thread) {
-    std::lock_guard<std::mutex> lock(reference_lines_mutex_);
+    // Wait the worker thread function GenerateThread() changes the flag of
+    // "processed_" to "true".
+    // See "http://en.cppreference.com/w/cpp/thread/condition_variable" for
+    // datails.
+    {
+      std::unique_lock<std::mutex> lock(notify_mutex_);
+      if (!cv_.wait_for(lock, std::chrono::milliseconds(10),
+                        [this]() { return processed_; })) {
+        AERROR << "Failed to update the current reference line whin 10ms. ";
+        return false;
+      }
+      // cv_.wait(lock, [this]() { return processed_; });
+    }
 
     if (!reference_lines_.empty()) {
       reference_lines->assign(reference_lines_.begin(), reference_lines_.end());

--- a/modules/planning/reference_line/reference_line_provider.h
+++ b/modules/planning/reference_line/reference_line_provider.h
@@ -163,6 +163,11 @@ class ReferenceLineProvider {
   std::list<ReferenceLine> reference_lines_;
   std::list<hdmap::RouteSegments> route_segments_;
   double last_calculation_time_ = 0.0;
+
+  std::mutex notify_mutex_;
+  std::condition_variable cv_;
+  bool pending_ = false;
+  bool processed_ = false;
 };
 
 }  // namespace planning


### PR DESCRIPTION
Because the task of updating the reference line conforms to the producer-consumer multithreading model, a condition_variable is used to inform the worker thread to update the reference line, thereby improving processing efficiency.