### PR TITLE
Fix a typo of the location of install_docker.sh

### DIFF
--- a/docker/scripts/README.md
+++ b/docker/scripts/README.md
@@ -7,7 +7,7 @@ Please follow the
 we also provide a bash script to install docker-ce
 
 ```bash
-bash docker/scripts/install_docker.sh
+bash docker/setup_host/install_docker.sh
 ```
 
 Don't forget the


### PR DESCRIPTION
Replace "bash docker/scripts/install_docker.sh" with  "bash docker/setup_host/install_docker.sh"