### PR TITLE
ReferenceLineProvider: support muti navigation paths change lane

### DIFF
--- a/modules/planning/reference_line/BUILD
+++ b/modules/planning/reference_line/BUILD
@@ -114,6 +114,7 @@ cc_library(
         "//modules/planning/common:planning_util",
         "//modules/planning/proto:planning_config_proto",
         "//modules/planning/proto:planning_status_proto",
+        "//modules/common/vehicle_state:vehicle_state_provider",
     ],
 )
 

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -30,6 +30,7 @@
 #include "modules/common/configs/vehicle_config_helper.h"
 #include "modules/common/time/time.h"
 #include "modules/common/util/file.h"
+#include "modules/common/vehicle_state/vehicle_state_provider.h"
 #include "modules/map/hdmap/hdmap_util.h"
 #include "modules/map/pnc_map/path.h"
 #include "modules/planning/common/planning_gflags.h"
@@ -298,7 +299,130 @@ bool ReferenceLineProvider::GetReferenceLinesFromRelativeMap(
   if (relative_map.navigation_path_size() <= 0) {
     return false;
   }
+
   auto *hdmap = HDMapUtil::BaseMapPtr();
+  if (!hdmap) {
+    AERROR << "hdmap is null";
+    return false;
+  }
+
+  // 1.get adc current lane info ,such as lane_id,lane_priority,neighbor lanes
+  std::unordered_set<std::string> navigation_lane_ids;
+  for (const auto &path_pair : relative_map.navigation_path()) {
+    const auto lane_id = path_pair.first;
+    navigation_lane_ids.insert(lane_id);
+  }
+  if (navigation_lane_ids.empty()) {
+    AERROR << "navigation path ids is empty";
+    return false;
+  }
+  // get curent adc lane info by vehicle state
+  common::VehicleState vehicle_state =
+      common::VehicleStateProvider::instance()->vehicle_state();
+  hdmap::LaneWaypoint adc_lane_way_point;
+  if (!GetNearestWayPointFromNavigationPath(vehicle_state, navigation_lane_ids,
+                                            &adc_lane_way_point)) {
+    return false;
+  }
+  const std::string adc_lane_id = adc_lane_way_point.lane->id().id();
+  auto adc_navigation_path = relative_map.navigation_path().find(adc_lane_id);
+  if (adc_navigation_path == relative_map.navigation_path().end()) {
+    AERROR << "adc lane cannot be found in relative_map.navigation_path";
+    return false;
+  }
+  const uint32_t adc_lane_priority =
+      adc_navigation_path->second.path_priority();
+  // get adc left neighbor lanes
+  std::vector<std::string> left_neighbor_lane_ids;
+  std::vector<std::string> right_neighbor_lane_ids;
+  for (const auto &left_lane_id :
+       adc_lane_way_point.lane->lane().left_neighbor_forward_lane_id()) {
+    left_neighbor_lane_ids.push_back(left_lane_id.id());
+  }
+  // get adc right neighbor lanes
+  for (const auto &right_lane_id :
+       adc_lane_way_point.lane->lane().right_neighbor_forward_lane_id()) {
+    right_neighbor_lane_ids.push_back(right_lane_id.id());
+  }
+
+  // 2.get the higher priority lane info list which priority higher
+  // than current lane and get the highest one as the target lane
+  using LaneIdPair = std::pair<std::string, uint32_t>;
+  std::vector<LaneIdPair> high_priority_lane_pairs;
+  ADEBUG << "relative_map.navigation_path_size = "
+         << relative_map.navigation_path_size();
+  for (const auto &path_pair : relative_map.navigation_path()) {
+    const auto lane_id = path_pair.first;
+    const uint32_t priority = path_pair.second.path_priority();
+    ADEBUG << "lane_id = " << lane_id;
+    ADEBUG << "priority = " << priority;
+    // the smaller the number, the higher the priority
+    if (adc_lane_id != lane_id && priority < adc_lane_priority) {
+      // high_priority_lane_pairs.emplace_back(lane_id, priority);
+    }
+  }
+  // get the target lane
+  bool is_lane_change_needed = false;
+  LaneIdPair target_lane_pair;
+  if (!high_priority_lane_pairs.empty()) {
+    // std::sort(high_priority_lane_pairs.begin(),
+    // high_priority_lane_pairs.end())；
+    std::sort(high_priority_lane_pairs.begin(), high_priority_lane_pairs.end(),
+              [](const LaneIdPair &left, const LaneIdPair &right) {
+                return left.second < right.second;
+              });
+    ADEBUG << "need to change lane";
+    // the higheast priority lane as the target naviagion lane
+    target_lane_pair = high_priority_lane_pairs.front();
+    is_lane_change_needed = true;
+  }
+  // 3.get current lane's the neareast neighbor lane to the target lane
+  // and make sure it position is left or right on the current lane
+  routing::ChangeLaneType lane_change_type = routing::FORWARD;
+  std::string neareast_neighbor_lane_id;
+  if (is_lane_change_needed) {
+    // target on the left of adc
+    if (left_neighbor_lane_ids.end() !=
+        std::find(left_neighbor_lane_ids.begin(), left_neighbor_lane_ids.end(),
+                  target_lane_pair.first)) {
+      auto lane_ptr =
+          hdmap->GetLaneById(hdmap::MakeMapId(target_lane_pair.first));
+      while (!lane_ptr &&
+             lane_ptr->lane().right_neighbor_forward_lane_id_size() > 0 &&
+             lane_ptr->lane().right_neighbor_forward_lane_id(0).id() !=
+                 adc_lane_id) {
+        lane_ptr = hdmap->GetLaneById(
+            lane_ptr->lane().right_neighbor_forward_lane_id(0));
+      }
+      if (lane_ptr->lane().right_neighbor_forward_lane_id(0).id() ==
+          adc_lane_id) {
+        neareast_neighbor_lane_id =
+            lane_ptr->lane().right_neighbor_forward_lane_id(0).id();
+        lane_change_type = routing::LEFT;
+      }
+      // target lane on the right of adc
+    } else if (right_neighbor_lane_ids.end() !=
+               std::find(right_neighbor_lane_ids.begin(),
+                         right_neighbor_lane_ids.end(),
+                         target_lane_pair.first)) {
+      auto lane_ptr =
+          hdmap->GetLaneById(hdmap::MakeMapId(target_lane_pair.first));
+      while (!lane_ptr &&
+             lane_ptr->lane().left_neighbor_forward_lane_id_size() > 0 &&
+             lane_ptr->lane().left_neighbor_forward_lane_id(0).id() !=
+                 adc_lane_id) {
+        lane_ptr = hdmap->GetLaneById(
+            lane_ptr->lane().left_neighbor_forward_lane_id(0));
+      }
+      if (lane_ptr->lane().left_neighbor_forward_lane_id(0).id() ==
+          adc_lane_id) {
+        neareast_neighbor_lane_id =
+            lane_ptr->lane().left_neighbor_forward_lane_id(0).id();
+        lane_change_type = routing::RIGHT;
+      }
+    }
+  }
+
   for (const auto &path_pair : relative_map.navigation_path()) {
     const auto &lane_id = path_pair.first;
     const auto &path_points = path_pair.second.path().path_point();
@@ -307,10 +431,19 @@ bool ReferenceLineProvider::GetReferenceLinesFromRelativeMap(
     segment.emplace_back(lane_ptr, 0.0, lane_ptr->total_length());
     segment.SetCanExit(true);
     segment.SetId(lane_id);
-    segment.SetNextAction(routing::FORWARD);
+    segment.SetNextAction(lane_change_type);
     segment.SetIsOnSegment(true);
     segment.SetStopForDestination(false);
     segment.SetPreviousAction(routing::FORWARD);
+    // need change line
+    if (is_lane_change_needed) {
+      if (lane_id == neareast_neighbor_lane_id) {
+        ADEBUG << "adc lane_id = " << adc_lane_id
+               << " neareast_neighbor_lane_id = " << lane_id;
+        segment.SetIsOnSegment(false);
+        segment.SetPreviousAction(lane_change_type);
+      }
+    }
     segments->emplace_back(segment);
     std::vector<ReferencePoint> ref_points;
     for (const auto &path_point : path_points) {
@@ -322,7 +455,85 @@ bool ReferenceLineProvider::GetReferenceLinesFromRelativeMap(
     }
     reference_line->emplace_back(ref_points.begin(), ref_points.end());
   }
-  return true;
+  return !segments->empty();
+}
+
+bool ReferenceLineProvider::GetNearestWayPointFromNavigationPath(
+    const common::VehicleState &state,
+    const std::unordered_set<std::string> &navigation_lane_ids,
+    hdmap::LaneWaypoint *waypoint) {
+  const double kMaxDistance = 10.0;
+  waypoint->lane = nullptr;
+  std::vector<hdmap::LaneInfoConstPtr> lanes;
+  auto point = common::util::MakePointENU(state.x(), state.y(), state.z());
+  if (std::isnan(point.x()) || std::isnan(point.y())) {
+    AERROR << "vehicle state is invalid";
+    return false;
+  }
+  auto *hdmap = HDMapUtil::BaseMapPtr();
+  if (!hdmap) {
+    AERROR << "hdmap is null";
+    return false;
+  }
+
+  // get all adc direction lanes from map in kMaxDistance range
+  // by vehicle point in map
+  const int status = hdmap->GetLanesWithHeading(
+      point, kMaxDistance, state.heading(), M_PI / 2.0, &lanes);
+  if (status < 0) {
+    AERROR << "failed to get lane from point " << point.ShortDebugString();
+    return false;
+  }
+  if (lanes.empty()) {
+    AERROR << "no valid lane found within " << kMaxDistance
+           << " meters with heading " << state.heading();
+    return false;
+  }
+
+  // get lanes that exist in both map and navigation paths as vallid lanes
+  std::vector<hdmap::LaneInfoConstPtr> valid_lanes;
+  std::copy_if(lanes.begin(), lanes.end(), std::back_inserter(valid_lanes),
+               [&](hdmap::LaneInfoConstPtr ptr) {
+                 return navigation_lane_ids.count(ptr->lane().id().id()) > 0;
+               });
+
+  // get nearest lane wayponints for current adc position
+  double min_distance = std::numeric_limits<double>::infinity();
+  for (const auto &lane : valid_lanes) {
+    // project adc point to lane to check if it is out of lane range
+    double s = 0.0;
+    double l = 0.0;
+    if (!lane->GetProjection({point.x(), point.y()}, &s, &l)) {
+      continue;
+    }
+    constexpr double kEpsilon = 1e-6;
+    if (s > (lane->total_length() + kEpsilon) || (s + kEpsilon) < 0.0) {
+      continue;
+    }
+
+    // get the neareast distance between adc point adn lane
+    double distance = 0.0;
+    common::PointENU map_point =
+        lane->GetNearestPoint({point.x(), point.y()}, &distance);
+    // reord the near distance lane
+    if (distance < min_distance) {
+      double s = 0.0;
+      double l = 0.0;
+      if (!lane->GetProjection({map_point.x(), map_point.y()}, &s, &l)) {
+        AERROR << "failed to get projection for map_point "
+               << map_point.DebugString();
+        continue;
+      }
+      min_distance = distance;
+      waypoint->lane = lane;
+      waypoint->s = s;
+    }
+  }
+
+  if (waypoint->lane == nullptr) {
+    AERROR << "failed to find nearest point " << point.ShortDebugString();
+  }
+  return waypoint->lane != nullptr;
 }
 
 bool ReferenceLineProvider::CreateRouteSegments(

--- a/modules/planning/reference_line/reference_line_provider.h
+++ b/modules/planning/reference_line/reference_line_provider.h
@@ -32,6 +32,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <unordered_set>
 
 #include "modules/common/vehicle_state/proto/vehicle_state.pb.h"
 #include "modules/map/relative_map/proto/navigation.pb.h"
@@ -142,6 +143,15 @@ class ReferenceLineProvider {
       const relative_map::MapMsg& relative_map,
       std::list<ReferenceLine>* reference_line,
       std::list<hdmap::RouteSegments>* segments);
+
+  /**
+   * @brief This function get adc lane info from navigation path and map
+   * by vehicle state.
+   */
+  bool GetNearestWayPointFromNavigationPath(
+       const common::VehicleState &state,
+       const std::unordered_set<std::string> &navigation_lane_ids,
+       hdmap::LaneWaypoint *waypoint);
 
  private:
   bool is_initialized_ = false;

--- a/modules/planning/testdata/navigation_mode_test/1_relative_map.pb.txt
+++ b/modules/planning/testdata/navigation_mode_test/1_relative_map.pb.txt
@@ -13,6 +13,11 @@ hdmap {
         line_segment {
           point {
             x: 0.0
+            y: 0.0
+            z: 0.0
+          }
+          point {
+            x: 0.0
             y: 0.275390625
             z: 0.0
           }


### PR DESCRIPTION
 add how to set change lane condition in ReferenceLineProvider::GetReferenceLinesFromRelativeMap
 
 add data for test case in testdata/navigation_mode_test/1_relative_map.pb.txt