### PR TITLE
Fix multi navigation issue

### DIFF
--- a/modules/planning/reference_line/BUILD
+++ b/modules/planning/reference_line/BUILD
@@ -114,7 +114,6 @@ cc_library(
         "//modules/planning/common:planning_util",
         "//modules/planning/proto:planning_config_proto",
         "//modules/planning/proto:planning_status_proto",
-        "//modules/common/vehicle_state:vehicle_state_provider",
     ],
 )
 


### PR DESCRIPTION
1.fix issue:When the target lane is on the left of the car, the method called to find the nearest adjacent lane to the car in the target direction is wrong.

2.Optimize the code:
  1)format log output.
  2)when need change lane, only provide the navigation line where the vehicle is currently located and 
     the navigation line where the vehicle is about to change lane.
  3)when can not need change lane,only provide the navigation line where the vehicle is currently 
     located.
  4)delete something about vehicle_state_provider.
     