### PR TITLE
Fix startup script for users with multiple groups

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -266,7 +266,7 @@ function main(){
         -e DOCKER_USER=$USER \
         -e USER=$USER \
         -e DOCKER_USER_ID=$USER_ID \
-        -e DOCKER_GRP=$GRP \
+        -e DOCKER_GRP="$GRP" \
         -e DOCKER_GRP_ID=$GRP_ID \
         -e DOCKER_IMG=$IMG \
         $(local_volumes) \


### PR DESCRIPTION
Starting the Docker container fails when the user starting the process is a 
member of multiple groups, as the space separated list of groups is passed 
unquoted to the docker command, which breaks the command. This is fixed 
by quoting the group parameter.

Fixes #4366 