### PR TITLE
ReferenceLineProvider : Under multiple navigation lines,Fix issue and…

### DIFF
--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -296,7 +296,12 @@ bool ReferenceLineProvider::GetReferenceLinesFromRelativeMap(
     const relative_map::MapMsg &relative_map,
     std::list<ReferenceLine> *reference_line,
     std::list<hdmap::RouteSegments> *segments) {
-  if (relative_map.navigation_path_size() <= 0) {
+  DCHECK_GE(relative_map.navigation_path_size(), 0);
+  DCHECK_NOTNULL(reference_line);
+  DCHECK_NOTNULL(segments);
+
+  if (relative_map.navigation_path().empty()) {
+    AERROR << "There isn't any navigation path in current relative map.";
     return false;
   }
 


### PR DESCRIPTION
… Optimize the generation of reference line information.

@lianglia-apollo thank you for your comments.
1.It has been modified according to the review comments.
2.In addition, the following aspects are optimized:
  1)format log output.
  2)when need change lane, only provide the navigation line where the vehicle is currently located and
    the navigation line where the vehicle is about to change lane.
  3)it is better to use a while loop than a for loop to get the left and right neighbor lanes of the current
lane.
  4)when changing lanes, use the first adjacent lane on the left or right of the current lane as the target
lane of this lane change.