### PR TITLE
Map: added a new item in MapMsg for relative map.

### DIFF
--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -548,6 +548,7 @@ void NavigationLane::ConvertLaneMarkerToPath(
 
 bool NavigationLane::CreateMap(const MapGenerationParam &map_config,
                                MapMsg *map_msg) const {
+  CHECK_NOTNULL(map_msg);
   auto *navigation_info = map_msg->mutable_navigation_path();
   auto *hdmap = map_msg->mutable_hdmap();
   auto *lane_marker = map_msg->mutable_lane_marker();
@@ -564,6 +565,12 @@ bool NavigationLane::CreateMap(const MapGenerationParam &map_config,
     lane->mutable_id()->set_id(std::to_string(navi_path->path_priority()) +
                                "_" + path.name());
     (*navigation_info)[lane->id().id()] = *navi_path;
+
+    // Set the lane id of the navigation path which the vehicle is currently on.
+    if (std::get<0>(navi_path_tuple) == std::get<0>(current_navi_path_tuple_)) {
+      map_msg->set_vechicle_lane_id(lane->id().id());
+    }
+
     // lane types
     lane->set_type(Lane::CITY_DRIVING);
     lane->set_turn(Lane::NO_TURN);

--- a/modules/map/relative_map/proto/navigation.proto
+++ b/modules/map/relative_map/proto/navigation.proto
@@ -10,7 +10,7 @@ import "modules/perception/proto/perception_obstacle.proto";
 
 message NavigationPath {
   optional apollo.common.Path path = 1;
- // highest = 0 which can directly reach destination; change lane indicator
+  // highest = 0 which can directly reach destination; change lane indicator
   optional uint32 path_priority = 2;
 }
 
@@ -38,4 +38,7 @@ message MapMsg {
 
   // localization
   optional apollo.localization.LocalizationEstimate localization = 5;
+
+  // the lane id of the navigation path which the vehicle is currently on
+  optional string vechicle_lane_id = 6;
 }


### PR DESCRIPTION
The "vechicle_lane_id" is the lane id of the navigation path which the vehicle is currently on. It is used to indicate the current lane when changing lanes.