### PR TITLE
Monitor: Extend acceptable_gnss_best_pose_unstable_duration to 120s.

### DIFF
--- a/modules/monitor/hardware/gps/gps_monitor.cc
+++ b/modules/monitor/hardware/gps/gps_monitor.cc
@@ -30,7 +30,7 @@ DEFINE_double(acceptable_gnss_best_pose_std_dev, 0.5,
               "Acceptable Gnss BestPose standard deviation on latitude, "
               "longitude and height.");
 
-DEFINE_double(acceptable_gnss_best_pose_unstable_duration, 30,
+DEFINE_double(acceptable_gnss_best_pose_unstable_duration, 120,
               "Acceptable Gnss BestPose unstable duration in seconds.");
 
 namespace apollo {


### PR DESCRIPTION
…conds.