### PR TITLE
Optimize routine GetSubnodeByName

### DIFF
--- a/modules/perception/onboard/dag_streaming.h
+++ b/modules/perception/onboard/dag_streaming.h
@@ -61,7 +61,7 @@ class DAGStreaming : public Thread {
 
   size_t CongestionValue() const;
 
-  static Subnode *GetSubnodeByName(std::string name);
+  static Subnode *GetSubnodeByName(const std::string &name);
 
  protected:
   void Run() override;


### PR DESCRIPTION
reduce one copy operation