### PR TITLE
Optimize routine GetSubnodeByName

### DIFF
--- a/modules/perception/onboard/dag_streaming.cc
+++ b/modules/perception/onboard/dag_streaming.cc
@@ -230,7 +230,7 @@ void DAGStreamingMonitor::Run() {
   }
 }
 
-Subnode* DAGStreaming::GetSubnodeByName(std::string name) {
+Subnode* DAGStreaming::GetSubnodeByName(const std::string &name) {
   std::map<std::string, SubnodeID>::iterator iter =
       subnode_name_map_.find(name);
   if (iter != subnode_name_map_.end()) {

--- a/modules/perception/onboard/dag_streaming.h
+++ b/modules/perception/onboard/dag_streaming.h
@@ -61,7 +61,7 @@ class DAGStreaming : public Thread {
 
   size_t CongestionValue() const;
 
-  static Subnode *GetSubnodeByName(std::string name);
+  static Subnode *GetSubnodeByName(const std::string &name);
 
  protected:
   void Run() override;


### PR DESCRIPTION
improve to reduce one copy operation.(#4828 )