### PR TITLE
control: remove death test

### DIFF
--- a/modules/control/control_test.cc
+++ b/modules/control/control_test.cc
@@ -39,15 +39,7 @@ class ControlTest : public ::testing::Test {
 TEST_F(ControlTest, Name) { EXPECT_EQ("control", control_.Name()); }
 
 TEST_F(ControlTest, Init) {
-  FLAGS_control_conf_file = "";
-  auto result = common::Status(
-      common::ErrorCode::CONTROL_INIT_ERROR,
-      "Unable to load control conf file: " + FLAGS_control_conf_file);
-  EXPECT_DEATH(control_.Init(), "Unable to load control conf file");
   FLAGS_control_conf_file = "modules/control/testdata/conf/lincoln.pb.txt";
-  FLAGS_control_adapter_config_filename = "";
-  EXPECT_DEATH(control_.Init(), "Unable to parse adapter config file " +
-                                    FLAGS_control_adapter_config_filename);
   FLAGS_control_adapter_config_filename =
       "modules/control/testdata/conf/adapter.conf";
   EXPECT_EQ(common::Status::OK(), control_.Init());


### PR DESCRIPTION
death test often generates core files