### PR TITLE
RelativeMap: down sampled raw navigation path data.

### DIFF
--- a/modules/map/relative_map/common/relative_map_gflags.cc
+++ b/modules/map/relative_map/common/relative_map_gflags.cc
@@ -51,3 +51,7 @@ DEFINE_bool(enable_cyclic_rerouting, false,
 
 DEFINE_bool(relative_map_generate_left_boundray, true,
             "Generate left boundary for detected lanes.");
+
+DEFINE_bool(navigator_down_sample, true,
+            "When a navigation line is sent, the original data is downsampled "
+            "to reduce unnecessary memory consumption.");

--- a/modules/map/relative_map/common/relative_map_gflags.h
+++ b/modules/map/relative_map/common/relative_map_gflags.h
@@ -32,5 +32,6 @@ DECLARE_double(min_lane_half_width);
 DECLARE_double(max_lane_half_width);
 DECLARE_bool(enable_cyclic_rerouting);
 DECLARE_bool(relative_map_generate_left_boundray);
+DECLARE_bool(navigator_down_sample);
 
 #endif  // MODULES_MAP_RELATIVE_MAP_RELATIVE_MAP_GFLAGS_H_

--- a/scripts/navigator.sh
+++ b/scripts/navigator.sh
@@ -18,14 +18,21 @@
 
 # Get the absolute path.
 i=0;
-for file_name in $@
+j=0;
+for str in $@
 do    
-    DIR=$(cd "$(dirname ${file_name} )" && pwd)
-    FILE_NAME=$(basename ${file_name})
-    PATH_NAME[i++]="${DIR}/${FILE_NAME}"    
+    # The strings starting with "--" are control arguments and need to be filtered.
+    if [[ ${str} =~ ^--.* ]]; then    
+        CTRL_ARGS[i++]=${str}
+        continue
+    fi
+    DIR=$(cd "$(dirname ${str} )" && pwd)
+    FILE_NAME=$(basename ${str})
+    PATH_NAME[j++]="${DIR}/${FILE_NAME}"    
 done
 
+#echo "${CTRL_ARGS[@]}"
 #echo "${PATH_NAME[@]}"
 cd /apollo
-./bazel-bin/modules/map/relative_map/tools/navigator "${PATH_NAME[@]}" 
+./bazel-bin/modules/map/relative_map/tools/navigator "${CTRL_ARGS[@]}" "${PATH_NAME[@]}" 
 


### PR DESCRIPTION
Apollo 3.0 uses a new smoothing algorithm to generate the navigation path, which makes the number of points in the navigation path very large. It may cause the ROS buffer to overflow and thus result in the navigation path not being sent successfully. Using a down sampling strategy can effectively solve this problem.
Instructions:
1. Do not use downsampling
```
  bash /apollo/scripts/navigator.sh left.smoothed right.smoothed --navigator_down_sample=0
```
2. Use downsampling
```
  bash /apollo/scripts/navigator.sh left.smoothed right.smoothed --navigator_down_sample=1
```
or
```
  bash /apollo/scripts/navigator.sh left.smoothed right.smoothed
```

![screenshot from 2018-07-27 15-53-56](https://user-images.githubusercontent.com/31435476/43309411-4f94c41a-91b7-11e8-9c4a-fa7a7d7956dd.png)