### PR TITLE
Docker: modify py27_conda.yml

### DIFF
--- a/docker/build/installers/py27_conda.yml
+++ b/docker/build/installers/py27_conda.yml
@@ -1,10 +1,13 @@
 name: py27
 dependencies:
-  - python=2.7.15
-
-  - protobuf
-  - python-gflags
-
+  - python=2.7
+  - numpy=1.8.2 # required by adu/ros-base
+  - h5py=2.3.0 # latest version compatible with numpy 1.8.2; can also use 2.5.0 with pip
   - pip:
+    - astropy==1.2.2 # anaconda says 0.4.1 is the latest version compatible with numpy 1.8.2, but not mature enough
     - glog
+    - grpcio==1.4.0
+    - grpcio-tools==1.4.0
+    - protobuf==3.4.0 # version 3.2.0 actually gives some parsing errors on the original protos
+    - python-gflags
 


### PR DESCRIPTION
Modify the Conda environment for python, which can be used to run rosbag-to-h5 extraction code in Apollo docker. @Capri2014 @xiaoxq @jinghaomiao 