### PR TITLE
planning: remove the most common unnecessary log.

### DIFF
--- a/modules/planning/tasks/st_graph/st_boundary_mapper.cc
+++ b/modules/planning/tasks/st_graph/st_boundary_mapper.cc
@@ -132,7 +132,7 @@ Status StBoundaryMapper::CreateStBoundary(PathDecision* path_decision) const {
         return Status(ErrorCode::PLANNING_ERROR,
                       "Fail to map overtake/yield decision");
       }
-    } else {
+    } else if (!decision.has_ignore()) {
       AWARN << "No mapping for decision: " << decision.DebugString();
     }
   }


### PR DESCRIPTION
FYI:  *top 5 most common logs in plannning*
 102128 st_boundary_mapper.cc:136] No mapping for decision: ignore {
  39561 dp_st_speed_optimizer.cc:163] Mapping obstacle for dp st speed optimizer failed.
  39560 em_planner.cc:462] Slowing down the car with polynomial.
  39560 em_planner.cc:194] Failed to run tasks[DpStSpeedOptimizer], Error message: Mapping obstacle for dp st speed optimizer failed.