### PR TITLE
[Localization] Fix bug in extract_ground_plane

### DIFF
--- a/modules/localization/msf/common/util/extract_ground_plane.h
+++ b/modules/localization/msf/common/util/extract_ground_plane.h
@@ -147,8 +147,10 @@ class FeatureXYPlane {
     pcl::copyPointCloud<PointT>(*cloud_new, inliers, *cloud_inlier);
     std::vector<int> outliers;
     unsigned int inlier_idx = 0;
+   
     for (unsigned int i = 0; i < cloud_new->points.size(); ++i) {
-      if (inlier_idx >= inliners.size() || static_cast<int>(i) < inliers[inlier_idx]) {
+      if (inlier_idx >= inliners.size() ||
+          static_cast<int>(i) < inliers[inlier_idx]) {
         outliers.push_back(i);
       } else {
         inlier_idx++;

--- a/modules/localization/msf/common/util/extract_ground_plane.h
+++ b/modules/localization/msf/common/util/extract_ground_plane.h
@@ -148,7 +148,7 @@ class FeatureXYPlane {
     std::vector<int> outliers;
     unsigned int inlier_idx = 0;
     for (unsigned int i = 0; i < cloud_new->points.size(); ++i) {
-      if (static_cast<int>(i) < inliers[inlier_idx]) {
+      if (inlier_idx >= inliners.size() || static_cast<int>(i) < inliers[inlier_idx]) {
         outliers.push_back(i);
       } else {
         inlier_idx++;


### PR DESCRIPTION
Since it haven't check whether inlier_idx is exceed the size of inliners .It will cause segmentation fault in some time.