### PR TITLE
All: Fix bug when testing USE_GPU flag in apollo.sh.

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -122,7 +122,7 @@ function generate_build_targets() {
 #=================================================
 
 function build() {
-  if ${USE_GPU} ; then
+  if [ "${USE_GPU}" = "1" ] ; then
     echo -e "${YELLOW}Running build under GPU mode. GPU is required to run the build.${NO_COLOR}"
   else
     echo -e "${YELLOW}Running build under CPU mode. No GPU is required to run the build.${NO_COLOR}"
@@ -755,6 +755,7 @@ function main() {
       ;;
     build)
       DEFINES="${DEFINES} --define USE_GPU=true --cxxopt=-DUSE_GPU"
+      USE_GPU="1"
       apollo_build_dbg $@
       ;;
     build_cpu)
@@ -786,10 +787,12 @@ function main() {
       ;;
     build_gpu)
       DEFINES="${DEFINES} --define USE_GPU=true --cxxopt=-DUSE_GPU"
+      USE_GPU="1"
       apollo_build_dbg $@
       ;;
     build_opt_gpu)
       DEFINES="${DEFINES} --define USE_GPU=true --cxxopt=-DUSE_GPU"
+      USE_GPU="1"
       apollo_build_opt $@
       ;;
     build_fe)


### PR DESCRIPTION
apollo.sh build told wrong message, even with build_cpu option,
the script always tell: "Running build under GPU mode". This patch
fixed this problem and added USE_GPU="1" for all options where
have --define USE_GPU=true set in the build command.