### PR TITLE
guardian:set steering rate to 25% in safety mode

### DIFF
--- a/modules/guardian/guardian.cc
+++ b/modules/guardian/guardian.cc
@@ -126,7 +126,7 @@ void Guardian::TriggerSafetyMode() {
 
   guardian_cmd_.mutable_control_command()->set_throttle(0.0);
   guardian_cmd_.mutable_control_command()->set_steering_target(0.0);
-  guardian_cmd_.mutable_control_command()->set_steering_rate(0.0);
+  guardian_cmd_.mutable_control_command()->set_steering_rate(25.0);
   guardian_cmd_.mutable_control_command()->set_is_in_safe_mode(true);
 
   // TODO(QiL) : Remove this one once hardware re-alignment is done.


### PR DESCRIPTION
It is reasonable to make the steering angle to zero in a low steering speed.