### PR TITLE
diagnostics.py: s/xrange/range/ and s/ == Ture/ is True/

### DIFF
--- a/docs/specs/apollo_secure_upgrade_user_guide-CN.md
+++ b/docs/specs/apollo_secure_upgrade_user_guide-CN.md
@@ -55,6 +55,10 @@ SDK包含4个目录：
 init_secure_upgrade(root_config_path)
 input para:
   root_config_path  root configuration file path
+Output para:
+  return code:
+     true    security environment is initialized successfully
+     false    security environment is initialized failed
 ```
 
 #### b) 设备token生成

--- a/modules/tools/diagnostics/diagnostics.py
+++ b/modules/tools/diagnostics/diagnostics.py
@@ -77,7 +77,7 @@ class Diagnostics(object):
                 self.stdscr.addstr(0, 70, "Min", curses.A_BOLD)
                 self.stdscr.addstr(0, 80, "Delay", curses.A_BOLD)
 
-                for idx in xrange(len(self.messages)):
+                for idx in range(len(self.messages)):
                     lidx = idx + 1
                     if idx == self.selection:
                         self.stdscr.addstr(lidx, 0, self.messages[idx].name,
@@ -87,7 +87,7 @@ class Diagnostics(object):
                     self.stdscr.addstr(
                         lidx, 15, self.messages[idx].topic,
                         curses.color_pair(2 if self.messages[idx]
-                                          .msg_received == True else 1))
+                                          .msg_received is True else 1))
 
                     self.stdscr.addstr(
                         lidx, 50,


### PR DESCRIPTION
The former is equal to range in Python3.x, if we need performance and reduce memory footprint, using six.moves instead.  However, range() is ok in this case.
