### PR TITLE
Replaced the file "planning.cc" by "planning.h" in the planner docume…

### DIFF
--- a/docs/specs/Class_Architecture_Planning.md
+++ b/docs/specs/Class_Architecture_Planning.md
@@ -51,7 +51,7 @@ In addition to the query concepts “where I want to go” and “what is surrou
 
 ## Code Structure and Class Hierarchy
 
-The code is organized as follows: The planning code entrance is the `planning.cc`. Inside the planner, the important class members are shown in the illustration below.
+The code is organized as follows: The planning code entrance is the `planning.h`. Inside the planner, the important class members are shown in the illustration below.
 
 ![img](https://github.com/ApolloAuto/apollo/blob/master/docs/specs/images/class_architecture_planning/image006.png)
 


### PR DESCRIPTION
…ntation

Replaced since "planning.cc" does not exists. Documentation should refer to "planning.h" instead.