### PR TITLE
Planning: fix thread pool crash in navi planner

### DIFF
--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -56,6 +56,7 @@ NaviPlanning::~NaviPlanning() { Stop(); }
 std::string NaviPlanning::Name() const { return "navi_planning"; }
 
 Status NaviPlanning::Init() {
+  common::util::ThreadPool::Init(FLAGS_max_planning_thread_pool_size);
   CHECK(apollo::common::util::GetProtoFromFile(FLAGS_planning_config_file,
                                                &config_))
       << "failed to load planning config file " << FLAGS_planning_config_file;

--- a/modules/planning/navi_planning.h
+++ b/modules/planning/navi_planning.h
@@ -24,6 +24,7 @@
 
 #include "modules/planning/proto/pad_msg.pb.h"
 
+#include "modules/common/util/thread_pool.h"
 #include "modules/planning/common/frame.h"
 #include "modules/planning/planner/navi_planner_dispatcher.h"
 #include "modules/planning/planner/planner_dispatcher.h"


### PR DESCRIPTION
This PR is for fixing a crash when launching a navigation planner. Currently, the navi planner does not initialize thread pool. This PR fixes this crash. Please check the log message and call stack below:

```
F1018 14:26:15.044888 24254 thread_pool.cc:36] Check failed: 'instance()->pool_.get()' Must be non NULL 
*** Check failure stack trace: ***
    @     0x7ffff12d9ec0  google::LogMessage::Fail()
    @     0x7ffff12d9e07  google::LogMessage::SendToLog()
    @     0x7ffff12d97de  google::LogMessage::Flush()
    @     0x7ffff12dc83b  google::LogMessageFatal::~LogMessageFatal()
    @           0x5f132a  google::CheckNotNull<>()
    @           0x5ef952  apollo::common::util::ThreadPool::pool()
    @           0x4bd590  apollo::planning::DpRoadGraph::GenerateMinCostPath()
    @           0x4bcb07  apollo::planning::DpRoadGraph::FindPathTunnel()
    @           0x4bbcd1  apollo::planning::DpPolyPathOptimizer::Process()
    @           0x4ed497  apollo::planning::PathOptimizer::Execute()
    @           0x4949fa  apollo::planning::LaneFollowScenario::PlanOnReferenceLine()
    @           0x49443b  apollo::planning::LaneFollowScenario::Process()
    @           0x45edc0  apollo::planning::EMPlanner::Plan()
    @           0x434a60  apollo::planning::NaviPlanning::Plan()
    @           0x433acb  apollo::planning::NaviPlanning::RunOnce()
    @           0x431105  apollo::planning::NaviPlanning::OnTimer()
    @           0x44c8fe  boost::_mfi::mf1<>::operator()()
    @           0x44c286  boost::_bi::list2<>::operator()<>()
    @           0x44b98e  boost::_bi::bind_t<>::operator()<>()
    @           0x44aef8  boost::detail::function::void_function_obj_invoker1<>::invoke()
    @     0x7ffff5ae2780  ros::TimerManager<>::TimerQueueCallback::call()
    @     0x7ffff5affad6  ros::CallbackQueue::callOneCB()
    @     0x7ffff5b002a3  ros::CallbackQueue::callAvailable()
    @     0x7ffff5b4ae35  ros::SingleThreadedSpinner::spin()
    @     0x7ffff5b2f7db  ros::spin()
    @           0x459da9  apollo::common::ApolloApp::Spin()
    @           0x429e35  main
    @     0x7ffff00a7f45  __libc_start_main
    @           0x429c3f  (unknown)

Program received signal SIGABRT, Aborted.
0x00007ffff00bcc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
```

```
#0  0x00007ffff00bcc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff00c0028 in __GI_abort () at abort.c:89
#2  0x00007ffff12e2284 in google::DumpStackTraceAndExit() () from /usr/local/lib/libglog.so.0
#3  0x00007ffff12d9ec0 in google::LogMessage::Fail() () from /usr/local/lib/libglog.so.0
#4  0x00007ffff12d9e07 in google::LogMessage::SendToLog() () from /usr/local/lib/libglog.so.0
#5  0x00007ffff12d97de in google::LogMessage::Flush() () from /usr/local/lib/libglog.so.0
#6  0x00007ffff12dc83b in google::LogMessageFatal::~LogMessageFatal() () from /usr/local/lib/libglog.so.0
#7  0x00000000005f132a in google::CheckNotNull<ctpl::thread_pool*>(char const*, int, char const*, ctpl::thread_pool*&&) (
    file=0xfd5b80 "modules/common/util/thread_pool.cc", line=36, names=0xfd5b50 "'instance()->pool_.get()' Must be non NULL", 
    t=<unknown type in /home/david/.cache/bazel/_bazel_david/540135163923dd7d5820f3ee4b306b32/execroot/apollo/bazel-out/local-dbg/bin/modules/planning/planning, CU 0x39bc5d6, DIE 0x39d2dbb>) at /usr/local/include/glog/logging.h:1334
#8  0x00000000005ef952 in apollo::common::util::ThreadPool::pool () at modules/common/util/thread_pool.cc:36
#9  0x00000000004bd590 in apollo::planning::DpRoadGraph::GenerateMinCostPath (this=0x7fffffffcc20, 
    obstacles=std::vector of length 0, capacity 0, min_cost_path=0x7fffffffcb30)
    at modules/planning/toolkits/optimizers/road_graph/dp_road_graph.cc:167
#10 0x00000000004bcb07 in apollo::planning::DpRoadGraph::FindPathTunnel (this=0x7fffffffcc20, init_point=..., 
    obstacles=std::vector of length 0, capacity 0, path_data=0x34de9b8)
    at modules/planning/toolkits/optimizers/road_graph/dp_road_graph.cc:85
#11 0x00000000004bbcd1 in apollo::planning::DpPolyPathOptimizer::Process (this=0x34815f0, speed_data=..., init_point=..., 
    path_data=0x34de9b8) at modules/planning/toolkits/optimizers/dp_poly_path/dp_poly_path_optimizer.cc:65
#12 0x00000000004ed497 in apollo::planning::PathOptimizer::Execute (this=0x34815f0, frame=0x353c4f0, reference_line_info=0x34de500)
    at modules/planning/toolkits/optimizers/path_optimizer.cc:37
#13 0x00000000004949fa in apollo::planning::LaneFollowScenario::PlanOnReferenceLine (this=0x1e4daa0, planning_start_point=..., 
    frame=0x353c4f0, reference_line_info=0x34de500) at modules/planning/scenarios/lane_follow/lane_follow_scenario.cc:204
#14 0x000000000049443b in apollo::planning::LaneFollowScenario::Process (this=0x1e4daa0, planning_start_point=..., frame=0x353c4f0)
    at modules/planning/scenarios/lane_follow/lane_follow_scenario.cc:168
#15 0x000000000045edc0 in apollo::planning::EMPlanner::Plan (this=0x185cd40, planning_start_point=..., frame=0x353c4f0)
    at modules/planning/planner/em/em_planner.cc:36
#16 0x0000000000434a60 in apollo::planning::NaviPlanning::Plan (this=0x183c5f0, current_time_stamp=1539897974.9430959, 
    stitching_trajectory=std::vector of length 1, capacity 1 = {...}, trajectory_pb=0x353c7d0) at modules/planning/navi_planning.cc:531
#17 0x0000000000433acb in apollo::planning::NaviPlanning::RunOnce (this=0x183c5f0) at modules/planning/navi_planning.cc:450
#18 0x0000000000431105 in apollo::planning::NaviPlanning::OnTimer (this=0x183c5f0) at modules/planning/navi_planning.cc:118
#19 0x000000000044c8fe in boost::_mfi::mf1<void, apollo::planning::NaviPlanning, ros::TimerEvent const&>::operator() (this=0x1e4e6e8, 
    p=0x183c5f0, a1=...) at /usr/include/boost/bind/mem_fn_template.hpp:165
#20 0x000000000044c286 in boost::_bi::list2<boost::_bi::value<apollo::planning::NaviPlanning*>, boost::arg<1> >::operator()<boost::_mfi::mf1<void, apollo::planning::NaviPlanning, ros::TimerEvent const&>, boost::_bi::list1<ros::TimerEvent const&> > (this=0x1e4e6f8, f=..., a=...)
    at /usr/include/boost/bind/bind.hpp:313
#21 0x000000000044b98e in boost::_bi::bind_t<void, boost::_mfi::mf1<void, apollo::planning::NaviPlanning, ros::TimerEvent const&>, boost::_bi::list2<boost::_bi::value<apollo::planning::NaviPlanning*>, boost::arg<1> > >::operator()<ros::TimerEvent> (this=0x1e4e6e8, a1=...)
    at /usr/include/boost/bind/bind_template.hpp:47
#22 0x000000000044aef8 in boost::detail::function::void_function_obj_invoker1<boost::_bi::bind_t<void, boost::_mfi::mf1<void, apollo::planning::NaviPlanning, ros::TimerEvent const&>, boost::_bi::list2<boost::_bi::value<apollo::planning::NaviPlanning*>, boost::arg<1> > >, void, ros::TimerEvent const&>::invoke (function_obj_ptr=..., a0=...) at /usr/include/boost/function/function_template.hpp:153
#23 0x00007ffff5ae2780 in operator() (a0=..., this=<optimized out>) at /usr/include/boost/function/function_template.hpp:767
#24 ros::TimerManager<ros::Time, ros::Duration, ros::TimerEvent>::TimerQueueCallback::call (this=0x7fff800008e0)
    at /apollo/apollo-platform/ros/ros_comm/roscpp/include/ros/timer_manager.h:184
#25 0x00007ffff5affad6 in ros::CallbackQueue::callOneCB (this=this@entry=0x18578e0, tls=tls@entry=0x1e65600)
    at /apollo/apollo-platform/ros/ros_comm/roscpp/src/libros/callback_queue.cpp:393
#26 0x00007ffff5b002a3 in ros::CallbackQueue::callAvailable (this=this@entry=0x18578e0, timeout=...)
    at /apollo/apollo-platform/ros/ros_comm/roscpp/src/libros/callback_queue.cpp:334
#27 0x00007ffff5b4ae35 in ros::SingleThreadedSpinner::spin (this=<optimized out>, queue=0x18578e0)
    at /apollo/apollo-platform/ros/ros_comm/roscpp/src/libros/spinner.cpp:62
#28 0x00007ffff5b2f7db in ros::spin () at /apollo/apollo-platform/ros/ros_comm/roscpp/src/libros/init.cpp:567
#29 0x0000000000459da9 in apollo::common::ApolloApp::Spin (this=0x7fffffffde20) at modules/common/apollo_app.cc:78
#30 0x0000000000429e35 in main (argc=1, argv=0x7fffffffdf58) at modules/planning/main.cc:20
```
