### PR TITLE
Localization: Fix typo in README.md

### DIFF
--- a/modules/localization/README.md
+++ b/modules/localization/README.md
@@ -12,7 +12,7 @@
   * GPS - The Global Positioning System.
   * IMU - Inertial Measurement Unit.
   * LiDAR - Light Detection And Ranging Sensor.
-  For more information, refer to [multi-sensor fusion localizaiton](https://github.com/ApolloAuto/apollo/tree/master/modules/localization/msf/README.md).
+  For more information, refer to [multi-sensor fusion localization](https://github.com/ApolloAuto/apollo/tree/master/modules/localization/msf/README.md).
 
 ## Output
   * An object instance defined by Protobuf message `LocalizationEstimate`, which can be found in file `localization/proto/localization.proto`.


### PR DESCRIPTION
Fix typo 'Localizaiton' to 'Localization'