### PR TITLE
Bug fixes in open-loop controller calibration tools

### DIFF
--- a/modules/tools/calibration/data_collector.py
+++ b/modules/tools/calibration/data_collector.py
@@ -157,11 +157,11 @@ class DataCollector(object):
                 self.case = 'd'
         elif self.case == 'd':
             if self.cmd[2] > 0:
-                self.controlcmd.throttle = self.cmd[0]
+                self.controlcmd.throttle = self.cmd[2]
                 self.controlcmd.brake = 0
             else:
                 self.controlcmd.throttle = 0
-                self.controlcmd.brake = -self.cmd[0]
+                self.controlcmd.brake = -self.cmd[2]
             if self.vehicle_speed == 0:
                 self.in_session = False
 

--- a/modules/tools/calibration/process.py
+++ b/modules/tools/calibration/process.py
@@ -48,16 +48,26 @@ def get_start_index(data):
     if np.all(data['vehicle_speed'] == 0):
         return 0
 
-    start_ind = np.where(data['brake_percentage'] == 40)[0][0]
+    start_ind = np.where(data['brake_percentage'] == 40)
 
-    ind = start_ind
-    while ind < len(data):
-        if data['brake_percentage'][
-                ind] == 40:  #or data['vehicle_speed'][ind] == 0.0:
-            ind = ind + 1
-        else:
-            break
-    return ind
+    if len(start_ind[0] > 0):
+        ind = start_ind[0][0]
+        while ind < len(data):
+            if data['brake_percentage'][ind] == 40:
+                ind += 1
+            else:
+                break
+        return ind
+    
+    else:
+        ind = 0
+        while ind < len(data):
+            if abs(data['vehicle_speed'][ind]) < 0.01:
+                ind += 1
+            else:
+                break
+        return ind
+
 
 
 def process(data):


### PR DESCRIPTION
This pull request addresses two issues in the calibration tools for the open-loop controller:

1. The data_collection.py script did not properly send brake commands when three arguments were provided as input. This has been fixed in [bd39136](https://github.com/ApolloAuto/apollo/commit/bd39136a892b8fac3da287bb0e6a0b73f22c45dc).

2. The processing.py script finds the first usable index by searching for the last entry where the brake percentage is at (exactly) 40. This is only useful for a case where the stationary vehicle always keeps the brake at 40 percent. I've added an additional check for cases where a brake percentage of 40 is not present in the data. In these cases, the velocity of the vehicle will be used to find the index of the first entry to be used for calibration. This is addressed in [3890654](https://github.com/ApolloAuto/apollo/commit/3890654aff693429760c7f70308b486bfd43f653).