### PR TITLE
4 Fixes on the tools under modules/tools/prediction and modules/tools/configurator

### DIFF
--- a/modules/tools/configurator/configurator.py
+++ b/modules/tools/configurator/configurator.py
@@ -21,6 +21,8 @@ Tool to modify configuration files
 import curses
 import os
 import traceback
+import six
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from ModuleConf import ModuleConf
 

--- a/modules/tools/prediction/mlp_train/common/feature_io.py
+++ b/modules/tools/prediction/mlp_train/common/feature_io.py
@@ -33,6 +33,9 @@ def readVarint32(stream):
     """
     mask = 0x80  #(1 << 7)
     raw_varint32 = []
+    # In Python 3.x, the 'True' is becomes a keyword and a real contant.
+    # Hence, we can replace '1' with 'True' in an infinite loop without
+    # performance regression.
     while 1:
         b = stream.read(1)
         if b == "":
@@ -61,7 +64,7 @@ def load_label_feature(filename):
             read_bytes, _ = decoder._DecodeVarint32(size, 0)
             data = f.read(read_bytes)
             if len(data) < read_bytes:
-                print "Fail to load protobuf"
+                print("Failed to load protobuf.")
                 break
             fea = feature_pb2.Feature()
             fea.ParseFromString(data)
@@ -80,9 +83,6 @@ def save_protobuf(filename, feature_trajectories):
                 serializedMessage = fea.SerializeToString()
                 delimiter = encoder._VarintBytes(len(serializedMessage))
                 f.write(delimiter + serializedMessage)
-
-    f.close()
-
 
 def build_trajectory(features):
     """

--- a/modules/tools/prediction/multiple_gpu_estimator/counting.py
+++ b/modules/tools/prediction/multiple_gpu_estimator/counting.py
@@ -1,5 +1,20 @@
+###############################################################################
+# Modification Copyright 2018 The Apollo Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
 import numpy as np
-import os
 from collections import Counter
 from glob import glob
 
@@ -9,7 +24,8 @@ filenames = glob('/tmp/data/feature_v1_bin/*/*.label.bin')
 for filename in filenames:
     bin_data = np.fromfile(filename, dtype=np.float32)
     if bin_data.shape[0] % (feature_dim + 1) != 0:
-        raise ValueError('data size (%d) must be multiple of feature_dim + 1 (%d).' %(bin_data.shape[0], feature_dim + 1))
+        raise ValueError('data size (%d) must be multiple of feature_dim + 1 (%d).'
+                        % (bin_data.shape[0], feature_dim + 1))
     label = bin_data[feature_dim::(feature_dim+1)].astype(np.int32)
     count.update(label)
 

--- a/modules/tools/prediction/multiple_gpu_estimator/mlp_utils.py
+++ b/modules/tools/prediction/multiple_gpu_estimator/mlp_utils.py
@@ -149,7 +149,7 @@ def local_device_setter(num_devices=1,
                         worker_device='/cpu:0',
                         ps_ops=None,
                         ps_strategy=None):
-    if ps_ops == None:
+    if ps_ops is None:
         ps_ops = ['Variable', 'VariableV2', 'VarHandleOp']
 
     if ps_strategy is None:


### PR DESCRIPTION
1. modules/tools/configurator/configurator.py: use xrange from six to keep the compatible between Python2.x/3.x
2. modules/tools/prediction/multiple_gpu_estimator/counting.py: os module is unused, don't need to import.
3. modules/tools/prediction/multiple_gpu_estimator/mlp_utils.py: s/== None/is None/
4. modules/tools/prediction/mlp_train/common/feature_io.py: remove close() operation since we use with statement for file IO.