### PR TITLE
Perception: fixed bug in Yuyv2rgb conversion for AVX non-compliant CPUs.

### DIFF
--- a/modules/perception/traffic_light/util/color_space.cc
+++ b/modules/perception/traffic_light/util/color_space.cc
@@ -168,10 +168,10 @@ void YUV2RGB(const unsigned char y, const unsigned char u,
 
 void Yuyv2rgb(unsigned char* YUV, unsigned char* RGB, int NumPixels) {
   for (int i = 0, int j = 0; i < (NumPixels << 1); i += 4, j += 6) {
-    unsigned char u = (unsigned char)YUV[i + 0];
-    unsigned char y0 = (unsigned char)YUV[i + 1];
-    unsigned char v = (unsigned char)YUV[i + 2];
-    unsigned char y1 = (unsigned char)YUV[i + 3];
+    unsigned char y0 = (unsigned char)YUV[i + 0];
+    unsigned char u = (unsigned char)YUV[i + 1];
+    unsigned char y1 = (unsigned char)YUV[i + 2];
+    unsigned char v = (unsigned char)YUV[i + 3];
     unsigned char r, g, b;
     YUV2RGB(y0, u, v, &r, &g, &b);
     RGB[j + 0] = r;


### PR DESCRIPTION
The function Yuyv2rgb has two definitions; one uses AVX instructions and the other does not. This commit fixes a bug in the latter function definition. The ordering of the color channels in the input image were incorrect which would result in an incorrect conversion to rgb which subsequently affects the perception results. The bug has been fixed by correcting the channel order the function expects.
(I copy this from your master branch.)