### PR TITLE
Perception: fix endless loop in cc_lane_post_processor

### DIFF
--- a/modules/perception/obstacle/camera/lane_post_process/cc_lane_post_processor/cc_lane_post_processor.cc
+++ b/modules/perception/obstacle/camera/lane_post_process/cc_lane_post_processor/cc_lane_post_processor.cc
@@ -579,7 +579,10 @@ bool CCLanePostProcessor::ProcessWithoutCC(
           Eigen::Matrix<double, 3, 1> xy_p = trans_mat_ * img_point;
           Eigen::Matrix<double, 2, 1> xy_point;
           Eigen::Matrix<double, 2, 1> uv_point;
-          if (std::abs(xy_p(2)) < 1e-6) continue;
+          if (std::abs(xy_p(2)) < 1e-6) {
+            ++x;
+            continue;
+          }
           xy_point << xy_p(0) / xy_p(2), xy_p(1) / xy_p(2);
           if (xy_point(0) < 0 || xy_point(0) > 300 || abs(xy_point(1)) > 30) {
             ++x;


### PR DESCRIPTION
This pull request is to fix the possible endless loop in cc_lane_post_processor.cc. In the original code, if `xy_p(2)` is less than `1e-6`, `x` and `y` are not changed. Then it will enter an infinite loop. 