### PR TITLE
CHECK_NOTNULL to CHECK

### DIFF
--- a/modules/common/math/line_segment2d.cc
+++ b/modules/common/math/line_segment2d.cc
@@ -74,7 +74,7 @@ double LineSegment2d::DistanceTo(const Vec2d &point) const {
 
 double LineSegment2d::DistanceTo(const Vec2d &point,
                                  Vec2d *const nearest_pt) const {
-  CHECK_NOTNULL(nearest_pt);
+  CHECK(nearest_pt);
   if (length_ <= kMathEpsilon) {
     *nearest_pt = start_;
     return point.DistanceTo(start_);
@@ -112,7 +112,7 @@ double LineSegment2d::DistanceSquareTo(const Vec2d &point) const {
 
 double LineSegment2d::DistanceSquareTo(const Vec2d &point,
                                        Vec2d *const nearest_pt) const {
-  CHECK_NOTNULL(nearest_pt);
+  CHECK(nearest_pt);
   if (length_ <= kMathEpsilon) {
     *nearest_pt = start_;
     return point.DistanceSquareTo(start_);
@@ -160,7 +160,7 @@ bool LineSegment2d::HasIntersect(const LineSegment2d &other_segment) const {
 
 bool LineSegment2d::GetIntersect(const LineSegment2d &other_segment,
                                  Vec2d *const point) const {
-  CHECK_NOTNULL(point);
+  CHECK(point);
   if (IsPointIn(other_segment.start())) {
     *point = other_segment.start();
     return true;
@@ -201,7 +201,7 @@ bool LineSegment2d::GetIntersect(const LineSegment2d &other_segment,
 // return distance with perpendicular foot point.
 double LineSegment2d::GetPerpendicularFoot(const Vec2d &point,
                                            Vec2d *const foot_point) const {
-  CHECK_NOTNULL(foot_point);
+  CHECK(foot_point);
   if (length_ <= kMathEpsilon) {
     *foot_point = start_;
     return point.DistanceTo(start_);

--- a/modules/common/math/math_utils.cc
+++ b/modules/common/math/math_utils.cc
@@ -86,8 +86,8 @@ double Sigmoid(const double x) { return 1.0 / (1.0 + std::exp(-x)); }
 
 void RotateAxis(const double theta, const double x0, const double y0,
                 double* x1, double* y1) {
-  CHECK_NOTNULL(x1);
-  CHECK_NOTNULL(y1);
+  CHECK(x1);
+  CHECK(y1);
 
   const double cos_theta = std::cos(theta);
   const double sin_theta = std::sin(theta);

--- a/modules/common/math/polygon2d.cc
+++ b/modules/common/math/polygon2d.cc
@@ -239,7 +239,7 @@ void Polygon2d::BuildFromPoints() {
 
 bool Polygon2d::ComputeConvexHull(const std::vector<Vec2d> &points,
                                   Polygon2d *const polygon) {
-  CHECK_NOTNULL(polygon);
+  CHECK(polygon);
   const int n = points.size();
   if (n < 3) {
     return false;
@@ -295,7 +295,7 @@ bool Polygon2d::ClipConvexHull(const LineSegment2d &line_segment,
   if (line_segment.length() <= kMathEpsilon) {
     return true;
   }
-  CHECK_NOTNULL(points);
+  CHECK(points);
   const int n = points->size();
   if (n < 3) {
     return false;
@@ -332,7 +332,7 @@ bool Polygon2d::ClipConvexHull(const LineSegment2d &line_segment,
 bool Polygon2d::ComputeOverlap(const Polygon2d &other_polygon,
                                Polygon2d *const overlap_polygon) const {
   CHECK_GE(points_.size(), 3);
-  CHECK_NOTNULL(overlap_polygon);
+  CHECK(overlap_polygon);
   CHECK(is_convex_ && other_polygon.is_convex());
   std::vector<Vec2d> points = other_polygon.points();
   for (int i = 0; i < num_points_; ++i) {
@@ -359,8 +359,8 @@ bool Polygon2d::HasOverlap(const LineSegment2d &line_segment) const {
 bool Polygon2d::GetOverlap(const LineSegment2d &line_segment,
                            Vec2d *const first, Vec2d *const last) const {
   CHECK_GE(points_.size(), 3);
-  CHECK_NOTNULL(first);
-  CHECK_NOTNULL(last);
+  CHECK(first);
+  CHECK(last);
 
   if (line_segment.length() <= kMathEpsilon) {
     if (!IsPointIn(line_segment.start())) {
@@ -466,8 +466,8 @@ std::vector<LineSegment2d> Polygon2d::GetAllOverlaps(
 void Polygon2d::ExtremePoints(const double heading, Vec2d *const first,
                               Vec2d *const last) const {
   CHECK_GE(points_.size(), 3);
-  CHECK_NOTNULL(first);
-  CHECK_NOTNULL(last);
+  CHECK(first);
+  CHECK(last);
 
   const Vec2d direction_vec = Vec2d::CreateUnitVec2d(heading);
   double min_proj = std::numeric_limits<double>::infinity();

--- a/modules/dreamview/backend/handlers/websocket_handler_test.cc
+++ b/modules/dreamview/backend/handlers/websocket_handler_test.cc
@@ -32,7 +32,7 @@ class MockClient {
     conn = mg_connect_websocket_client(host, port, 0, error_buffer, 100,
                                        "/websocket", "", &MockClient::OnMessage,
                                        nullptr, nullptr);
-    CHECK_NOTNULL(conn);
+    CHECK(conn);
   }
 
   const std::vector<std::string> &GetReceivedMessages() {

--- a/modules/drivers/canbus/can_client/esd/esd_can_client.cc
+++ b/modules/drivers/canbus/can_client/esd/esd_can_client.cc
@@ -116,7 +116,7 @@ void EsdCanClient::Stop() {
 // Synchronous transmission of CAN messages
 ErrorCode EsdCanClient::Send(const std::vector<CanFrame> &frames,
                              int32_t *const frame_num) {
-  CHECK_NOTNULL(frame_num);
+  CHECK(frame_num);
   CHECK_EQ(frames.size(), static_cast<size_t>(*frame_num));
 
   if (!is_started_) {

--- a/modules/drivers/canbus/can_client/hermes_can/hermes_can_client.cc
+++ b/modules/drivers/canbus/can_client/hermes_can/hermes_can_client.cc
@@ -110,7 +110,7 @@ apollo::common::ErrorCode HermesCanClient::Send(
       uint64_t bcan_msg_timestamp; // TBD
   } bcan_msg_t;
   */
-  CHECK_NOTNULL(frame_num);
+  CHECK(frame_num);
   CHECK_EQ(frames.size(), static_cast<size_t>(*frame_num));
 
   if (!_is_init) {

--- a/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
+++ b/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
@@ -133,7 +133,7 @@ void SocketCanClientRaw::Stop() {
 // Synchronous transmission of CAN messages
 ErrorCode SocketCanClientRaw::Send(const std::vector<CanFrame> &frames,
                                    int32_t *const frame_num) {
-  CHECK_NOTNULL(frame_num);
+  CHECK(frame_num);
   CHECK_EQ(frames.size(), static_cast<size_t>(*frame_num));
 
   if (!is_started_) {

--- a/modules/drivers/canbus/can_comm/can_receiver.h
+++ b/modules/drivers/canbus/can_comm/can_receiver.h
@@ -130,8 +130,8 @@ template <typename SensorType>
 template <typename SensorType>
 void CanReceiver<SensorType>::RecvThreadFunc() {
   AINFO << "Can client receiver thread starts.";
-  CHECK_NOTNULL(can_client_);
-  CHECK_NOTNULL(pt_manager_);
+  CHECK(can_client_);
+  CHECK(pt_manager_);
 
   int32_t receive_error_count = 0;
   int32_t receive_none_count = 0;

--- a/modules/drivers/canbus/can_comm/can_sender.h
+++ b/modules/drivers/canbus/can_comm/can_sender.h
@@ -271,7 +271,7 @@ int32_t SenderMessage<SensorType>::curr_period() const {
 
 template <typename SensorType>
 void CanSender<SensorType>::PowerSendThreadFunc() {
-  CHECK_NOTNULL(can_client_);
+  CHECK(can_client_);
   sched_param sch;
   sch.sched_priority = 99;
   pthread_setschedparam(pthread_self(), SCHED_FIFO, &sch);

--- a/modules/drivers/gnss/stream/raw_stream.cc
+++ b/modules/drivers/gnss/stream/raw_stream.cc
@@ -145,8 +145,8 @@ RawStream::~RawStream() {
 }
 
 bool RawStream::Init() {
-  CHECK_NOTNULL(data_parser_ptr_);
-  CHECK_NOTNULL(rtcm_parser_ptr_);
+  CHECK(data_parser_ptr_);
+  CHECK(rtcm_parser_ptr_);
   if (!data_parser_ptr_->Init()) {
     AERROR << "Init data parser failed.";
     return false;
@@ -498,7 +498,7 @@ void RawStream::RtkSpin() {
 
 void RawStream::PublishRtkData(size_t length) {
   std_msgs::StringPtr rtkmsg(new std_msgs::String);
-  CHECK_NOTNULL(rtkmsg);
+  CHECK(rtkmsg);
   rtkmsg->data.assign(reinterpret_cast<const char *>(buffer_rtk_), length);
   AdapterManager::PublishRtcmData(*rtkmsg);
   rtcm_parser_ptr_->ParseRtcmData(rtkmsg);

--- a/modules/drivers/lidar_velodyne/pointcloud/rawdata.cc
+++ b/modules/drivers/lidar_velodyne/pointcloud/rawdata.cc
@@ -180,10 +180,10 @@ void RawData::unpack(const velodyne_msgs::VelodynePacket &pkt,
 void RawData::compute_xyzi(const uint8_t chan_id, const uint16_t azimuth_uint,
                            const float distance, float *intensity,
                            float *x_coord, float *y_coord, float *z_coord) {
-  CHECK_NOTNULL(intensity);
-  CHECK_NOTNULL(x_coord);
-  CHECK_NOTNULL(y_coord);
-  CHECK_NOTNULL(z_coord);
+  CHECK(intensity);
+  CHECK(x_coord);
+  CHECK(y_coord);
+  CHECK(z_coord);
 
   float x, y, z;
   LaserCorrection &corrections = calibration_.laser_corrections[chan_id];

--- a/modules/drivers/lidar_velodyne/pointcloud/transform.cc
+++ b/modules/drivers/lidar_velodyne/pointcloud/transform.cc
@@ -65,7 +65,7 @@ Transform::Transform(ros::NodeHandle node, ros::NodeHandle private_nh)
 }
 
 void Transform::reconfigure_callback(TransformNodeConf *config) {
-  CHECK_NOTNULL(config);
+  CHECK(config);
   ROS_INFO_STREAM("Reconfigure request.");
   data_->setParameters(config->min_range(), config->max_range(),
                        config->view_direction(), config->view_width());

--- a/modules/localization/lmd/common/pose_list.cc
+++ b/modules/localization/lmd/common/pose_list.cc
@@ -78,7 +78,7 @@ T InterpolateQuaternion(const T &p1, const T &p2, double frac1) {
 }  // namespace
 
 bool PoseList::FindMatchingPose(double timestamp_sec, Pose *pose) const {
-  CHECK_NOTNULL(pose);
+  CHECK(pose);
 
   auto p = RangeOf(timestamp_sec);
   if (p.first == end() || p.second == end()) {
@@ -91,7 +91,7 @@ bool PoseList::FindMatchingPose(double timestamp_sec, Pose *pose) const {
 }
 
 bool PoseList::FindNearestPose(double timestamp_sec, Pose *pose) const {
-  CHECK_NOTNULL(pose);
+  CHECK(pose);
 
   if (!FindMatchingPose(timestamp_sec, pose)) {
     auto it = Nearest(timestamp_sec);
@@ -109,7 +109,7 @@ void PoseList::InterpolatePose(double timestamp_sec1, const Pose &pose1,
                                double timestamp_sec, Pose *pose) {
   CHECK_GE(timestamp_sec, timestamp_sec1);
   CHECK_GE(timestamp_sec2, timestamp_sec);
-  CHECK_NOTNULL(pose);
+  CHECK(pose);
 
   auto time_diff = timestamp_sec2 - timestamp_sec1;
   if (fabs(time_diff) > 0.0) {

--- a/modules/localization/msf/common/util/frame_transform.cc
+++ b/modules/localization/msf/common/util/frame_transform.cc
@@ -173,7 +173,7 @@ double FootpointLatitude(const double y) {
  */
 void MaplatlonToXY(const double phi, const double lambda, double lambda0,
                    UTMCoor *xy) {
-  CHECK_NOTNULL(xy);
+  CHECK(xy);
 
   /* Precalculate ep2 */
   double ep2 = (pow(kSmA, 2.0) - pow(kSmB, 2.0)) / pow(kSmB, 2.0);
@@ -256,7 +256,7 @@ void MaplatlonToXY(const double phi, const double lambda, double lambda0,
  */
 void MapXYToLatlon(const double x, const double y, const double lambda0,
                    WGS84Corr *philambda) {
-  CHECK_NOTNULL(philambda);
+  CHECK(philambda);
 
   /* Get the value of phif, the footpoint latitude. */
   double phif = FootpointLatitude(y);
@@ -355,7 +355,7 @@ void MapXYToLatlon(const double x, const double y, const double lambda0,
  *
  */
 void LatlonToUtmXY(const double lon_rad, const double lat_rad, UTMCoor *xy) {
-  CHECK_NOTNULL(xy);
+  CHECK(xy);
 
   int zone = 0;
   zone = static_cast<int>((lon_rad * kSinsRadToDeg + 180) / 6) + 1;
@@ -394,7 +394,7 @@ void LatlonToUtmXY(const double lon_rad, const double lat_rad, UTMCoor *xy) {
  */
 void UtmXYToLatlon(const double x, const double y, const int zone,
                    const bool southhemi, WGS84Corr *latlon) {
-  CHECK_NOTNULL(latlon);
+  CHECK(latlon);
 
   double xx = x;
   xx -= 500000.0;
@@ -413,7 +413,7 @@ void UtmXYToLatlon(const double x, const double y, const int zone,
 }
 
 void XYZToBlh(const Eigen::Vector3d &xyz, Eigen::Vector3d *blh) {
-  CHECK_NOTNULL(blh);
+  CHECK(blh);
 
   //    double e2=FE_WGS84*(2.0-FE_WGS84);
   double r2 = xyz[0] * xyz[0] + xyz[1] * xyz[1];
@@ -435,7 +435,7 @@ void XYZToBlh(const Eigen::Vector3d &xyz, Eigen::Vector3d *blh) {
 }
 
 void BlhToXYZ(const Eigen::Vector3d &blh, Eigen::Vector3d *xyz) {
-  CHECK_NOTNULL(xyz);
+  CHECK(xyz);
 
   double sin_lati_2 = sin(blh[1]) * sin(blh[1]);
   double temp_a = sqrt(1.0 - kSinsE2 * sin_lati_2);

--- a/modules/localization/msf/local_integ/gnss_msg_transfer.cc
+++ b/modules/localization/msf/local_integ/gnss_msg_transfer.cc
@@ -24,7 +24,7 @@ namespace msf {
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::BandObservation &in,
     BandObservationMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_band_id()) {
     out->set_band_id(GnssBandID(in.band_id()));
   }
@@ -55,7 +55,7 @@ void GnssMagTransfer::Transfer(
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::SatelliteObservation &in,
     SatelliteObservationMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_sat_prn()) {
     out->set_sat_prn(in.sat_prn());
   }
@@ -77,7 +77,7 @@ void GnssMagTransfer::Transfer(
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::EpochObservation &in,
     EpochObservationMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_receiver_id()) {
     out->set_receiver_id(in.receiver_id());
   }
@@ -116,7 +116,7 @@ void GnssMagTransfer::Transfer(
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::KepplerOrbit &in,
     KepplerOrbitMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_gnss_type()) {
     out->set_gnss_type(GnssType(in.gnss_type()));
   }
@@ -238,7 +238,7 @@ void GnssMagTransfer::Transfer(
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::GlonassOrbit &in,
     GlonassOrbitMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_gnss_type()) {
     out->set_gnss_type(GnssType(in.gnss_type()));
   }
@@ -327,7 +327,7 @@ void GnssMagTransfer::Transfer(
 void GnssMagTransfer::Transfer(
     const apollo::drivers::gnss::GnssEphemeris &in,
     GnssEphemerisMsg* out) {
-  CHECK_NOTNULL(out);
+  CHECK(out);
   if (in.has_gnss_type()) {
     out->set_gnss_type(GnssType(in.gnss_type()));
   }

--- a/modules/localization/msf/local_integ/lidar_msg_transfer.cc
+++ b/modules/localization/msf/local_integ/lidar_msg_transfer.cc
@@ -37,7 +37,7 @@ void LidarMsgTransfer::Transfer(
 
 void LidarMsgTransfer::TransferCloud(
     const sensor_msgs::PointCloud2 &lidar_data, LidarFrame *lidar_frame) {
-  CHECK_NOTNULL(lidar_frame);
+  CHECK(lidar_frame);
 
   ParseCloudField(lidar_data);
   // organized point cloud
@@ -111,7 +111,7 @@ void LidarMsgTransfer::ParseCloudField(
 
 void LidarMsgTransfer::TransferOrganizedCloud32(
     const sensor_msgs::PointCloud2 &lidar_data, LidarFrame *lidar_frame) {
-  CHECK_NOTNULL(lidar_frame);
+  CHECK(lidar_frame);
 
   for (uint32_t i = 0; i < lidar_data.height; ++i) {
     for (uint32_t j = 0; j < lidar_data.width; ++j) {
@@ -139,7 +139,7 @@ void LidarMsgTransfer::TransferOrganizedCloud32(
 
 void LidarMsgTransfer::TransferOrganizedCloud64(
     const sensor_msgs::PointCloud2 &lidar_data, LidarFrame *lidar_frame) {
-  CHECK_NOTNULL(lidar_frame);
+  CHECK(lidar_frame);
 
   for (uint32_t i = 0; i < lidar_data.height; ++i) {
     for (uint32_t j = 0; j < lidar_data.width; ++j) {
@@ -167,7 +167,7 @@ void LidarMsgTransfer::TransferOrganizedCloud64(
 
 void LidarMsgTransfer::TransferUnorganizedCloud32(
     const sensor_msgs::PointCloud2 &lidar_data, LidarFrame *lidar_frame) {
-  CHECK_NOTNULL(lidar_frame);
+  CHECK(lidar_frame);
 
   for (uint32_t i = 0; i < lidar_data.height; ++i) {
     for (uint32_t j = 0; j < lidar_data.width; ++j) {
@@ -195,7 +195,7 @@ void LidarMsgTransfer::TransferUnorganizedCloud32(
 
 void LidarMsgTransfer::TransferUnorganizedCloud64(
     const sensor_msgs::PointCloud2 &lidar_data, LidarFrame *lidar_frame) {
-  CHECK_NOTNULL(lidar_frame);
+  CHECK(lidar_frame);
 
   for (uint32_t i = 0; i < lidar_data.height; ++i) {
     for (uint32_t j = 0; j < lidar_data.width; ++j) {

--- a/modules/localization/msf/local_integ/localization_gnss_process.cc
+++ b/modules/localization/msf/local_integ/localization_gnss_process.cc
@@ -198,7 +198,7 @@ void LocalizationGnssProcess::IntegSinsPvaProcess(const InsPva &sins_pva_msg,
 
 LocalizationMeasureState LocalizationGnssProcess::GetResult(
     MeasureData *gnss_msg) {
-  CHECK_NOTNULL(gnss_msg);
+  CHECK(gnss_msg);
 
   // convert GnssPntResult to IntegMeasure
   // double sec_s = Clock::NowInSeconds(); // ros::Time::now().toSec();
@@ -305,7 +305,7 @@ inline void LocalizationGnssProcess::LogPnt(const GnssPntResultMsg &rover_pnt,
 }
 
 bool LocalizationGnssProcess::GnssPosition(EpochObservationMsg *raw_rover_obs) {
-  CHECK_NOTNULL(raw_rover_obs);
+  CHECK(raw_rover_obs);
 
   gnss_state_ = LocalizationMeasureState::NOT_VALID;
   if (raw_rover_obs->receiver_id() != 0) {

--- a/modules/localization/msf/local_integ/localization_integ.cc
+++ b/modules/localization/msf/local_integ/localization_integ.cc
@@ -127,7 +127,7 @@ void LocalizationInteg::GetGnssLocalizationList(
 
 void LocalizationInteg::TransferImuRfu(const drivers::gnss::Imu &imu_msg,
                                        ImuData *imu_rfu) {
-  CHECK_NOTNULL(imu_rfu);
+  CHECK(imu_rfu);
 
   double measurement_time = TimeUtil::Gps2unix(imu_msg.measurement_time());
   imu_rfu->measurement_time = measurement_time;
@@ -143,7 +143,7 @@ void LocalizationInteg::TransferImuRfu(const drivers::gnss::Imu &imu_msg,
 
 void LocalizationInteg::TransferImuFlu(const drivers::gnss::Imu &imu_msg,
                                        ImuData *imu_flu) {
-  CHECK_NOTNULL(imu_flu);
+  CHECK(imu_flu);
 
   double measurement_time = TimeUtil::Gps2unix(imu_msg.measurement_time());
   imu_flu->measurement_time = measurement_time;

--- a/modules/localization/msf/local_integ/localization_integ_impl.cc
+++ b/modules/localization/msf/local_integ/localization_integ_impl.cc
@@ -486,7 +486,7 @@ void LocalizationIntegImpl::GnssBestPoseProcessImpl(
 
 void LocalizationIntegImpl::TransferGnssMeasureToLocalization(
     const MeasureData& measure, LocalizationEstimate* localization) {
-  CHECK_NOTNULL(localization);
+  CHECK(localization);
 
   apollo::common::Header* headerpb = localization->mutable_header();
   apollo::localization::Pose* posepb = localization->mutable_pose();
@@ -535,8 +535,8 @@ void LocalizationIntegImpl::TransferGnssMeasureToLocalization(
 
 void LocalizationIntegImpl::GetLastestLidarLocalization(
     LocalizationMeasureState* state, LocalizationEstimate* lidar_localization) {
-  CHECK_NOTNULL(state);
-  CHECK_NOTNULL(lidar_localization);
+  CHECK(state);
+  CHECK(lidar_localization);
 
   lidar_localization_mutex_.lock();
   if (lidar_localization_list_.size()) {
@@ -552,8 +552,8 @@ void LocalizationIntegImpl::GetLastestLidarLocalization(
 
 void LocalizationIntegImpl::GetLastestIntegLocalization(
     LocalizationMeasureState* state, LocalizationEstimate* integ_localization) {
-  CHECK_NOTNULL(state);
-  CHECK_NOTNULL(integ_localization);
+  CHECK(state);
+  CHECK(integ_localization);
 
   integ_localization_mutex_.lock();
   if (integ_localization_list_.size()) {
@@ -569,8 +569,8 @@ void LocalizationIntegImpl::GetLastestIntegLocalization(
 
 void LocalizationIntegImpl::GetLastestGnssLocalization(
     LocalizationMeasureState* state, LocalizationEstimate* gnss_localization) {
-  CHECK_NOTNULL(state);
-  CHECK_NOTNULL(gnss_localization);
+  CHECK(state);
+  CHECK(gnss_localization);
 
   gnss_localization_mutex_.lock();
   if (gnss_localization_list_.size()) {
@@ -586,7 +586,7 @@ void LocalizationIntegImpl::GetLastestGnssLocalization(
 
 void LocalizationIntegImpl::GetLidarLocalizationList(
     std::list<LocalizationResult>* results) {
-  CHECK_NOTNULL(results);
+  CHECK(results);
 
   lidar_localization_mutex_.lock();
   *results = lidar_localization_list_;
@@ -596,7 +596,7 @@ void LocalizationIntegImpl::GetLidarLocalizationList(
 
 void LocalizationIntegImpl::GetIntegLocalizationList(
     std::list<LocalizationResult>* results) {
-  CHECK_NOTNULL(results);
+  CHECK(results);
 
   integ_localization_mutex_.lock();
   *results = integ_localization_list_;
@@ -606,7 +606,7 @@ void LocalizationIntegImpl::GetIntegLocalizationList(
 
 void LocalizationIntegImpl::GetGnssLocalizationList(
     std::list<LocalizationResult>* results) {
-  CHECK_NOTNULL(results);
+  CHECK(results);
 
   gnss_localization_mutex_.lock();
   *results = gnss_localization_list_;

--- a/modules/localization/msf/local_integ/localization_integ_process.cc
+++ b/modules/localization/msf/local_integ/localization_integ_process.cc
@@ -145,7 +145,7 @@ void LocalizationIntegProcess::GetValidFromOK() {
 }
 
 void LocalizationIntegProcess::GetState(IntegState *state) {
-  CHECK_NOTNULL(state);
+  CHECK(state);
 
   *state = integ_state_;
   return;
@@ -153,8 +153,8 @@ void LocalizationIntegProcess::GetState(IntegState *state) {
 
 void LocalizationIntegProcess::GetResult(IntegState *state,
                                          LocalizationEstimate *localization) {
-  CHECK_NOTNULL(state);
-  CHECK_NOTNULL(localization);
+  CHECK(state);
+  CHECK(localization);
 
   // state
   *state = integ_state_;
@@ -235,9 +235,9 @@ void LocalizationIntegProcess::GetResult(IntegState *state,
 
 void LocalizationIntegProcess::GetResult(IntegState *state, InsPva *sins_pva,
                                          double pva_covariance[9][9]) {
-  CHECK_NOTNULL(state);
-  CHECK_NOTNULL(sins_pva);
-  CHECK_NOTNULL(pva_covariance);
+  CHECK(state);
+  CHECK(sins_pva);
+  CHECK(pva_covariance);
 
   *state = integ_state_;
   *sins_pva = ins_pva_;
@@ -335,7 +335,7 @@ bool LocalizationIntegProcess::CheckIntegMeasureData(
 
 bool LocalizationIntegProcess::LoadGnssAntennaExtrinsic(
     const std::string &file_path, TransformD *extrinsic) const {
-  CHECK_NOTNULL(extrinsic);
+  CHECK(extrinsic);
 
   YAML::Node confige = YAML::LoadFile(file_path);
   if (confige["leverarm"]) {

--- a/modules/localization/msf/local_integ/localization_lidar.cc
+++ b/modules/localization/msf/local_integ/localization_lidar.cc
@@ -210,7 +210,7 @@ void LocalizationLidar::GetResult(Eigen::Affine3d *location,
 
 void LocalizationLidar::GetLocalizationDistribution(
     Eigen::MatrixXd *distribution) {
-  CHECK_NOTNULL(distribution);
+  CHECK(distribution);
 
   int width = 0;
   int height = 0;
@@ -229,7 +229,7 @@ void LocalizationLidar::GetLocalizationDistribution(
 }
 
 void LocalizationLidar::RefineAltitudeFromMap(Eigen::Affine3d *pose) {
-  CHECK_NOTNULL(pose);
+  CHECK(pose);
 
   Eigen::Affine3d lidar_pose = *pose * velodyne_extrinsic_;
   Eigen::Vector3d lidar_trans = lidar_pose.translation();

--- a/modules/localization/msf/local_integ/localization_lidar_process.cc
+++ b/modules/localization/msf/local_integ/localization_lidar_process.cc
@@ -204,9 +204,9 @@ void LocalizationLidarProcess::PcdProcess(const LidarFrame& lidar_frame) {
 void LocalizationLidarProcess::GetResult(int* lidar_status,
                                          TransformD* location,
                                          Matrix3D* covariance) const {
-  CHECK_NOTNULL(lidar_status);
-  CHECK_NOTNULL(location);
-  CHECK_NOTNULL(covariance);
+  CHECK(lidar_status);
+  CHECK(location);
+  CHECK(covariance);
 
   *lidar_status = static_cast<int>(lidar_status_);
   *location = location_;
@@ -269,8 +269,8 @@ void LocalizationLidarProcess::RawImuProcess(const ImuData& imu_msg) {
 bool LocalizationLidarProcess::GetPredictPose(const double lidar_time,
                                               TransformD* predict_pose,
                                               ForcastState* forcast_state) {
-  CHECK_NOTNULL(predict_pose);
-  CHECK_NOTNULL(forcast_state);
+  CHECK(predict_pose);
+  CHECK(forcast_state);
 
   double latest_imu_time = pose_forcastor_->GetLastestImuTime();
   if (latest_imu_time - lidar_time > imu_lidar_max_delay_time_) {
@@ -382,7 +382,7 @@ void LocalizationLidarProcess::UpdateState(const int ret, const double time) {
 
 bool LocalizationLidarProcess::LoadLidarExtrinsic(const std::string& file_path,
                                                   TransformD* lidar_extrinsic) {
-  CHECK_NOTNULL(lidar_extrinsic);
+  CHECK(lidar_extrinsic);
 
   YAML::Node config = YAML::LoadFile(file_path);
   if (config["transform"]) {
@@ -409,7 +409,7 @@ bool LocalizationLidarProcess::LoadLidarExtrinsic(const std::string& file_path,
 
 bool LocalizationLidarProcess::LoadLidarHeight(const std::string& file_path,
                                                LidarHeight* height) {
-  CHECK_NOTNULL(height);
+  CHECK(height);
 
   if (!common::util::PathExists(file_path)) {
     return false;

--- a/modules/localization/msf/local_integ/measure_republish_process.cc
+++ b/modules/localization/msf/local_integ/measure_republish_process.cc
@@ -60,7 +60,7 @@ bool MeasureRepublishProcess::NovatelBestgnssposProcess(
   if (gnss_mode_ != GnssMode::NOVATEL) {
     return false;
   }
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   if (!CheckBestgnssposeStatus(bestgnsspos_msg)) {
     AWARN << "Discard a bestgnsspose msg. "
@@ -113,7 +113,7 @@ void MeasureRepublishProcess::GnssLocalProcess(
     return;
   }
 
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   MeasureData measure_data = gnss_local_msg;
   if (is_trans_gpstime_to_utctime_) {
@@ -263,7 +263,7 @@ void MeasureRepublishProcess::IntegPvaProcess(const InsPva& inspva_msg) {
 
 bool MeasureRepublishProcess::LidarLocalProcess(
     const LocalizationEstimate& lidar_local_msg, MeasureData* measure) {
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   MeasureData measure_data;
   measure_data.time = lidar_local_msg.measurement_time();
@@ -337,7 +337,7 @@ bool MeasureRepublishProcess::IsSinsAlign() {
 
 void MeasureRepublishProcess::TransferXYZFromBestgnsspose(
     const GnssBestPose& bestgnsspos_msg, MeasureData* measure) {
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   measure->time = bestgnsspos_msg.measurement_time();
   if (is_trans_gpstime_to_utctime_) {
@@ -369,7 +369,7 @@ void MeasureRepublishProcess::TransferXYZFromBestgnsspose(
 
 void MeasureRepublishProcess::TransferFirstMeasureFromBestgnsspose(
     const GnssBestPose& bestgnsspos_msg, MeasureData* measure) {
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   TransferXYZFromBestgnsspose(bestgnsspos_msg, measure);
 
@@ -387,7 +387,7 @@ void MeasureRepublishProcess::TransferFirstMeasureFromBestgnsspose(
 
 bool MeasureRepublishProcess::CalculateVelFromBestgnsspose(
     const GnssBestPose& bestgnsspos_msg, MeasureData* measure) {
-  CHECK_NOTNULL(measure);
+  CHECK(measure);
 
   TransferXYZFromBestgnsspose(bestgnsspos_msg, measure);
 

--- a/modules/localization/msf/local_map/base_map/base_map.cc
+++ b/modules/localization/msf/local_map/base_map/base_map.cc
@@ -285,8 +285,8 @@ void BaseMap::LoadMapNodeThreadSafety(MapNodeIndex index, bool is_reserved) {
 void BaseMap::PreloadMapArea(const Eigen::Vector3d& location,
                              const Eigen::Vector3d& trans_diff,
                              unsigned int resolution_id, unsigned int zone_id) {
-  CHECK_NOTNULL(p_map_preload_threads_);
-  CHECK_NOTNULL(map_node_pool_);
+  CHECK(p_map_preload_threads_);
+  CHECK(map_node_pool_);
 
   int x_direction = trans_diff[0] > 0 ? 1 : -1;
   int y_direction = trans_diff[1] > 0 ? 1 : -1;
@@ -422,8 +422,8 @@ void BaseMap::PreloadMapArea(const Eigen::Vector3d& location,
 bool BaseMap::LoadMapArea(const Eigen::Vector3d& seed_pt3d,
                           unsigned int resolution_id, unsigned int zone_id,
                           int filter_size_x, int filter_size_y) {
-  CHECK_NOTNULL(p_map_load_threads_);
-  CHECK_NOTNULL(map_node_pool_);
+  CHECK(p_map_load_threads_);
+  CHECK(map_node_pool_);
   std::set<MapNodeIndex> map_ids;
   float map_pixel_resolution =
       this->map_config_->map_resolutions_[resolution_id];

--- a/modules/localization/msf/local_tool/data_extraction/compare_poses.cc
+++ b/modules/localization/msf/local_tool/data_extraction/compare_poses.cc
@@ -29,7 +29,7 @@
 
 static bool LoadGnssAntennaExtrinsic(
     const std::string &file_path, Eigen::Vector3d *imu_ant_offset) {
-  CHECK_NOTNULL(imu_ant_offset);
+  CHECK(imu_ant_offset);
 
   YAML::Node config = YAML::LoadFile(file_path);
   if (config["leverarm"]) {

--- a/modules/localization/rtk/rtk_localization.cc
+++ b/modules/localization/rtk/rtk_localization.cc
@@ -196,7 +196,7 @@ bool RTKLocalization::FindMatchingIMU(const double gps_timestamp_sec,
 
 bool RTKLocalization::InterpolateIMU(const CorrectedImu &imu1,
   const CorrectedImu &imu2, const double timestamp_sec, CorrectedImu *imu_msg) {
-  DCHECK_NOTNULL(imu_msg);
+  DCHECK(imu_msg);
   if (!(imu1.has_header() && imu1.header().has_timestamp_sec() &&
         imu2.has_header() && imu2.header().has_timestamp_sec())) {
     AERROR << "imu1 and imu2 has no header or no timestamp_sec in header";

--- a/modules/map/hdmap/adapter/coordinate_convert_tool.cc
+++ b/modules/map/hdmap/adapter/coordinate_convert_tool.cc
@@ -74,9 +74,9 @@ Status CoordinateConvertTool::CoordiateConvert(const double longitude,
                                              const double height_ellipsoid,
                                              double* utm_x, double* utm_y,
                                              double* utm_z) {
-  CHECK_NOTNULL(utm_x);
-  CHECK_NOTNULL(utm_y);
-  CHECK_NOTNULL(utm_z);
+  CHECK(utm_x);
+  CHECK(utm_y);
+  CHECK(utm_z);
   if (!pj_from_ || !pj_to_) {
       std::string err_msg = "no transform param";
       return Status(apollo::common::ErrorCode::HDMAP_DATA_ERROR, err_msg);

--- a/modules/map/hdmap/adapter/opendrive_adapter.cc
+++ b/modules/map/hdmap/adapter/opendrive_adapter.cc
@@ -26,7 +26,7 @@ namespace adapter {
 
 bool OpendriveAdapter::LoadData(const std::string& filename,
                                 apollo::hdmap::Map* pb_map) {
-  CHECK_NOTNULL(pb_map);
+  CHECK(pb_map);
 
   tinyxml2::XMLDocument document;
   if (document.LoadFile(filename.c_str()) != tinyxml2::XML_SUCCESS) {

--- a/modules/map/hdmap/adapter/xml_parser/lanes_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/lanes_xml_parser.cc
@@ -32,12 +32,12 @@ namespace adapter {
 Status LanesXmlParser::Parse(const tinyxml2::XMLElement& xml_node,
                              const std::string& road_id,
                              std::vector<RoadSectionInternal>* sections) {
-  CHECK_NOTNULL(sections);
+  CHECK(sections);
   const auto lanes_node = xml_node.FirstChildElement("lanes");
-  CHECK_NOTNULL(lanes_node);
+  CHECK(lanes_node);
   const tinyxml2::XMLElement* sub_node =
       lanes_node->FirstChildElement("laneSection");
-  CHECK_NOTNULL(sub_node);
+  CHECK(sub_node);
 
   size_t section_cnt = 0;
   while (sub_node) {
@@ -62,7 +62,7 @@ Status LanesXmlParser::Parse(const tinyxml2::XMLElement& xml_node,
 
 Status LanesXmlParser::ParseSectionBoundary(
     const tinyxml2::XMLElement& xml_node, PbBoundaryPolygon* boundary) {
-  CHECK_NOTNULL(boundary);
+  CHECK(boundary);
 
   auto boundaries_node = xml_node.FirstChildElement("boundaries");
   if (boundaries_node == nullptr) {
@@ -93,7 +93,7 @@ Status LanesXmlParser::ParseSectionBoundary(
 
 Status LanesXmlParser::ToPbBoundaryType(const std::string& type,
                                         PbBoundaryEdgeType* boundary_type) {
-  CHECK_NOTNULL(boundary_type);
+  CHECK(boundary_type);
 
   std::string upper_type = UtilXmlParser::ToUpper(type);
 
@@ -110,7 +110,7 @@ Status LanesXmlParser::ToPbBoundaryType(const std::string& type,
 
 Status LanesXmlParser::ParseLaneSection(const tinyxml2::XMLElement& xml_node,
                                         std::vector<LaneInternal>* lanes) {
-  CHECK_NOTNULL(lanes);
+  CHECK(lanes);
 
   // left
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("left");
@@ -135,9 +135,9 @@ Status LanesXmlParser::ParseLaneSection(const tinyxml2::XMLElement& xml_node,
   // center
   LaneInternal reference_lane_internal;
   sub_node = xml_node.FirstChildElement("center");
-  CHECK_NOTNULL(sub_node);
+  CHECK(sub_node);
   sub_node = sub_node->FirstChildElement("lane");
-  CHECK_NOTNULL(sub_node);
+  CHECK(sub_node);
   RETURN_IF_ERROR(ParseLane(*sub_node, &reference_lane_internal));
   *(reference_lane_internal.lane.mutable_left_boundary()) =
       reference_lane_internal.lane.right_boundary();
@@ -168,7 +168,7 @@ Status LanesXmlParser::ParseLaneSection(const tinyxml2::XMLElement& xml_node,
 
 Status LanesXmlParser::ParseLane(const tinyxml2::XMLElement& xml_node,
                                  LaneInternal* lane_internal) {
-  CHECK_NOTNULL(lane_internal);
+  CHECK(lane_internal);
 
   PbLane* lane = &lane_internal->lane;
   // lane id
@@ -304,7 +304,7 @@ Status LanesXmlParser::ParseLane(const tinyxml2::XMLElement& xml_node,
 
 Status LanesXmlParser::ParseDirection(const tinyxml2::XMLElement& xml_node,
                                       PbLane* lane) {
-  CHECK_NOTNULL(lane);
+  CHECK(lane);
   std::string direction;
   int checker =
       UtilXmlParser::QueryStringAttribute(xml_node, "direction", &direction);
@@ -325,7 +325,7 @@ Status LanesXmlParser::ParseDirection(const tinyxml2::XMLElement& xml_node,
 
 Status LanesXmlParser::ParseCenterCurve(const tinyxml2::XMLElement& xml_node,
                                         PbLane* lane) {
-  CHECK_NOTNULL(lane);
+  CHECK(lane);
   auto sub_node = xml_node.FirstChildElement("centerLine");
   if (!sub_node) {
     std::string err_msg = "Error parse lane center curve";
@@ -362,7 +362,7 @@ Status LanesXmlParser::ParseSpeed(const tinyxml2::XMLElement& xml_node,
 
 Status LanesXmlParser::ParseSampleAssociates(
     const tinyxml2::XMLElement& xml_node, PbLane* lane) {
-  CHECK_NOTNULL(lane);
+  CHECK(lane);
   auto sub_node = xml_node.FirstChildElement("sampleAssociates");
   if (sub_node == nullptr) {
     std::string err_msg = "Error parse sample associates";
@@ -402,7 +402,7 @@ Status LanesXmlParser::ParseSampleAssociates(
 
 Status LanesXmlParser::ParseRoadSampleAssociates(
     const tinyxml2::XMLElement& xml_node, PbLane* lane) {
-  CHECK_NOTNULL(lane);
+  CHECK(lane);
   auto sub_node = xml_node.FirstChildElement("roadSampleAssociations");
   if (sub_node == nullptr) {
     std::string err_msg = "Error parse road sample associations";
@@ -443,7 +443,7 @@ Status LanesXmlParser::ParseRoadSampleAssociates(
 Status LanesXmlParser::ParseObjectOverlapGroup(
     const tinyxml2::XMLElement& xml_node,
     std::vector<OverlapWithLane>* object_overlaps) {
-  CHECK_NOTNULL(object_overlaps);
+  CHECK(object_overlaps);
 
   auto object_overlap = xml_node.FirstChildElement("objectOverlapGroup");
   if (object_overlap) {
@@ -483,7 +483,7 @@ Status LanesXmlParser::ParseObjectOverlapGroup(
 Status LanesXmlParser::ParseSignalOverlapGroup(
     const tinyxml2::XMLElement& xml_node,
     std::vector<OverlapWithLane>* signal_overlaps) {
-  CHECK_NOTNULL(signal_overlaps);
+  CHECK(signal_overlaps);
 
   auto signal_overlap = xml_node.FirstChildElement("signalOverlapGroup");
   if (signal_overlap) {
@@ -524,7 +524,7 @@ Status LanesXmlParser::ParseSignalOverlapGroup(
 Status LanesXmlParser::ParseJunctionOverlapGroup(
     const tinyxml2::XMLElement& xml_node,
     std::vector<OverlapWithLane>* junction_overlaps) {
-  CHECK_NOTNULL(junction_overlaps);
+  CHECK(junction_overlaps);
 
   auto overlap_group = xml_node.FirstChildElement("junctionOverlapGroup");
   if (overlap_group) {
@@ -565,7 +565,7 @@ Status LanesXmlParser::ParseJunctionOverlapGroup(
 Status LanesXmlParser::ParseLaneOverlapGroup(
     const tinyxml2::XMLElement& xml_node,
     std::vector<OverlapWithLane>* lane_overlaps) {
-  CHECK_NOTNULL(lane_overlaps);
+  CHECK(lane_overlaps);
 
   auto overlap_node = xml_node.FirstChildElement("laneOverlapGroup");
   if (overlap_node) {
@@ -606,7 +606,7 @@ Status LanesXmlParser::ParseLaneOverlapGroup(
 
 Status LanesXmlParser::ToPbLaneType(const std::string& type,
                                     PbLaneType* lane_type) {
-  CHECK_NOTNULL(lane_type);
+  CHECK(lane_type);
 
   std::string upper_str = UtilXmlParser::ToUpper(type);
 
@@ -632,7 +632,7 @@ Status LanesXmlParser::ToPbLaneType(const std::string& type,
 
 Status LanesXmlParser::ToPbTurnType(const std::string& type,
                                     PbTurnType* pb_turn_type) {
-  CHECK_NOTNULL(pb_turn_type);
+  CHECK(pb_turn_type);
 
   std::string upper_str = UtilXmlParser::ToUpper(type);
 
@@ -654,7 +654,7 @@ Status LanesXmlParser::ToPbTurnType(const std::string& type,
 
 Status LanesXmlParser::ToPbDirection(const std::string& type,
                                      PbLaneDirection* pb_direction) {
-  CHECK_NOTNULL(pb_direction);
+  CHECK(pb_direction);
 
   std::string upper_str = UtilXmlParser::ToUpper(type);
 
@@ -674,7 +674,7 @@ Status LanesXmlParser::ToPbDirection(const std::string& type,
 
 void LanesXmlParser::ParseLaneLink(const tinyxml2::XMLElement& xml_node,
                                    PbLane* lane) {
-  CHECK_NOTNULL(lane);
+  CHECK(lane);
 
   const tinyxml2::XMLElement* sub_node =
       xml_node.FirstChildElement("predecessor");
@@ -724,7 +724,7 @@ void LanesXmlParser::ParseLaneLink(const tinyxml2::XMLElement& xml_node,
 Status LanesXmlParser::ParseLaneBorderMark(
     const tinyxml2::XMLElement& xml_node,
     PbLaneBoundaryTypeType* boundary_type) {
-  CHECK_NOTNULL(boundary_type);
+  CHECK(boundary_type);
 
   std::string type;
   std::string color;
@@ -748,7 +748,7 @@ Status LanesXmlParser::ParseLaneBorderMark(
 Status LanesXmlParser::ToPbLaneMarkType(const std::string& type,
                                         const std::string& color,
                                         PbLaneBoundaryTypeType* boundary_type) {
-  CHECK_NOTNULL(boundary_type);
+  CHECK(boundary_type);
 
   std::string upper_type = UtilXmlParser::ToUpper(type);
   std::string upper_color = UtilXmlParser::ToUpper(color);

--- a/modules/map/hdmap/adapter/xml_parser/objects_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/objects_xml_parser.cc
@@ -26,7 +26,7 @@ namespace adapter {
 
 Status ObjectsXmlParser::ParseCrosswalks(const tinyxml2::XMLElement& xml_node,
                                          std::vector<PbCrosswalk>* crosswalks) {
-  CHECK_NOTNULL(crosswalks);
+  CHECK(crosswalks);
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("object");
   while (sub_node) {
     std::string object_type;
@@ -60,7 +60,7 @@ Status ObjectsXmlParser::ParseCrosswalks(const tinyxml2::XMLElement& xml_node,
 Status ObjectsXmlParser::ParseClearAreas(
     const tinyxml2::XMLElement& xml_node,
     std::vector<PbClearArea>* clear_areas) {
-  CHECK_NOTNULL(clear_areas);
+  CHECK(clear_areas);
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("object");
   while (sub_node) {
     std::string object_type;
@@ -97,7 +97,7 @@ Status ObjectsXmlParser::ParseClearAreas(
 Status ObjectsXmlParser::ParseSpeedBumps(
     const tinyxml2::XMLElement& xml_node,
     std::vector<PbSpeedBump>* speed_bumps) {
-  CHECK_NOTNULL(speed_bumps);
+  CHECK(speed_bumps);
   const tinyxml2::XMLElement* object_node =
       xml_node.FirstChildElement("object");
   while (object_node) {
@@ -137,7 +137,7 @@ Status ObjectsXmlParser::ParseSpeedBumps(
 Status ObjectsXmlParser::ParseStopLines(
     const tinyxml2::XMLElement& xml_node,
     std::vector<StopLineInternal>* stop_lines) {
-  CHECK_NOTNULL(stop_lines);
+  CHECK(stop_lines);
   const tinyxml2::XMLElement* object_node =
       xml_node.FirstChildElement("object");
   while (object_node) {
@@ -173,7 +173,7 @@ Status ObjectsXmlParser::ParseStopLines(
 Status ObjectsXmlParser::ParseParkingSpaces(
         const tinyxml2::XMLElement& xml_node,
         std::vector<PbParkingSpace>* parking_spaces) {
-  CHECK_NOTNULL(parking_spaces);
+  CHECK(parking_spaces);
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("object");
   while (sub_node) {
     std::string object_type;

--- a/modules/map/hdmap/adapter/xml_parser/roads_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/roads_xml_parser.cc
@@ -34,7 +34,7 @@ namespace adapter {
 
 Status RoadsXmlParser::Parse(const tinyxml2::XMLElement& xml_node,
                              std::vector<RoadInternal>* roads) {
-  CHECK_NOTNULL(roads);
+  CHECK(roads);
 
   auto road_node = xml_node.FirstChildElement("road");
   while (road_node) {

--- a/modules/map/hdmap/adapter/xml_parser/signals_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/signals_xml_parser.cc
@@ -27,7 +27,7 @@ namespace adapter {
 Status SignalsXmlParser::ParseTrafficLights(
     const tinyxml2::XMLElement& xml_node,
     std::vector<TrafficLightInternal>* traffic_lights) {
-  CHECK_NOTNULL(traffic_lights);
+  CHECK(traffic_lights);
   auto signal_node = xml_node.FirstChildElement("signal");
   while (signal_node) {
     std::string object_type;
@@ -116,7 +116,7 @@ Status SignalsXmlParser::ParseTrafficLights(
 
 Status SignalsXmlParser::ToPbSignalType(const std::string& xml_type,
                                         PbSignalType* signal_type) {
-  CHECK_NOTNULL(signal_type);
+  CHECK(signal_type);
 
   std::string upper_str = UtilXmlParser::ToUpper(xml_type);
 
@@ -142,7 +142,7 @@ Status SignalsXmlParser::ToPbSignalType(const std::string& xml_type,
 
 Status SignalsXmlParser::ToPbSubSignalType(const std::string& xml_type,
                                            PbSubSignalType* sub_signal_type) {
-  CHECK_NOTNULL(sub_signal_type);
+  CHECK(sub_signal_type);
 
   std::string upper_str = UtilXmlParser::ToUpper(xml_type);
 
@@ -172,7 +172,7 @@ Status SignalsXmlParser::ToPbSubSignalType(const std::string& xml_type,
 Status SignalsXmlParser::ParseStopSigns(
     const tinyxml2::XMLElement& xml_node,
     std::vector<StopSignInternal>* stop_signs) {
-  CHECK_NOTNULL(stop_signs);
+  CHECK(stop_signs);
 
   auto signal_node = xml_node.FirstChildElement("signal");
   while (signal_node) {
@@ -219,7 +219,7 @@ Status SignalsXmlParser::ParseStopSigns(
 Status SignalsXmlParser::ParseYieldSigns(
     const tinyxml2::XMLElement& xml_node,
     std::vector<YieldSignInternal>* yield_signs) {
-  CHECK_NOTNULL(yield_signs);
+  CHECK(yield_signs);
 
   auto signal_node = xml_node.FirstChildElement("signal");
   while (signal_node) {

--- a/modules/map/hdmap/adapter/xml_parser/util_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/util_xml_parser.cc
@@ -30,7 +30,7 @@ namespace adapter {
 
 Status UtilXmlParser::ParseCurve(const tinyxml2::XMLElement& xml_node,
                                  PbCurve* curve) {
-  CHECK_NOTNULL(curve);
+  CHECK(curve);
 
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("geometry");
   while (sub_node) {
@@ -44,7 +44,7 @@ Status UtilXmlParser::ParseCurve(const tinyxml2::XMLElement& xml_node,
 
 Status UtilXmlParser::ParseGeometry(const tinyxml2::XMLElement& xml_node,
                                     PbCurveSegment* curve_segment) {
-  CHECK_NOTNULL(curve_segment);
+  CHECK(curve_segment);
 
   // Read geometry attributes
   double s = 0.0;
@@ -150,7 +150,7 @@ Status UtilXmlParser::ParseOutline(const tinyxml2::XMLElement& xml_node,
 
 Status UtilXmlParser::ParsePoint(const tinyxml2::XMLElement& xml_node,
                                  PbPoint3D* pt) {
-  CHECK_NOTNULL(pt);
+  CHECK(pt);
 
   const auto sub_node = xml_node.FirstChildElement("centerPoint");
   CHECK(sub_node != nullptr);
@@ -205,7 +205,7 @@ double UtilXmlParser::CurveLength(const PbCurve& curve) {
 tinyxml2::XMLError UtilXmlParser::QueryStringAttribute(
     const tinyxml2::XMLElement& xml_node, const std::string& name,
     std::string* value) {
-  CHECK_NOTNULL(value);
+  CHECK(value);
   const char* val = xml_node.Attribute(name.c_str());
   if (val == nullptr) {
     return tinyxml2::XML_NO_ATTRIBUTE;

--- a/modules/map/hdmap/hdmap_impl.cc
+++ b/modules/map/hdmap/hdmap_impl.cc
@@ -241,7 +241,7 @@ int HDMapImpl::GetRoads(const Vec2d& point, double distance,
 
   for (auto& road_id : road_ids) {
     RoadInfoConstPtr road = GetRoadById(CreateHDMapId(road_id));
-    CHECK_NOTNULL(road);
+    CHECK(road);
     roads->push_back(road);
   }
 
@@ -460,9 +460,9 @@ int HDMapImpl::GetNearestLane(const PointENU& point,
 int HDMapImpl::GetNearestLane(const Vec2d& point,
                               LaneInfoConstPtr* nearest_lane, double* nearest_s,
                               double* nearest_l) const {
-  CHECK_NOTNULL(nearest_lane);
-  CHECK_NOTNULL(nearest_s);
-  CHECK_NOTNULL(nearest_l);
+  CHECK(nearest_lane);
+  CHECK(nearest_s);
+  CHECK(nearest_l);
   const auto* segment_object = lane_segment_kdtree_->GetNearestObject(point);
   if (segment_object == nullptr) {
     return -1;
@@ -494,9 +494,9 @@ int HDMapImpl::GetNearestLaneWithHeading(
     const Vec2d& point, const double distance, const double central_heading,
     const double max_heading_difference, LaneInfoConstPtr* nearest_lane,
     double* nearest_s, double* nearest_l) const {
-  CHECK_NOTNULL(nearest_lane);
-  CHECK_NOTNULL(nearest_s);
-  CHECK_NOTNULL(nearest_l);
+  CHECK(nearest_lane);
+  CHECK(nearest_s);
+  CHECK(nearest_l);
 
   std::vector<LaneInfoConstPtr> lanes;
   if (GetLanesWithHeading(point, distance, central_heading,
@@ -546,7 +546,7 @@ int HDMapImpl::GetLanesWithHeading(const Vec2d& point, const double distance,
                                    const double central_heading,
                                    const double max_heading_difference,
                                    std::vector<LaneInfoConstPtr>* lanes) const {
-  CHECK_NOTNULL(lanes);
+  CHECK(lanes);
   std::vector<LaneInfoConstPtr> all_lanes;
   const int status = GetLanes(point, distance, &all_lanes);
   if (status < 0 || all_lanes.size() <= 0) {
@@ -576,8 +576,8 @@ int HDMapImpl::GetRoadBoundaries(
     const PointENU& point, double radius,
     std::vector<RoadROIBoundaryPtr>* road_boundaries,
     std::vector<JunctionBoundaryPtr>* junctions) const {
-  CHECK_NOTNULL(road_boundaries);
-  CHECK_NOTNULL(junctions);
+  CHECK(road_boundaries);
+  CHECK(junctions);
 
   road_boundaries->clear();
   junctions->clear();
@@ -598,7 +598,7 @@ int HDMapImpl::GetRoadBoundaries(
     }
     road_section_id_set.insert(unique_id);
     const auto road_ptr = GetRoadById(road_id);
-    CHECK_NOTNULL(road_ptr);
+    CHECK(road_ptr);
     if (road_ptr->has_junction_id()) {
       const Id junction_id = road_ptr->junction_id();
       if (junction_id_set.count(junction_id.id()) > 0) {
@@ -607,7 +607,7 @@ int HDMapImpl::GetRoadBoundaries(
       junction_id_set.insert(junction_id.id());
       JunctionBoundaryPtr junction_boundary_ptr(new JunctionBoundary());
       junction_boundary_ptr->junction_info = GetJunctionById(junction_id);
-      CHECK_NOTNULL(junction_boundary_ptr->junction_info);
+      CHECK(junction_boundary_ptr->junction_info);
       junctions->push_back(junction_boundary_ptr);
     } else {
       RoadROIBoundaryPtr road_boundary_ptr(new RoadROIBoundary());
@@ -628,7 +628,7 @@ int HDMapImpl::GetRoadBoundaries(
 int HDMapImpl::GetForwardNearestSignalsOnLane(
     const apollo::common::PointENU& point, const double distance,
     std::vector<SignalInfoConstPtr>* signals) const {
-  CHECK_NOTNULL(signals);
+  CHECK(signals);
 
   signals->clear();
   LaneInfoConstPtr lane_ptr = nullptr;
@@ -735,7 +735,7 @@ int HDMapImpl::GetForwardNearestSignalsOnLane(
 
 int HDMapImpl::GetStopSignAssociatedStopSigns(
     const Id& id, std::vector<StopSignInfoConstPtr>* stop_signs) const {
-  CHECK_NOTNULL(stop_signs);
+  CHECK(stop_signs);
 
   const auto& stop_sign = GetStopSignById(id);
   if (stop_sign == nullptr) {
@@ -772,7 +772,7 @@ int HDMapImpl::GetStopSignAssociatedStopSigns(
 
 int HDMapImpl::GetStopSignAssociatedLanes(
     const Id& id, std::vector<LaneInfoConstPtr>* lanes) const {
-  CHECK_NOTNULL(lanes);
+  CHECK(lanes);
 
   const auto& stop_sign = GetStopSignById(id);
   if (stop_sign == nullptr) {

--- a/modules/map/pnc_map/path.cc
+++ b/modules/map/pnc_map/path.cc
@@ -108,7 +108,7 @@ LaneWaypoint LeftNeighborWaypoint(const LaneWaypoint& waypoint) {
   }
   auto point = waypoint.lane->GetSmoothPoint(waypoint.s);
   auto map_ptr = HDMapUtil::BaseMapPtr();
-  CHECK_NOTNULL(map_ptr);
+  CHECK(map_ptr);
   for (const auto& lane_id :
        waypoint.lane->lane().left_neighbor_forward_lane_id()) {
     auto lane = map_ptr->GetLaneById(lane_id);
@@ -164,7 +164,7 @@ LaneWaypoint RightNeighborWaypoint(const LaneWaypoint& waypoint) {
   }
   auto point = waypoint.lane->GetSmoothPoint(waypoint.s);
   auto map_ptr = HDMapUtil::BaseMapPtr();
-  CHECK_NOTNULL(map_ptr);
+  CHECK(map_ptr);
   for (const auto& lane_id :
        waypoint.lane->lane().right_neighbor_forward_lane_id()) {
     auto lane = map_ptr->GetLaneById(lane_id);
@@ -371,7 +371,7 @@ void Path::InitWidth() {
       AWARN << "path point:" << point.DebugString() << " has invalid width.";
     } else {
       const LaneWaypoint waypoint = point.lane_waypoints()[0];
-      CHECK_NOTNULL(waypoint.lane);
+      CHECK(waypoint.lane);
 
       double lane_left_width = 0.0;
       double lane_right_width = 0.0;
@@ -777,8 +777,8 @@ double Path::GetLaneRightWidth(const double s) const {
 
 bool Path::GetLaneWidth(const double s, double* lane_left_width,
                         double* lane_right_width) const {
-  CHECK_NOTNULL(lane_left_width);
-  CHECK_NOTNULL(lane_right_width);
+  CHECK(lane_left_width);
+  CHECK(lane_right_width);
 
   if (s < 0.0 || s > length_) {
     return false;
@@ -798,8 +798,8 @@ double Path::GetRoadRightWidth(const double s) const {
 
 bool Path::GetRoadWidth(const double s, double* road_left_width,
                         double* road_right_width) const {
-  CHECK_NOTNULL(road_left_width);
-  CHECK_NOTNULL(road_right_width);
+  CHECK(road_left_width);
+  CHECK(road_right_width);
 
   if (s < 0.0 || s > length_) {
     return false;

--- a/modules/map/pnc_map/pnc_map.cc
+++ b/modules/map/pnc_map/pnc_map.cc
@@ -68,7 +68,7 @@ const double kDuplicatedPointsEpsilon = 1e-7;
 const double kTrajectoryApproximationMaxError = 2.0;
 
 void RemoveDuplicates(std::vector<MapPathPoint> *points) {
-  CHECK_NOTNULL(points);
+  CHECK(points);
   int count = 0;
   const double limit = kDuplicatedPointsEpsilon * kDuplicatedPointsEpsilon;
   for (size_t i = 0; i < points->size(); ++i) {
@@ -375,7 +375,7 @@ int PncMap::GetWaypointIndex(const LaneWaypoint &waypoint) const {
 
 bool PncMap::PassageToSegments(routing::Passage passage,
                                RouteSegments *segments) const {
-  CHECK_NOTNULL(segments);
+  CHECK(segments);
   segments->clear();
   for (const auto &lane : passage.segment()) {
     auto lane_ptr = hdmap_->GetLaneById(hdmap::MakeMapId(lane.id()));
@@ -648,7 +648,7 @@ bool PncMap::ExtendSegments(const RouteSegments &segments, double start_s,
     AERROR << "The input segments is empty";
     return false;
   }
-  CHECK_NOTNULL(truncated_segments);
+  CHECK(truncated_segments);
   truncated_segments->SetProperties(segments);
 
   if (start_s >= end_s) {

--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -238,7 +238,7 @@ double NavigationLane::EvaluateCubicPolynomial(const double c0, const double c1,
 
 void NavigationLane::MergeNavigationLineAndLaneMarker(const int line_index,
                                                       common::Path *path) {
-  CHECK_NOTNULL(path);
+  CHECK(path);
 
   // If the size of "path" points is smaller than 2, it indicates that a
   // navigation path needs to be generated firstly.
@@ -290,7 +290,7 @@ common::PathPoint NavigationLane::GetPathPointByS(const common::Path &path,
                                                   const int start_index,
                                                   const double s,
                                                   int *matched_index) {
-  CHECK_NOTNULL(matched_index);
+  CHECK(matched_index);
   const int size = path.path_point_size();
 
   if (start_index < 0 || s < path.path_point(start_index).s()) {
@@ -324,7 +324,7 @@ common::PathPoint NavigationLane::GetPathPointByS(const common::Path &path,
 
 bool NavigationLane::ConvertNavigationLineToPath(const int line_index,
                                                  common::Path *path) {
-  CHECK_NOTNULL(path);
+  CHECK(path);
   if (!navigation_info_.navigation_path(line_index).has_path() ||
       navigation_info_.navigation_path(line_index).path().path_point_size() ==
           0) {
@@ -370,7 +370,7 @@ bool NavigationLane::ConvertNavigationLineToPath(const int line_index,
       [this, &navigation_path, &enu_to_flu_func](
           const int start, const int end, const double ref_s_base,
           const double max_length, common::Path *path) {
-        CHECK_NOTNULL(path);
+        CHECK(path);
         const double ref_s = navigation_path.path_point(start).s();
         for (int i = start; i < end; ++i) {
           auto *point = path->add_path_point();
@@ -537,7 +537,7 @@ double NavigationLane::GetKappa(const double c1, const double c2,
 
 void NavigationLane::ConvertLaneMarkerToPath(
     const perception::LaneMarkers &lane_marker, common::Path *path) {
-  CHECK_NOTNULL(path);
+  CHECK(path);
 
   path->set_name("Path from lane markers.");
   const auto &left_lane = lane_marker.left_lane_marker();

--- a/modules/map/relative_map/navigation_lane_test.cc
+++ b/modules/map/relative_map/navigation_lane_test.cc
@@ -48,7 +48,7 @@ using nlohmann::json;
 namespace {
 bool GetNavigationPathFromFile(const std::string& filename,
                                NavigationPath* navigation_path) {
-  CHECK_NOTNULL(navigation_path);
+  CHECK(navigation_path);
 
   std::ifstream ifs(filename, std::ios::in);
   if (!ifs.is_open()) {
@@ -78,7 +78,7 @@ bool GetNavigationPathFromFile(const std::string& filename,
 bool GenerateNavigationInfo(
     const std::vector<std::string>& navigation_line_filenames,
     NavigationInfo* navigation_info) {
-  CHECK_NOTNULL(navigation_info);
+  CHECK(navigation_info);
 
   int i = 0;
   for (const std::string& filename : navigation_line_filenames) {

--- a/modules/map/relative_map/relative_map.cc
+++ b/modules/map/relative_map/relative_map.cc
@@ -151,7 +151,7 @@ void RelativeMap::OnReceiveNavigationInfo(
 }
 
 bool RelativeMap::CreateMapFromNavigationLane(MapMsg* map_msg) {
-  CHECK_NOTNULL(map_msg);
+  CHECK(map_msg);
 
   if (AdapterManager::GetLocalization()->Empty()) {
     LogErrorStatus(map_msg, "localization is not ready");

--- a/modules/map/relative_map/tools/navigator.cc
+++ b/modules/map/relative_map/tools/navigator.cc
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
 bool ParseNavigationLineFileNames(
     int argc, char** argv,
     std::vector<std::string>* navigation_line_filenames) {
-  CHECK_NOTNULL(navigation_line_filenames);
+  CHECK(navigation_line_filenames);
   bool initialized = false;
   if (argc > 1) {
     try {
@@ -134,7 +134,7 @@ bool ParseNavigationLineFileNames(
 
 bool GetNavigationPathFromFile(const std::string& filename,
                                NavigationPath* navigation_path) {
-  CHECK_NOTNULL(navigation_path);
+  CHECK(navigation_path);
 
   std::ifstream ifs(filename, std::ios::in);
   if (!ifs.is_open()) {

--- a/modules/perception/lib/base/registerer.cc
+++ b/modules/perception/lib/base/registerer.cc
@@ -30,7 +30,7 @@ BaseClassMap& GlobalFactoryMap() {
 bool GetRegisteredClasses(
     const std::string& base_class_name,
     std::vector<std::string>* registered_derived_classes_names) {
-  CHECK_NOTNULL(registered_derived_classes_names);
+  CHECK(registered_derived_classes_names);
   BaseClassMap& map = GlobalFactoryMap();
   auto iter = map.find(base_class_name);
   if (iter == map.end()) {

--- a/modules/perception/obstacle/camera/detector/common/feature_extractor.cc
+++ b/modules/perception/obstacle/camera/detector/common/feature_extractor.cc
@@ -77,7 +77,7 @@ bool ReorgFeatureExtractor::init(
 
 bool ReorgFeatureExtractor::extract(
     std::vector<std::shared_ptr<VisualObject>> *objects) {
-  CHECK_NOTNULL(objects);
+  CHECK(objects);
   if (objects->empty()) {
     return true;
   }
@@ -143,7 +143,7 @@ bool ROIPoolingFeatureExtractor::init(
 
 bool ROIPoolingFeatureExtractor::extract(
     std::vector<std::shared_ptr<VisualObject>> *objects) {
-  CHECK_NOTNULL(objects);
+  CHECK(objects);
   if (objects->empty()) {
     return true;
   }

--- a/modules/perception/obstacle/camera/detector/yolo_camera_detector/yolo_camera_detector_test.cc
+++ b/modules/perception/obstacle/camera/detector/yolo_camera_detector/yolo_camera_detector_test.cc
@@ -64,7 +64,7 @@ TEST_F(YoloCameraDetectorTest, model_init_test) {
   CHECK(SetProtoToASCIIFile(yolo_param, yolo_config));
   BaseCameraDetector *camera_detector =
       BaseCameraDetectorRegisterer::GetInstanceByName("YoloCameraDetector");
-  CHECK_NOTNULL(camera_detector);
+  CHECK(camera_detector);
   CHECK(camera_detector->Init());
 
   // Recover to origin config.
@@ -81,7 +81,7 @@ TEST_F(YoloCameraDetectorTest, yolo_camera_detector_roipooling_test) {
   ADEBUG << "test image file: " << image_file;
 
   cv::Mat frame = cv::imread(image_file, CV_LOAD_IMAGE_COLOR);
-  CHECK_NOTNULL(frame.data);
+  CHECK(frame.data);
 
   CameraDetectorOptions options;
   CHECK_EQ(camera_detector->Detect(frame, options, NULL), false);
@@ -115,7 +115,7 @@ TEST_F(YoloCameraDetectorTest, multi_task_test) {
   ADEBUG << "test image file: " << image_file;
 
   cv::Mat frame = cv::imread(image_file, CV_LOAD_IMAGE_COLOR);
-  CHECK_NOTNULL(frame.data);
+  CHECK(frame.data);
 
   CameraDetectorOptions options;
   CHECK_EQ(camera_detector->Multitask(frame, options, NULL, NULL), false);

--- a/modules/perception/obstacle/camera/filter/object_camera_filter.cc
+++ b/modules/perception/obstacle/camera/filter/object_camera_filter.cc
@@ -53,7 +53,7 @@ bool ObjectCameraFilter::Filter(
 std::string ObjectCameraFilter::Name() const { return "ObjectCameraFilter"; }
 
 void ObjectCameraFilter::InitFilter(const float x, KalmanFilter1D* filter) {
-  CHECK_NOTNULL(filter);
+  CHECK(filter);
 
   Eigen::Matrix<float, 2, 1> state_x;
   state_x << x, 0.0f;

--- a/modules/perception/obstacle/fusion/async_fusion/async_fusion.cc
+++ b/modules/perception/obstacle/fusion/async_fusion/async_fusion.cc
@@ -33,7 +33,7 @@ using apollo::common::util::GetProtoFromFile;
 
 bool AsyncFusion::Init() {
   track_manager_ = PbfTrackManager::instance();
-  CHECK_NOTNULL(track_manager_);
+  CHECK(track_manager_);
 
   if (!GetProtoFromFile(FLAGS_async_fusion_config, &config_)) {
     AERROR << "Cannot get config proto from file: " << FLAGS_tracker_config;

--- a/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_base_track_object_matcher.cc
+++ b/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_base_track_object_matcher.cc
@@ -38,9 +38,9 @@ void PbfBaseTrackObjectMatcher::IdAssign(
     std::vector<std::pair<int, int>> *assignments,
     std::vector<int> *unassigned_fusion_tracks,
     std::vector<int> *unassigned_sensor_objects) {
-  CHECK_NOTNULL(assignments);
-  CHECK_NOTNULL(unassigned_fusion_tracks);
-  CHECK_NOTNULL(unassigned_sensor_objects);
+  CHECK(assignments);
+  CHECK(unassigned_fusion_tracks);
+  CHECK(unassigned_sensor_objects);
 
   size_t num_track = fusion_tracks.size();
   size_t num_obj = sensor_objects.size();

--- a/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_hm_track_object_matcher.cc
+++ b/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_hm_track_object_matcher.cc
@@ -33,11 +33,11 @@ bool PbfHmTrackObjectMatcher::Match(
     std::vector<int> *unassigned_sensor_objects,
     std::vector<double> *track2measurements_dist,
     std::vector<double> *measurement2track_dist) {
-  CHECK_NOTNULL(assignments);
-  CHECK_NOTNULL(unassigned_fusion_tracks);
-  CHECK_NOTNULL(unassigned_sensor_objects);
-  CHECK_NOTNULL(track2measurements_dist);
-  CHECK_NOTNULL(measurement2track_dist);
+  CHECK(assignments);
+  CHECK(unassigned_fusion_tracks);
+  CHECK(unassigned_sensor_objects);
+  CHECK(track2measurements_dist);
+  CHECK(measurement2track_dist);
 
   if (options.ref_point == nullptr) {
     AERROR << "reference points is nullptr!";
@@ -127,7 +127,7 @@ void PbfHmTrackObjectMatcher::ComputeAssociationMat(
     const std::vector<int> &unassigned_sensor_objects,
     const Eigen::Vector3d &ref_point, const Eigen::Matrix4d &sensor_world_pose,
     std::vector<std::vector<double>> *association_mat) {
-  CHECK_NOTNULL(association_mat);
+  CHECK(association_mat);
 
   PbfTrackObjectDistance pbf_distance;
   Eigen::Vector3d local_ref_point = ref_point;

--- a/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_sensor.cc
+++ b/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_sensor.cc
@@ -30,7 +30,7 @@ PbfSensor::~PbfSensor() {}
 
 void PbfSensor::QueryLatestFrames(const double time_stamp,
                                   std::vector<PbfSensorFramePtr> *frames) {
-  CHECK_NOTNULL(frames);
+  CHECK(frames);
   frames->clear();
   for (size_t i = 0; i < frames_.size(); ++i) {
     if (frames_[i]->timestamp > latest_query_timestamp_ &&
@@ -79,7 +79,7 @@ void PbfSensor::AddFrame(const SensorObjects &frame) {
 
 bool PbfSensor::GetPose(const double time_stamp, const double time_range,
                         Eigen::Matrix4d *pose) {
-  CHECK_NOTNULL(pose);
+  CHECK(pose);
   CHECK_GE(time_range, 0.0);
 
   for (auto rit = frames_.rbegin(); rit != frames_.rend(); ++rit) {

--- a/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_track_object_distance.cc
+++ b/modules/perception/obstacle/fusion/probabilistic_fusion/pbf_track_object_distance.cc
@@ -328,7 +328,7 @@ float PbfTrackObjectDistance::ComputeEuclideanDistance(
 
 bool PbfTrackObjectDistance::ComputePolygonCenter(const PolygonDType &polygon,
                                                   Eigen::Vector3d *center) {
-  CHECK_NOTNULL(center);
+  CHECK(center);
   if (polygon.empty()) {
     return false;
   }
@@ -345,7 +345,7 @@ bool PbfTrackObjectDistance::ComputePolygonCenter(const PolygonDType &polygon,
 bool PbfTrackObjectDistance::ComputePolygonCenter(
     const PolygonDType &polygon, const Eigen::Vector3d &ref_pos, int range,
     Eigen::Vector3d *center) {
-  CHECK_NOTNULL(center);
+  CHECK(center);
   PolygonDType polygon_part;
   std::set<std::pair<double, int>> distance2idx_set;
 

--- a/modules/perception/tool/data_generator/velodyne64.cc
+++ b/modules/perception/tool/data_generator/velodyne64.cc
@@ -109,7 +109,7 @@ void Velodyne64::TransPointCloudMsgToPCL(
 bool Velodyne64::GetTrans(const std::string& to_frame,
                           const std::string& from_frame,
                           const double query_time, Matrix4d* trans) {
-  CHECK_NOTNULL(trans);
+  CHECK(trans);
   ros::Time query_stamp(query_time);
   const auto& tf2_buffer = AdapterManager::Tf2Buffer();
   const double kTf2BuffSize = 10 / 1000.0;  // buff size

--- a/modules/perception/traffic_light/onboard/hdmap_input.cc
+++ b/modules/perception/traffic_light/onboard/hdmap_input.cc
@@ -31,7 +31,7 @@ HDMapInput::HDMapInput() {}
 bool HDMapInput::GetSignals(const Eigen::Matrix4d &pointd,
                             std::vector<apollo::hdmap::Signal> *signals) {
   auto hdmap = HDMapUtil::BaseMapPtr();
-  CHECK_NOTNULL(hdmap);
+  CHECK(hdmap);
 
   std::vector<hdmap::SignalInfoConstPtr> forward_signals;
   apollo::common::PointENU point;

--- a/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.cc
+++ b/modules/perception/traffic_light/onboard/tl_preprocessor_subnode.cc
@@ -70,7 +70,7 @@ bool TLPreprocessorSubnode::InitInternal() {
 }
 
 bool TLPreprocessorSubnode::InitSharedData() {
-  CHECK_NOTNULL(shared_data_manager_);
+  CHECK(shared_data_manager_);
 
   const std::string preprocessing_data_name("TLPreprocessingData");
   preprocessing_data_ = dynamic_cast<TLPreprocessingData *>(

--- a/modules/perception/traffic_light/onboard/tl_proc_subnode.cc
+++ b/modules/perception/traffic_light/onboard/tl_proc_subnode.cc
@@ -299,7 +299,7 @@ bool TLProcSubnode::ProcEvent(const Event &event) {
 }
 
 bool TLProcSubnode::InitSharedData() {
-  CHECK_NOTNULL(shared_data_manager_);
+  CHECK(shared_data_manager_);
 
   const std::string preprocessing_data_name("TLPreprocessingData");
   preprocessing_data_ = dynamic_cast<TLPreprocessingData *>(

--- a/modules/perception/traffic_light/util/color_space.cc
+++ b/modules/perception/traffic_light/util/color_space.cc
@@ -48,10 +48,10 @@ namespace traffic_light {
 template <bool align>
 SIMD_INLINE void YuvSeperateAvx2(uint8_t *y, __m256i *y0, __m256i *y1,
                                  __m256i *u0, __m256i *v0) {
-  DCHECK_NOTNULL(y0);
-  DCHECK_NOTNULL(y1);
-  DCHECK_NOTNULL(u0);
-  DCHECK_NOTNULL(v0);
+  DCHECK(y0);
+  DCHECK(y1);
+  DCHECK(u0);
+  DCHECK(v0);
 
   __m256i yuv_m256[4];
 

--- a/modules/planning/common/frame.cc
+++ b/modules/planning/common/frame.cc
@@ -348,7 +348,7 @@ const Obstacle *Frame::CreateStaticVirtualObstacle(const std::string &id,
 
 Status Frame::Init() {
   hdmap_ = hdmap::HDMapUtil::BaseMapPtr();
-  CHECK_NOTNULL(hdmap_);
+  CHECK(hdmap_);
   vehicle_state_ = common::VehicleStateProvider::instance()->vehicle_state();
   const auto &point = common::util::MakePointENU(
       vehicle_state_.x(), vehicle_state_.y(), vehicle_state_.z());

--- a/modules/planning/common/frame_open_space.cc
+++ b/modules/planning/common/frame_open_space.cc
@@ -78,7 +78,7 @@ const common::VehicleState &FrameOpenSpace::vehicle_state() const {
 
 Status FrameOpenSpace::Init() {
   hdmap_ = hdmap::HDMapUtil::BaseMapPtr();
-  CHECK_NOTNULL(hdmap_);
+  CHECK(hdmap_);
   vehicle_state_ = common::VehicleStateProvider::instance()->vehicle_state();
   const auto &point = common::util::MakePointENU(
       vehicle_state_.x(), vehicle_state_.y(), vehicle_state_.z());

--- a/modules/planning/common/lag_prediction.cc
+++ b/modules/planning/common/lag_prediction.cc
@@ -127,7 +127,7 @@ void LagPrediction::GetLaggedPrediction(PredictionObstacles* obstacles) const {
 void LagPrediction::AddObstacleToPrediction(
     double delay_sec, const prediction::PredictionObstacle& history_obstacle,
     prediction::PredictionObstacles* obstacles) const {
-  CHECK_NOTNULL(obstacles);
+  CHECK(obstacles);
 
   auto* obstacle = obstacles->add_prediction_obstacle();
   if (obstacle == nullptr) {

--- a/modules/planning/common/path/path_data.cc
+++ b/modules/planning/common/path/path_data.cc
@@ -101,8 +101,8 @@ bool PathData::GetPathPointWithPathS(
 
 bool PathData::GetPathPointWithRefS(const double ref_s,
                                     common::PathPoint *const path_point) const {
-  DCHECK_NOTNULL(reference_line_);
-  DCHECK_NOTNULL(path_point);
+  DCHECK(reference_line_);
+  DCHECK(path_point);
   DCHECK_EQ(discretized_path_.path_points().size(),
             frenet_path_.points().size());
   if (ref_s < 0) {
@@ -162,7 +162,7 @@ std::string PathData::DebugString() const {
 
 bool PathData::SLToXY(const FrenetFramePath &frenet_path,
                       DiscretizedPath *const discretized_path) {
-  DCHECK_NOTNULL(discretized_path);
+  DCHECK(discretized_path);
   std::vector<common::PathPoint> path_points;
   for (const common::FrenetFramePoint &frenet_point : frenet_path.points()) {
     common::SLPoint sl_point;
@@ -205,8 +205,8 @@ bool PathData::SLToXY(const FrenetFramePath &frenet_path,
 
 bool PathData::XYToSL(const DiscretizedPath &discretized_path,
                       FrenetFramePath *const frenet_path) {
-  CHECK_NOTNULL(frenet_path);
-  CHECK_NOTNULL(reference_line_);
+  CHECK(frenet_path);
+  CHECK(reference_line_);
   std::vector<common::FrenetFramePoint> frenet_frame_points;
   const double max_len = reference_line_->Length();
   for (const auto &path_point : discretized_path.path_points()) {

--- a/modules/planning/common/path_obstacle.cc
+++ b/modules/planning/common/path_obstacle.cc
@@ -62,7 +62,7 @@ const std::unordered_map<ObjectDecisionType::ObjectTagCase, int,
 const std::string& PathObstacle::Id() const { return id_; }
 
 PathObstacle::PathObstacle(const Obstacle* obstacle) : obstacle_(obstacle) {
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   id_ = obstacle_->Id();
 }
 

--- a/modules/planning/common/reference_line_info.cc
+++ b/modules/planning/common/reference_line_info.cc
@@ -434,7 +434,7 @@ std::string ReferenceLineInfo::PathSpeedDebugString() const {
 
 void ReferenceLineInfo::ExportTurnSignal(VehicleSignal* signal) const {
   // set vehicle change lane signal
-  CHECK_NOTNULL(signal);
+  CHECK(signal);
 
   signal->Clear();
   signal->set_turn_signal(VehicleSignal::TURN_NONE);
@@ -537,7 +537,7 @@ void ReferenceLineInfo::ExportDecision(DecisionResult* decision_result) const {
 }
 
 void ReferenceLineInfo::MakeDecision(DecisionResult* decision_result) const {
-  CHECK_NOTNULL(decision_result);
+  CHECK(decision_result);
   decision_result->Clear();
 
   // cruise by default

--- a/modules/planning/common/speed/st_boundary.cc
+++ b/modules/planning/common/speed/st_boundary.cc
@@ -269,8 +269,8 @@ void StBoundary::SetCharacteristicLength(const double characteristic_length) {
 
 bool StBoundary::GetUnblockSRange(const double curr_time, double* s_upper,
                                   double* s_lower) const {
-  CHECK_NOTNULL(s_upper);
-  CHECK_NOTNULL(s_lower);
+  CHECK(s_upper);
+  CHECK(s_lower);
 
   *s_upper = s_high_limit_;
   *s_lower = 0.0;
@@ -310,8 +310,8 @@ bool StBoundary::GetUnblockSRange(const double curr_time, double* s_upper,
 
 bool StBoundary::GetBoundarySRange(const double curr_time, double* s_upper,
                                    double* s_lower) const {
-  CHECK_NOTNULL(s_upper);
-  CHECK_NOTNULL(s_lower);
+  CHECK(s_upper);
+  CHECK(s_lower);
   if (curr_time < min_t_ || curr_time > max_t_) {
     return false;
   }
@@ -343,8 +343,8 @@ double StBoundary::max_t() const { return max_t_; }
 bool StBoundary::GetIndexRange(const std::vector<STPoint>& points,
                                const double t, size_t* left,
                                size_t* right) const {
-  CHECK_NOTNULL(left);
-  CHECK_NOTNULL(right);
+  CHECK(left);
+  CHECK(right);
   if (t < points.front().t() || t > points.back().t()) {
     AERROR << "t is out of range. t = " << t;
     return false;

--- a/modules/planning/common/trajectory/publishable_trajectory.cc
+++ b/modules/planning/common/trajectory/publishable_trajectory.cc
@@ -41,7 +41,7 @@ double PublishableTrajectory::header_time() const { return header_time_; }
 
 void PublishableTrajectory::PopulateTrajectoryProtobuf(
     ADCTrajectory* trajectory_pb) const {
-  CHECK_NOTNULL(trajectory_pb);
+  CHECK(trajectory_pb);
   trajectory_pb->mutable_header()->set_timestamp_sec(header_time_);
   trajectory_pb->mutable_trajectory_point()->CopyFrom(
       {trajectory_points_.begin(), trajectory_points_.end()});

--- a/modules/planning/lattice/trajectory_generation/trajectory1d_generator.h
+++ b/modules/planning/lattice/trajectory_generation/trajectory1d_generator.h
@@ -94,7 +94,7 @@ inline void Trajectory1dGenerator::GenerateTrajectory1DBundle<4>(
     const std::array<double, 3>& init_state,
     const std::vector<std::pair<std::array<double, 3>, double>>& end_conditions,
     std::vector<std::shared_ptr<Curve1d>>* ptr_trajectory_bundle) const {
-  CHECK_NOTNULL(ptr_trajectory_bundle);
+  CHECK(ptr_trajectory_bundle);
   CHECK(!end_conditions.empty());
 
   ptr_trajectory_bundle->reserve(end_conditions.size());
@@ -115,7 +115,7 @@ inline void Trajectory1dGenerator::GenerateTrajectory1DBundle<5>(
     const std::array<double, 3>& init_state,
     const std::vector<std::pair<std::array<double, 3>, double>>& end_conditions,
     std::vector<std::shared_ptr<Curve1d>>* ptr_trajectory_bundle) const {
-  CHECK_NOTNULL(ptr_trajectory_bundle);
+  CHECK(ptr_trajectory_bundle);
   CHECK(!end_conditions.empty());
 
   ptr_trajectory_bundle->reserve(end_conditions.size());

--- a/modules/planning/lattice/trajectory_generation/trajectory_evaluator.cc
+++ b/modules/planning/lattice/trajectory_generation/trajectory_evaluator.cc
@@ -211,7 +211,7 @@ double TrajectoryEvaluator::EvaluateDiscreteTrajectory(
     const std::vector<SpeedPoint>& st_points,
     const std::vector<FrenetFramePoint>& sl_points,
     std::vector<double>* cost_components) {
-  CHECK_NOTNULL(cost_components);
+  CHECK(cost_components);
 
   double lat_offset_cost = LatOffsetCost(sl_points);
   double lat_comfort_cost = LatComfortCost(sl_points);

--- a/modules/planning/math/spiral_curve/cubic_spiral_curve.cc
+++ b/modules/planning/math/spiral_curve/cubic_spiral_curve.cc
@@ -182,7 +182,7 @@ bool CubicSpiralCurve::CalculatePath() {
 
 Status CubicSpiralCurve::GetPathVec(const std::uint32_t n,
                                     std::vector<PathPoint>* path_points) const {
-  CHECK_NOTNULL(path_points);
+  CHECK(path_points);
 
   // initialization
   if (n < 2 || error() > spiral_config().newton_raphson_tol()) {
@@ -241,7 +241,7 @@ Status CubicSpiralCurve::GetPathVec(const std::uint32_t n,
 Status CubicSpiralCurve::GetPathVecWithS(
     const std::vector<double>& vec_s,
     std::vector<PathPoint>* path_points) const {
-  CHECK_NOTNULL(path_points);
+  CHECK(path_points);
 
   if (vec_s.empty() || error() > spiral_config().newton_raphson_tol()) {
     return Status(ErrorCode::PLANNING_ERROR,

--- a/modules/planning/math/spiral_curve/quintic_spiral_curve.cc
+++ b/modules/planning/math/spiral_curve/quintic_spiral_curve.cc
@@ -193,7 +193,7 @@ bool QuinticSpiralCurve::CalculatePath() {
 
 Status QuinticSpiralCurve::GetPathVec(
     const std::uint32_t n, std::vector<common::PathPoint>* path_points) const {
-  CHECK_NOTNULL(path_points);
+  CHECK(path_points);
 
   if (n <= 1 || error() > spiral_config().newton_raphson_tol()) {
     return Status(ErrorCode::PLANNING_ERROR,
@@ -250,7 +250,7 @@ Status QuinticSpiralCurve::GetPathVec(
 Status QuinticSpiralCurve::GetPathVecWithS(
     const std::vector<double>& vec_s,
     std::vector<common::PathPoint>* path_points) const {
-  CHECK_NOTNULL(path_points);
+  CHECK(path_points);
 
   if (error() > spiral_config().newton_raphson_tol()) {
     return Status(ErrorCode::PLANNING_ERROR,

--- a/modules/planning/navi/decider/navi_obstacle_decider.cc
+++ b/modules/planning/navi/decider/navi_obstacle_decider.cc
@@ -250,7 +250,7 @@ void NaviObstacleDecider::RecordLastNudgeDistance(const double nudge_dist) {
 
 void NaviObstacleDecider::SmoothNudgeDistance(
     const common::VehicleState& vehicle_state, double* nudge_dist) {
-  CHECK_NOTNULL(nudge_dist);
+  CHECK(nudge_dist);
   if (vehicle_state.linear_velocity() < config_.max_allow_nudge_speed()) {
     limit_speed_num_ = limit_speed_num_ + 1;
   } else {
@@ -275,7 +275,7 @@ double NaviObstacleDecider::GetNudgeDistance(
     const ReferenceLine& reference_line, const PathDecision& path_decision,
     const std::vector<common::PathPoint>& path_data_points,
     const common::VehicleState& vehicle_state, int* lane_obstacles_num) {
-  CHECK_NOTNULL(lane_obstacles_num);
+  CHECK(lane_obstacles_num);
 
   // Calculating the left and right nudgeable distance on the lane
   double left_nudge_lane = 0.0;

--- a/modules/planning/navi/decider/navi_path_decider.cc
+++ b/modules/planning/navi/decider/navi_path_decider.cc
@@ -99,8 +99,8 @@ apollo::common::Status NaviPathDecider::Process(
     const common::TrajectoryPoint& init_point,
     const std::vector<const Obstacle*>& obstacles,
     PathDecision* const path_decision, PathData* const path_data) {
-  CHECK_NOTNULL(path_decision);
-  CHECK_NOTNULL(path_data);
+  CHECK(path_decision);
+  CHECK(path_data);
   start_plan_point_.set_x(vehicle_state_.x());
   start_plan_point_.set_y(vehicle_state_.y());
   start_plan_point_.set_theta(vehicle_state_.heading());
@@ -234,7 +234,7 @@ void NaviPathDecider::RecordDebugInfo(const PathData& path_data) {
 bool NaviPathDecider::GetBasicPathData(
     const ReferenceLine& reference_line,
     std::vector<common::PathPoint>* const path_points) {
-  CHECK_NOTNULL(path_points);
+  CHECK(path_points);
 
   double min_path_len = config_.min_path_length();
   // get min path plan lenth s = v0 * t + 1 / 2.0 * a * t^2

--- a/modules/planning/navi/decider/navi_path_decider_test.cc
+++ b/modules/planning/navi/decider/navi_path_decider_test.cc
@@ -42,7 +42,7 @@ class NaviPathDeciderTest : public ::testing::Test {
   static void GeneratePathData(
       double s, double init_y, double kappa,
       std::vector<common::PathPoint>* const path_points) {
-    DCHECK_NOTNULL(path_points);
+    DCHECK(path_points);
     for (double x = 0.0, y = init_y; x < s; ++x) {
       path_points->clear();
       auto path_point = MakePathPoint(x, y, 0.0, 0.0, kappa, 0.0, 0.0);
@@ -51,12 +51,12 @@ class NaviPathDeciderTest : public ::testing::Test {
   }
 
   static void InitPlannigConfig(PlanningConfig* const plannig_config) {
-    DCHECK_NOTNULL(plannig_config);
+    DCHECK(plannig_config);
     auto* navi_planner_config = plannig_config->mutable_planner_navi_config();
-    DCHECK_NOTNULL(navi_planner_config);
+    DCHECK(navi_planner_config);
     auto* navi_path_decider_config =
         navi_planner_config->mutable_navi_path_decider_config();
-    DCHECK_NOTNULL(navi_path_decider_config);
+    DCHECK(navi_path_decider_config);
     navi_path_decider_config->set_min_path_length(5.0);
     navi_path_decider_config->set_min_look_forward_time(2.0);
     navi_path_decider_config->set_max_keep_lane_distance(0.4);
@@ -67,9 +67,9 @@ class NaviPathDeciderTest : public ::testing::Test {
     navi_path_decider_config->clear_move_dest_lane_config_talbe();
     auto* move_dest_lane_cfg_table =
         navi_path_decider_config->mutable_move_dest_lane_config_talbe();
-    DCHECK_NOTNULL(move_dest_lane_cfg_table);
+    DCHECK(move_dest_lane_cfg_table);
     auto* move_shift_config = move_dest_lane_cfg_table->add_lateral_shift();
-    DCHECK_NOTNULL(move_shift_config);
+    DCHECK(move_shift_config);
     move_shift_config->set_max_speed(34);
     move_shift_config->set_max_move_dest_lane_shift_y(0.45);
   }
@@ -158,8 +158,8 @@ TEST_F(NaviPathDeciderTest, KeepLane) {
       vehicle_state, plan_start_point, ref_line, route_segments);
   navi_path_decider.frame_ =
       new Frame(1, plan_start_point, 0, vehicle_state, nullptr);
-  DCHECK_NOTNULL(navi_path_decider.reference_line_info_);
-  DCHECK_NOTNULL(navi_path_decider.frame_);
+  DCHECK(navi_path_decider.reference_line_info_);
+  DCHECK(navi_path_decider.frame_);
   GeneratePathData(kMaxS, 0.19, 0.03, &path_points);
   dest_y = path_points[0].y();
   expect_y = path_points[0].y();

--- a/modules/planning/navi/decider/navi_speed_decider.cc
+++ b/modules/planning/navi/decider/navi_speed_decider.cc
@@ -251,7 +251,7 @@ Status NaviSpeedDecider::MakeSpeedDecision(
     const std::vector<const Obstacle*>& obstacles,
     const std::function<const Obstacle*(const std::string&)>& find_obstacle,
     SpeedData* const speed_data) {
-  CHECK_NOTNULL(speed_data);
+  CHECK(speed_data);
   CHECK_GE(path_points.size(), 2);
 
   auto start_s = path_points.front().has_s() ? path_points.front().s() : 0.0;

--- a/modules/planning/navi/decider/navi_speed_ts_graph.cc
+++ b/modules/planning/navi/decider/navi_speed_ts_graph.cc
@@ -191,7 +191,7 @@ void NaviSpeedTsGraph::UpdateObstacleConstraints(double distance,
 }
 
 Status NaviSpeedTsGraph::Solve(std::vector<NaviSpeedTsPoint>* output) {
-  CHECK_NOTNULL(output);
+  CHECK(output);
 
   // make constraints of the first point
   auto& constraints = constraints_[0];

--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -220,7 +220,7 @@ std::string NaviPlanning::GetCurrentLaneId() {
 
 void NaviPlanning::GetLeftNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  DCHECK_NOTNULL(lane_info_group);
+  DCHECK(lane_info_group);
   auto& ref_line_info_group = frame_->reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {
@@ -248,7 +248,7 @@ void NaviPlanning::GetLeftNeighborLanesInfo(
 
 void NaviPlanning::GetRightNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  DCHECK_NOTNULL(lane_info_group);
+  DCHECK(lane_info_group);
   auto& ref_line_info_group = frame_->reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {
@@ -487,7 +487,7 @@ void NaviPlanning::RunOnce() {
 }
 
 void NaviPlanning::SetFallbackTrajectory(ADCTrajectory* trajectory_pb) {
-  CHECK_NOTNULL(trajectory_pb);
+  CHECK(trajectory_pb);
 
   const double v = VehicleStateProvider::instance()->linear_velocity();
   for (double t = 0.0; t < FLAGS_navigation_fallback_cruise_time; t += 0.1) {

--- a/modules/planning/planner/planner.h
+++ b/modules/planning/planner/planner.h
@@ -92,7 +92,7 @@ class PlannerWithReferenceLine : public Planner {
   virtual apollo::common::Status PlanOnReferenceLine(
       const common::TrajectoryPoint& planning_init_point, Frame* frame,
       ReferenceLineInfo* reference_line_info) {
-    CHECK_NOTNULL(frame);
+    CHECK(frame);
     return apollo::common::Status::OK();
   }
 };

--- a/modules/planning/planning_base.cc
+++ b/modules/planning/planning_base.cc
@@ -106,7 +106,7 @@ void PlanningBase::PublishPlanningPb(ADCTrajectory* trajectory_pb,
 }
 
 void PlanningBase::SetFallbackTrajectory(ADCTrajectory* trajectory_pb) {
-  CHECK_NOTNULL(trajectory_pb);
+  CHECK(trajectory_pb);
   // use planning trajecotry from last cycle
   auto* last_planning = AdapterManager::GetPlanning();
   if (last_planning != nullptr && !last_planning->Empty()) {

--- a/modules/planning/reference_line/reference_line.cc
+++ b/modules/planning/reference_line/reference_line.cc
@@ -319,7 +319,7 @@ ReferencePoint ReferenceLine::GetReferencePoint(const double x,
 
 bool ReferenceLine::SLToXY(const SLPoint& sl_point,
                            common::math::Vec2d* const xy_point) const {
-  CHECK_NOTNULL(xy_point);
+  CHECK(xy_point);
   if (map_path_.num_points() < 2) {
     AERROR << "The reference line has too few points.";
     return false;
@@ -334,7 +334,7 @@ bool ReferenceLine::SLToXY(const SLPoint& sl_point,
 
 bool ReferenceLine::XYToSL(const common::math::Vec2d& xy_point,
                            SLPoint* const sl_point) const {
-  DCHECK_NOTNULL(sl_point);
+  DCHECK(sl_point);
   double s = 0.0;
   double l = 0.0;
   if (!map_path_.GetProjection(xy_point, &s, &l)) {
@@ -425,7 +425,7 @@ bool ReferenceLine::GetRoadWidth(const double s, double* const road_left_width,
 
 void ReferenceLine::GetLaneFromS(
     const double s, std::vector<hdmap::LaneInfoConstPtr>* lanes) const {
-  CHECK_NOTNULL(lanes);
+  CHECK(lanes);
   auto ref_point = GetReferencePoint(s);
   std::unordered_set<hdmap::LaneInfoConstPtr> lane_set;
   for (auto& lane_waypoint : ref_point.lane_waypoints()) {

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -210,8 +210,8 @@ double ReferenceLineProvider::LastTimeDelay() {
 bool ReferenceLineProvider::GetReferenceLines(
     std::list<ReferenceLine> *reference_lines,
     std::list<hdmap::RouteSegments> *segments) {
-  CHECK_NOTNULL(reference_lines);
-  CHECK_NOTNULL(segments);
+  CHECK(reference_lines);
+  CHECK(segments);
 
   if (FLAGS_use_navigation_mode) {
     double start_time = Clock::NowInSeconds();
@@ -257,7 +257,7 @@ bool ReferenceLineProvider::GetReferenceLines(
 
 void ReferenceLineProvider::PrioritzeChangeLane(
     std::list<hdmap::RouteSegments> *route_segments) {
-  CHECK_NOTNULL(route_segments);
+  CHECK(route_segments);
   auto iter = route_segments->begin();
   while (iter != route_segments->end()) {
     if (!iter->IsOnSegment()) {
@@ -273,8 +273,8 @@ bool ReferenceLineProvider::GetReferenceLinesFromRelativeMap(
     std::list<ReferenceLine> *reference_lines,
     std::list<hdmap::RouteSegments> *segments) {
   DCHECK_GE(relative_map.navigation_path_size(), 0);
-  DCHECK_NOTNULL(reference_lines);
-  DCHECK_NOTNULL(segments);
+  DCHECK(reference_lines);
+  DCHECK(segments);
 
   if (relative_map.navigation_path().empty()) {
     AERROR << "There isn't any navigation path in current relative map.";
@@ -536,8 +536,8 @@ bool ReferenceLineProvider::CreateRouteSegments(
 bool ReferenceLineProvider::CreateReferenceLine(
     std::list<ReferenceLine> *reference_lines,
     std::list<hdmap::RouteSegments> *segments) {
-  CHECK_NOTNULL(reference_lines);
-  CHECK_NOTNULL(segments);
+  CHECK(reference_lines);
+  CHECK(segments);
 
   common::VehicleState vehicle_state;
   {
@@ -783,7 +783,7 @@ AnchorPoint ReferenceLineProvider::GetAnchorPoint(
 void ReferenceLineProvider::GetAnchorPoints(
     const ReferenceLine &reference_line,
     std::vector<AnchorPoint> *anchor_points) const {
-  CHECK_NOTNULL(anchor_points);
+  CHECK(anchor_points);
   const double interval = smoother_config_.max_constraint_interval();
   int num_of_anchors =
       std::max(2, static_cast<int>(reference_line.Length() / interval + 0.5));

--- a/modules/planning/reference_line/reference_point.cc
+++ b/modules/planning/reference_line/reference_point.cc
@@ -60,7 +60,7 @@ std::string ReferencePoint::DebugString() const {
 }
 
 void ReferencePoint::RemoveDuplicates(std::vector<ReferencePoint>* points) {
-  CHECK_NOTNULL(points);
+  CHECK(points);
   int count = 0;
   const double limit = kDuplicatedPointsEpsilon * kDuplicatedPointsEpsilon;
   for (size_t i = 0; i < points->size(); ++i) {

--- a/modules/planning/toolkits/deciders/creeper.cc
+++ b/modules/planning/toolkits/deciders/creeper.cc
@@ -63,7 +63,7 @@ bool Creeper::BuildStopDecision(const PathOverlap& overlap,
                                 const double max_creeping_target_distance,
                                 Frame* frame,
                                 ReferenceLineInfo* reference_line_info) {
-  CHECK_NOTNULL(frame);
+  CHECK(frame);
 
   // check
   const auto& reference_line = reference_line_info->reference_line();

--- a/modules/planning/toolkits/deciders/crosswalk.cc
+++ b/modules/planning/toolkits/deciders/crosswalk.cc
@@ -59,8 +59,8 @@ Crosswalk::Crosswalk(const TrafficRuleConfig& config) : TrafficRule(config) {}
 
 Status Crosswalk::ApplyRule(Frame* const frame,
                             ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   if (!FindCrosswalks(reference_line_info)) {
     GetPlanningStatus()->clear_crosswalk();
@@ -73,8 +73,8 @@ Status Crosswalk::ApplyRule(Frame* const frame,
 
 void Crosswalk::MakeDecisions(Frame* const frame,
                               ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   auto* path_decision = reference_line_info->path_decision();
   double adc_front_edge_s = reference_line_info->AdcSlBoundary().end_s();
@@ -319,7 +319,7 @@ void Crosswalk::MakeDecisions(Frame* const frame,
 }
 
 bool Crosswalk::FindCrosswalks(ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   crosswalk_overlaps_.clear();
   const std::vector<hdmap::PathOverlap>& crosswalk_overlaps =
@@ -338,9 +338,9 @@ int Crosswalk::BuildStopDecision(Frame* const frame,
                                  ReferenceLineInfo* const reference_line_info,
                                  hdmap::PathOverlap* const crosswalk_overlap,
                                  std::vector<std::string> pedestrians) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
-  CHECK_NOTNULL(crosswalk_overlap);
+  CHECK(frame);
+  CHECK(reference_line_info);
+  CHECK(crosswalk_overlap);
 
   // check
   const auto& reference_line = reference_line_info->reference_line();

--- a/modules/planning/toolkits/deciders/destination.cc
+++ b/modules/planning/toolkits/deciders/destination.cc
@@ -42,8 +42,8 @@ Destination::Destination(const TrafficRuleConfig& config)
 
 Status Destination::ApplyRule(Frame* frame,
                               ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   if (!frame->is_near_destination()) {
     return Status::OK();
@@ -73,8 +73,8 @@ Status Destination::ApplyRule(Frame* frame,
  */
 int Destination::BuildStopDecision(
     Frame* frame, ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   const auto& routing =
       AdapterManager::GetRoutingResponse()->GetLatestObserved();
@@ -122,8 +122,8 @@ int Destination::BuildStopDecision(
 int Destination::Stop(Frame* const frame,
                       ReferenceLineInfo* const reference_line_info,
                       const std::string lane_id, const double lane_s) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   const auto& reference_line = reference_line_info->reference_line();
 
@@ -174,7 +174,7 @@ bool Destination::CheckPullOver(ReferenceLineInfo* const reference_line_info,
                                 const std::string& dest_lane_id,
                                 const double dest_lane_s,
                                 common::PointENU* dest_point) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   if (!config_.destination().enable_pull_over()) {
     return false;

--- a/modules/planning/toolkits/deciders/front_vehicle.cc
+++ b/modules/planning/toolkits/deciders/front_vehicle.cc
@@ -48,8 +48,8 @@ FrontVehicle::FrontVehicle(const TrafficRuleConfig& config)
 
 Status FrontVehicle::ApplyRule(Frame* const frame,
                                ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   MakeDecisions(frame, reference_line_info);
 
@@ -61,8 +61,8 @@ Status FrontVehicle::ApplyRule(Frame* const frame,
  */
 void FrontVehicle::MakeDecisions(Frame* frame,
                                  ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   MakeSidePassDecision(reference_line_info);
 
@@ -74,7 +74,7 @@ void FrontVehicle::MakeDecisions(Frame* frame,
  */
 bool FrontVehicle::MakeSidePassDecision(
     ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   if (!config_.front_vehicle().enable_side_pass()) {
     return true;
@@ -108,7 +108,7 @@ bool FrontVehicle::MakeSidePassDecision(
 
 bool FrontVehicle::ProcessSidePass(
     ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   // find obstacle being blocked, to process SIDEPASS
   std::string passable_obstacle_id = FindPassableObstacle(reference_line_info);
@@ -226,7 +226,7 @@ bool FrontVehicle::ProcessSidePass(
  */
 std::string FrontVehicle::FindPassableObstacle(
     ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   std::string passable_obstacle_id;
   const auto& adc_sl_boundary = reference_line_info->AdcSlBoundary();

--- a/modules/planning/toolkits/deciders/keep_clear.cc
+++ b/modules/planning/toolkits/deciders/keep_clear.cc
@@ -36,8 +36,8 @@ KeepClear::KeepClear(const TrafficRuleConfig& config) : TrafficRule(config) {}
 
 Status KeepClear::ApplyRule(Frame* const frame,
                             ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   // keep_clear zone
   if (config_.keep_clear().enable_keep_clear_zone()) {
@@ -83,9 +83,9 @@ bool KeepClear::BuildKeepClearObstacle(
     Frame* const frame, ReferenceLineInfo* const reference_line_info,
     PathOverlap* const keep_clear_overlap,
     const std::string& virtual_obstacle_id) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
-  CHECK_NOTNULL(keep_clear_overlap);
+  CHECK(frame);
+  CHECK(reference_line_info);
+  CHECK(keep_clear_overlap);
 
   // check
   const double adc_front_edge_s = reference_line_info->AdcSlBoundary().end_s();

--- a/modules/planning/toolkits/deciders/pull_over.cc
+++ b/modules/planning/toolkits/deciders/pull_over.cc
@@ -401,7 +401,7 @@ int PullOver::FindPullOverStop(PointENU* stop_point) {
     for (const auto& neighbor_lane_id :
          lane->lane().right_neighbor_forward_lane_id()) {
       const auto hdmap_ptr = HDMapUtil::BaseMapPtr();
-      CHECK_NOTNULL(hdmap_ptr);
+      CHECK(hdmap_ptr);
       const auto& neighbor_lane = hdmap_ptr->GetLaneById(neighbor_lane_id);
       if (!neighbor_lane) {
         ADEBUG << "Failed to find lane[" << neighbor_lane_id.id() << "]";

--- a/modules/planning/toolkits/deciders/signal_light.cc
+++ b/modules/planning/toolkits/deciders/signal_light.cc
@@ -146,7 +146,7 @@ void SignalLight::MakeDecisions(Frame* const frame,
 void SignalLight::SetCreepForwardSignalDecision(
     ReferenceLineInfo* const reference_line_info,
     hdmap::PathOverlap* const signal_light) const {
-  CHECK_NOTNULL(signal_light);
+  CHECK(signal_light);
 
   if (EgoInfo::instance()->start_point().v() >
       config_.signal_light().righ_turn_creep().speed_limit()) {

--- a/modules/planning/toolkits/deciders/stop_sign.cc
+++ b/modules/planning/toolkits/deciders/stop_sign.cc
@@ -59,8 +59,8 @@ StopSign::StopSign(const TrafficRuleConfig& config) : TrafficRule(config) {}
 
 Status StopSign::ApplyRule(Frame* const frame,
                            ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   if (!FindNextStopSign(reference_line_info)) {
     GetPlanningStatus()->clear_stop_sign();
@@ -77,8 +77,8 @@ Status StopSign::ApplyRule(Frame* const frame,
  */
 void StopSign::MakeDecisions(Frame* frame,
                              ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   StopSignLaneVehicles watch_vehicles;
   GetWatchVehicles(*next_stop_sign_, &watch_vehicles);
@@ -162,7 +162,7 @@ void StopSign::MakeDecisions(Frame* frame,
  * @brief: fine next stop sign ahead of adc along reference line
  */
 bool StopSign::FindNextStopSign(ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   StopSignStatus stop_sign_status = GetPlanningStatus()->stop_sign();
   const std::vector<PathOverlap>& stop_sign_overlaps =
@@ -306,7 +306,7 @@ bool StopSign::CheckCreepDone(ReferenceLineInfo* const reference_line_info) {
 int StopSign::ProcessStopStatus(ReferenceLineInfo* const reference_line_info,
                                 const StopSignInfo& stop_sign_info,
                                 StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   // get stop status from PlanningStatus
   auto* stop_sign_status = GetPlanningStatus()->mutable_stop_sign();
@@ -387,7 +387,7 @@ int StopSign::ProcessStopStatus(ReferenceLineInfo* const reference_line_info,
  * @brief: check valid stop_sign stop
  */
 bool StopSign::CheckADCkStop(ReferenceLineInfo* const reference_line_info) {
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(reference_line_info);
 
   double adc_speed =
       common::VehicleStateProvider::instance()->linear_velocity();
@@ -422,7 +422,7 @@ bool StopSign::CheckADCkStop(ReferenceLineInfo* const reference_line_info) {
  */
 void StopSign::GetWatchVehicles(const StopSignInfo& stop_sign_info,
                                 StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(watch_vehicles);
+  CHECK(watch_vehicles);
 
   watch_vehicles->clear();
 
@@ -445,7 +445,7 @@ void StopSign::GetWatchVehicles(const StopSignInfo& stop_sign_info,
  * @brief: update PlanningStatus with watch vehicles
  */
 void StopSign::UpdateWatchVehicles(StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(watch_vehicles);
+  CHECK(watch_vehicles);
 
   auto* stop_sign_status = GetPlanningStatus()->mutable_stop_sign();
   stop_sign_status->clear_lane_watch_vehicles();
@@ -469,7 +469,7 @@ void StopSign::UpdateWatchVehicles(StopSignLaneVehicles* watch_vehicles) {
  */
 int StopSign::AddWatchVehicle(const PathObstacle& path_obstacle,
                               StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(watch_vehicles);
+  CHECK(watch_vehicles);
 
   const PerceptionObstacle& perception_obstacle =
       path_obstacle.obstacle()->Perception();
@@ -567,7 +567,7 @@ int StopSign::RemoveWatchVehicle(
     const PathObstacle& path_obstacle,
     const std::vector<std::string>& watch_vehicle_ids,
     StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(watch_vehicles);
+  CHECK(watch_vehicles);
 
   const PerceptionObstacle& perception_obstacle =
       path_obstacle.obstacle()->Perception();
@@ -685,8 +685,8 @@ int StopSign::RemoveWatchVehicle(
 
 int StopSign::ClearWatchVehicle(ReferenceLineInfo* const reference_line_info,
                                 StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(reference_line_info);
-  CHECK_NOTNULL(watch_vehicles);
+  CHECK(reference_line_info);
+  CHECK(watch_vehicles);
 
   const auto& path_obstacles =
       reference_line_info->path_decision()->path_obstacles().Items();
@@ -745,8 +745,8 @@ int StopSign::BuildStopDecision(Frame* frame,
                                 const double stop_line_s,
                                 const double stop_distance,
                                 StopSignLaneVehicles* watch_vehicles) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   // check
   const auto& reference_line = reference_line_info->reference_line();

--- a/modules/planning/toolkits/deciders/traffic_decider.cc
+++ b/modules/planning/toolkits/deciders/traffic_decider.cc
@@ -146,8 +146,8 @@ void TrafficDecider::BuildPlanningTarget(
 
 Status TrafficDecider::Execute(Frame *frame,
                                ReferenceLineInfo *reference_line_info) {
-  CHECK_NOTNULL(frame);
-  CHECK_NOTNULL(reference_line_info);
+  CHECK(frame);
+  CHECK(reference_line_info);
 
   for (const auto &rule_config : rule_configs_.config()) {
     if (!rule_config.enabled()) {

--- a/modules/planning/toolkits/optimizers/dp_poly_path/dp_poly_path_optimizer.cc
+++ b/modules/planning/toolkits/optimizers/dp_poly_path/dp_poly_path_optimizer.cc
@@ -53,7 +53,7 @@ Status DpPolyPathOptimizer::Process(const SpeedData &speed_data,
     AERROR << "Please call Init() before Process().";
     return Status(ErrorCode::PLANNING_ERROR, "Not inited.");
   }
-  CHECK_NOTNULL(path_data);
+  CHECK(path_data);
   DpRoadGraph dp_road_graph(config_, *reference_line_info_, speed_data);
   dp_road_graph.SetDebugLogger(reference_line_info_->mutable_debug());
   dp_road_graph.SetWaypointSampler(

--- a/modules/planning/toolkits/optimizers/path_decider/path_decider.cc
+++ b/modules/planning/toolkits/optimizers/path_decider/path_decider.cc
@@ -50,7 +50,7 @@ apollo::common::Status PathDecider::Execute(
 
 Status PathDecider::Process(const PathData &path_data,
                             PathDecision *const path_decision) {
-  CHECK_NOTNULL(path_decision);
+  CHECK(path_decision);
   if (!MakeObjectDecision(path_data, path_decision)) {
     AERROR << "Failed to make decision based on tunnel";
     return Status(ErrorCode::PLANNING_ERROR, "dp_road_graph decision ");
@@ -60,7 +60,7 @@ Status PathDecider::Process(const PathData &path_data,
 
 bool PathDecider::MakeObjectDecision(const PathData &path_data,
                                      PathDecision *const path_decision) {
-  DCHECK_NOTNULL(path_decision);
+  DCHECK(path_decision);
   if (!MakeStaticObstacleDecision(path_data, path_decision)) {
     AERROR << "Failed to make decisions for static obstacles";
     return false;
@@ -70,7 +70,7 @@ bool PathDecider::MakeObjectDecision(const PathData &path_data,
 
 bool PathDecider::MakeStaticObstacleDecision(
     const PathData &path_data, PathDecision *const path_decision) {
-  DCHECK_NOTNULL(path_decision);
+  DCHECK(path_decision);
   const auto &frenet_path = path_data.frenet_frame_path();
   const auto &frenet_points = frenet_path.points();
   if (frenet_points.empty()) {

--- a/modules/planning/toolkits/optimizers/poly_st_speed/poly_st_graph.cc
+++ b/modules/planning/toolkits/optimizers/poly_st_speed/poly_st_graph.cc
@@ -53,7 +53,7 @@ bool PolyStGraph::FindStTunnel(
     const common::TrajectoryPoint &init_point,
     const std::vector<const PathObstacle *> &obstacles,
     SpeedData *const speed_data) {
-  CHECK_NOTNULL(speed_data);
+  CHECK(speed_data);
 
   // set init point
   init_point_ = init_point;
@@ -90,7 +90,7 @@ bool PolyStGraph::GenerateMinCostSpeedProfile(
     const std::vector<std::vector<STPoint>> &points,
     const std::vector<const PathObstacle *> &obstacles,
     PolyStGraphNode *const min_cost_node) {
-  CHECK_NOTNULL(min_cost_node);
+  CHECK(min_cost_node);
   PolyStGraphNode start_node = {STPoint(0.0, 0.0), init_point_.v(),
                                 init_point_.a()};
   SpeedProfileCost cost(config_, obstacles, speed_limit_, init_point_);
@@ -119,7 +119,7 @@ bool PolyStGraph::GenerateMinCostSpeedProfile(
 
 bool PolyStGraph::SampleStPoints(
     std::vector<std::vector<STPoint>> *const points) {
-  CHECK_NOTNULL(points);
+  CHECK(points);
   constexpr double start_t = 6.0;
   constexpr double start_s = 0.0;
   for (double t = start_t; t <= planning_time_; t += unit_t_) {

--- a/modules/planning/toolkits/optimizers/qp_spline_path/qp_frenet_frame.cc
+++ b/modules/planning/toolkits/optimizers/qp_spline_path/qp_frenet_frame.cc
@@ -266,7 +266,7 @@ bool QpFrenetFrame::MapNudgeLine(
     const common::SLPoint& start, const common::SLPoint& end,
     const ObjectNudge::Type nudge_type,
     std::vector<std::pair<double, double>>* const constraint) {
-  DCHECK_NOTNULL(constraint);
+  DCHECK(constraint);
 
   const common::SLPoint& near_point = (start.s() < end.s() ? start : end);
   const common::SLPoint& further_point = (start.s() < end.s() ? end : start);

--- a/modules/planning/toolkits/optimizers/qp_spline_st_speed/qp_piecewise_st_graph.cc
+++ b/modules/planning/toolkits/optimizers/qp_spline_st_speed/qp_piecewise_st_graph.cc
@@ -218,7 +218,7 @@ Status QpPiecewiseStGraph::AddKernel(
     const std::vector<const StBoundary*>& boundaries,
     const SpeedLimit& speed_limit) {
   auto* kernel = generator_->mutable_kernel();
-  DCHECK_NOTNULL(kernel);
+  DCHECK(kernel);
 
   if (qp_st_speed_config_.qp_piecewise_config().accel_kernel_weight() > 0) {
     kernel->AddSecondOrderDerivativeMatrix(
@@ -369,7 +369,7 @@ Status QpPiecewiseStGraph::EstimateSpeedUpperBound(
     const common::TrajectoryPoint& init_point, const SpeedLimit& speed_limit,
     std::vector<double>* speed_upper_bound) const {
   // TODO(Lianliang): define a QpStGraph class and move this function in it.
-  DCHECK_NOTNULL(speed_upper_bound);
+  DCHECK(speed_upper_bound);
 
   speed_upper_bound->clear();
 

--- a/modules/planning/toolkits/optimizers/qp_spline_st_speed/qp_spline_st_graph.cc
+++ b/modules/planning/toolkits/optimizers/qp_spline_st_speed/qp_spline_st_graph.cc
@@ -525,7 +525,7 @@ const SpeedData QpSplineStGraph::GetHistorySpeed() const {
 Status QpSplineStGraph::EstimateSpeedUpperBound(
     const common::TrajectoryPoint& init_point, const SpeedLimit& speed_limit,
     std::vector<double>* speed_upper_bound) const {
-  DCHECK_NOTNULL(speed_upper_bound);
+  DCHECK(speed_upper_bound);
 
   speed_upper_bound->clear();
 

--- a/modules/planning/toolkits/optimizers/road_graph/dp_road_graph.cc
+++ b/modules/planning/toolkits/optimizers/road_graph/dp_road_graph.cc
@@ -60,7 +60,7 @@ bool DpRoadGraph::FindPathTunnel(
     const common::TrajectoryPoint &init_point,
     const std::vector<const PathObstacle *> &obstacles,
     PathData *const path_data) {
-  CHECK_NOTNULL(path_data);
+  CHECK(path_data);
 
   init_point_ = init_point;
   if (!reference_line_.XYToSL(
@@ -210,9 +210,9 @@ void DpRoadGraph::UpdateNode(const std::list<DpRoadGraphNode> &prev_nodes,
                              TrajectoryCost *trajectory_cost,
                              DpRoadGraphNode *front,
                              DpRoadGraphNode *cur_node) {
-  DCHECK_NOTNULL(trajectory_cost);
-  DCHECK_NOTNULL(front);
-  DCHECK_NOTNULL(cur_node);
+  DCHECK(trajectory_cost);
+  DCHECK(front);
+  DCHECK(cur_node);
   for (const auto &prev_dp_node : prev_nodes) {
     const auto &prev_sl_point = prev_dp_node.sl_point;
     const auto &cur_point = cur_node->sl_point;

--- a/modules/planning/toolkits/optimizers/road_graph/side_pass_waypoint_sampler.cc
+++ b/modules/planning/toolkits/optimizers/road_graph/side_pass_waypoint_sampler.cc
@@ -43,7 +43,7 @@ using apollo::common::util::MakeSLPoint;
 bool SidePassWaypointSampler::SamplePathWaypoints(
     const common::TrajectoryPoint &init_point,
     std::vector<std::vector<common::SLPoint>> *const points) {
-  CHECK_NOTNULL(points);
+  CHECK(points);
 
   const float kMinSampleDistance = 40.0;
   const float total_length = std::fmin(

--- a/modules/planning/toolkits/optimizers/road_graph/waypoint_sampler.cc
+++ b/modules/planning/toolkits/optimizers/road_graph/waypoint_sampler.cc
@@ -52,7 +52,7 @@ void WaypointSampler::Init(
 bool WaypointSampler::SamplePathWaypoints(
     const common::TrajectoryPoint &init_point,
     std::vector<std::vector<common::SLPoint>> *const points) {
-  CHECK_NOTNULL(points);
+  CHECK(points);
 
   const float kMinSampleDistance = 40.0;
   const float total_length = std::fmin(

--- a/modules/planning/toolkits/optimizers/side_pass_path/side_pass_path_optimizer.cc
+++ b/modules/planning/toolkits/optimizers/side_pass_path/side_pass_path_optimizer.cc
@@ -53,7 +53,7 @@ Status SidePassPathOptimizer::Process(const SpeedData &speed_data,
     AERROR << "Please call Init() before Process().";
     return Status(ErrorCode::PLANNING_ERROR, "Not inited.");
   }
-  CHECK_NOTNULL(path_data);
+  CHECK(path_data);
   DpRoadGraph dp_road_graph(config_, *reference_line_info_, speed_data);
   dp_road_graph.SetDebugLogger(reference_line_info_->mutable_debug());
   dp_road_graph.SetWaypointSampler(

--- a/modules/planning/toolkits/optimizers/speed_decider/speed_decider.cc
+++ b/modules/planning/toolkits/optimizers/speed_decider/speed_decider.cc
@@ -263,7 +263,7 @@ void SpeedDecider::AppendIgnoreDecision(PathObstacle* path_obstacle) const {
 bool SpeedDecider::CreateStopDecision(const PathObstacle& path_obstacle,
                                       ObjectDecisionType* const stop_decision,
                                       double stop_distance) const {
-  DCHECK_NOTNULL(stop_decision);
+  DCHECK(stop_decision);
 
   const auto& boundary = path_obstacle.st_boundary();
   const double fence_s =
@@ -302,7 +302,7 @@ bool SpeedDecider::CreateStopDecision(const PathObstacle& path_obstacle,
 bool SpeedDecider::CreateFollowDecision(
     const PathObstacle& path_obstacle,
     ObjectDecisionType* const follow_decision) const {
-  DCHECK_NOTNULL(follow_decision);
+  DCHECK(follow_decision);
 
   const double follow_speed = init_point_.v();
   const double follow_distance_s = -std::fmax(
@@ -341,7 +341,7 @@ bool SpeedDecider::CreateFollowDecision(
 bool SpeedDecider::CreateYieldDecision(
     const PathObstacle& path_obstacle,
     ObjectDecisionType* const yield_decision) const {
-  DCHECK_NOTNULL(yield_decision);
+  DCHECK(yield_decision);
 
   PerceptionObstacle::Type obstacle_type =
       path_obstacle.obstacle()->Perception().type();
@@ -389,7 +389,7 @@ bool SpeedDecider::CreateYieldDecision(
 bool SpeedDecider::CreateOvertakeDecision(
     const PathObstacle& path_obstacle,
     ObjectDecisionType* const overtake_decision) const {
-  DCHECK_NOTNULL(overtake_decision);
+  DCHECK(overtake_decision);
 
   constexpr double kOvertakeTimeBuffer = 3.0;    // in seconds
   constexpr double kMinOvertakeDistance = 10.0;  // in meters

--- a/modules/planning/toolkits/optimizers/st_graph/speed_limit_decider.cc
+++ b/modules/planning/toolkits/optimizers/st_graph/speed_limit_decider.cc
@@ -53,7 +53,7 @@ SpeedLimitDecider::SpeedLimitDecider(const SLBoundary& adc_sl_boundary,
 void SpeedLimitDecider::GetAvgKappa(
     const std::vector<common::PathPoint>& path_points,
     std::vector<double>* kappa) const {
-  CHECK_NOTNULL(kappa);
+  CHECK(kappa);
   const int kHalfNumPoints = st_boundary_config_.num_points_to_avg_kappa() / 2;
   CHECK_GT(kHalfNumPoints, 0);
   kappa->clear();
@@ -85,7 +85,7 @@ void SpeedLimitDecider::GetAvgKappa(
 Status SpeedLimitDecider::GetSpeedLimits(
     const IndexedList<std::string, PathObstacle>& path_obstacles,
     SpeedLimit* const speed_limit_data) const {
-  CHECK_NOTNULL(speed_limit_data);
+  CHECK(speed_limit_data);
 
   std::vector<double> avg_kappa;
   GetAvgKappa(path_data_.discretized_path().path_points(), &avg_kappa);

--- a/modules/planning/toolkits/optimizers/st_graph/st_boundary_mapper.cc
+++ b/modules/planning/toolkits/optimizers/st_graph/st_boundary_mapper.cc
@@ -328,8 +328,8 @@ bool StBoundaryMapper::GetOverlapBoundaryPoints(
     const std::vector<PathPoint>& path_points, const Obstacle& obstacle,
     std::vector<STPoint>* upper_points,
     std::vector<STPoint>* lower_points) const {
-  DCHECK_NOTNULL(upper_points);
-  DCHECK_NOTNULL(lower_points);
+  DCHECK(upper_points);
+  DCHECK(lower_points);
   DCHECK(upper_points->empty());
   DCHECK(lower_points->empty());
   DCHECK_GT(path_points.size(), 0);

--- a/modules/prediction/evaluator/evaluator_manager.cc
+++ b/modules/prediction/evaluator/evaluator_manager.cc
@@ -94,7 +94,7 @@ void EvaluatorManager::Run(
   ObstaclesContainer* container = dynamic_cast<ObstaclesContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PERCEPTION_OBSTACLES));
-  CHECK_NOTNULL(container);
+  CHECK(container);
 
   Evaluator* evaluator = nullptr;
   for (const auto& perception_obstacle :
@@ -119,14 +119,14 @@ void EvaluatorManager::Run(
       case PerceptionObstacle::VEHICLE: {
         if (obstacle->IsOnLane()) {
           evaluator = GetEvaluator(vehicle_on_lane_evaluator_);
-          CHECK_NOTNULL(evaluator);
+          CHECK(evaluator);
         }
         break;
       }
       case PerceptionObstacle::BICYCLE: {
         if (obstacle->IsOnLane()) {
           evaluator = GetEvaluator(cyclist_on_lane_evaluator_);
-          CHECK_NOTNULL(evaluator);
+          CHECK(evaluator);
         }
         break;
       }
@@ -136,7 +136,7 @@ void EvaluatorManager::Run(
       default: {
         if (obstacle->IsOnLane()) {
           evaluator = GetEvaluator(default_on_lane_evaluator_);
-          CHECK_NOTNULL(evaluator);
+          CHECK(evaluator);
         }
         break;
       }

--- a/modules/prediction/evaluator/evaluator_manager_test.cc
+++ b/modules/prediction/evaluator/evaluator_manager_test.cc
@@ -62,7 +62,7 @@ TEST_F(EvaluatorManagerTest, General) {
   ObstaclesContainer* obstacles_container = dynamic_cast<ObstaclesContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PERCEPTION_OBSTACLES));
-  CHECK_NOTNULL(obstacles_container);
+  CHECK(obstacles_container);
   obstacles_container->Insert(perception_obstacles_);
 
   EvaluatorManager::instance()->Init(prediction_conf_);

--- a/modules/prediction/evaluator/vehicle/cost_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/cost_evaluator.cc
@@ -24,7 +24,7 @@ namespace prediction {
 using apollo::prediction::math_util::Sigmoid;
 
 void CostEvaluator::Evaluate(Obstacle* obstacle_ptr) {
-  CHECK_NOTNULL(obstacle_ptr);
+  CHECK(obstacle_ptr);
   int id = obstacle_ptr->id();
   if (!obstacle_ptr->latest_feature().IsInitialized()) {
     AERROR << "Obstacle [" << id << "] has no latest feature.";
@@ -32,7 +32,7 @@ void CostEvaluator::Evaluate(Obstacle* obstacle_ptr) {
   }
 
   Feature* latest_feature_ptr = obstacle_ptr->mutable_latest_feature();
-  CHECK_NOTNULL(latest_feature_ptr);
+  CHECK(latest_feature_ptr);
   if (!latest_feature_ptr->has_lane() ||
       !latest_feature_ptr->lane().has_lane_graph()) {
     ADEBUG << "Obstacle [" << id << "] has no lane graph.";
@@ -50,7 +50,7 @@ void CostEvaluator::Evaluate(Obstacle* obstacle_ptr) {
 
   LaneGraph* lane_graph_ptr =
       latest_feature_ptr->mutable_lane()->mutable_lane_graph();
-  CHECK_NOTNULL(lane_graph_ptr);
+  CHECK(lane_graph_ptr);
   if (lane_graph_ptr->lane_sequence_size() == 0) {
     AERROR << "Obstacle [" << id << "] has no lane sequences.";
     return;
@@ -58,7 +58,7 @@ void CostEvaluator::Evaluate(Obstacle* obstacle_ptr) {
 
   for (int i = 0; i < lane_graph_ptr->lane_sequence_size(); ++i) {
     LaneSequence* lane_sequence_ptr = lane_graph_ptr->mutable_lane_sequence(i);
-    CHECK_NOTNULL(lane_sequence_ptr);
+    CHECK(lane_sequence_ptr);
     double probability =
         ComputeProbability(obstacle_length, obstacle_width, *lane_sequence_ptr);
     lane_sequence_ptr->set_probability(probability);

--- a/modules/prediction/evaluator/vehicle/mlp_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/mlp_evaluator.cc
@@ -53,7 +53,7 @@ void MLPEvaluator::Clear() { obstacle_feature_values_map_.clear(); }
 
 void MLPEvaluator::Evaluate(Obstacle* obstacle_ptr) {
   Clear();
-  CHECK_NOTNULL(obstacle_ptr);
+  CHECK(obstacle_ptr);
   CHECK_LE(LANE_FEATURE_SIZE, 4 * FLAGS_max_num_lane_point);
 
   int id = obstacle_ptr->id();
@@ -63,7 +63,7 @@ void MLPEvaluator::Evaluate(Obstacle* obstacle_ptr) {
   }
 
   Feature* latest_feature_ptr = obstacle_ptr->mutable_latest_feature();
-  CHECK_NOTNULL(latest_feature_ptr);
+  CHECK(latest_feature_ptr);
   if (!latest_feature_ptr->has_lane() ||
       !latest_feature_ptr->lane().has_lane_graph()) {
     ADEBUG << "Obstacle [" << id << "] has no lane graph.";
@@ -74,7 +74,7 @@ void MLPEvaluator::Evaluate(Obstacle* obstacle_ptr) {
 
   LaneGraph* lane_graph_ptr =
       latest_feature_ptr->mutable_lane()->mutable_lane_graph();
-  CHECK_NOTNULL(lane_graph_ptr);
+  CHECK(lane_graph_ptr);
   if (lane_graph_ptr->lane_sequence_size() == 0) {
     AERROR << "Obstacle [" << id << "] has no lane sequences.";
     return;

--- a/modules/prediction/evaluator/vehicle/rnn_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/rnn_evaluator.cc
@@ -35,7 +35,7 @@ RNNEvaluator::RNNEvaluator() { LoadModel(FLAGS_evaluator_vehicle_rnn_file); }
 
 void RNNEvaluator::Evaluate(Obstacle* obstacle_ptr) {
   Clear();
-  CHECK_NOTNULL(obstacle_ptr);
+  CHECK(obstacle_ptr);
 
   int id = obstacle_ptr->id();
   if (!obstacle_ptr->latest_feature().IsInitialized()) {
@@ -44,7 +44,7 @@ void RNNEvaluator::Evaluate(Obstacle* obstacle_ptr) {
   }
 
   Feature* latest_feature_ptr = obstacle_ptr->mutable_latest_feature();
-  CHECK_NOTNULL(latest_feature_ptr);
+  CHECK(latest_feature_ptr);
   if (!latest_feature_ptr->has_lane() ||
       !latest_feature_ptr->lane().has_lane_graph()) {
     ADEBUG << "Obstacle [" << id << "] has no lane graph.";
@@ -53,7 +53,7 @@ void RNNEvaluator::Evaluate(Obstacle* obstacle_ptr) {
 
   LaneGraph* lane_graph_ptr =
       latest_feature_ptr->mutable_lane()->mutable_lane_graph();
-  CHECK_NOTNULL(lane_graph_ptr);
+  CHECK(lane_graph_ptr);
   if (lane_graph_ptr->lane_sequence_size() == 0) {
     ADEBUG << "Obstacle [" << id << "] has no lane sequences.";
     return;

--- a/modules/prediction/prediction.cc
+++ b/modules/prediction/prediction.cc
@@ -191,7 +191,7 @@ void Prediction::Stop() {
 void Prediction::OnLocalization(const LocalizationEstimate& localization) {
   PoseContainer* pose_container = dynamic_cast<PoseContainer*>(
       ContainerManager::instance()->GetContainer(AdapterConfig::LOCALIZATION));
-  CHECK_NOTNULL(pose_container);
+  CHECK(pose_container);
   pose_container->Insert(localization);
 
   ADEBUG << "Received a localization message ["
@@ -203,7 +203,7 @@ void Prediction::OnPlanning(const planning::ADCTrajectory& adc_trajectory) {
       dynamic_cast<ADCTrajectoryContainer*>(
           ContainerManager::instance()->GetContainer(
               AdapterConfig::PLANNING_TRAJECTORY));
-  CHECK_NOTNULL(adc_trajectory_container);
+  CHECK(adc_trajectory_container);
   adc_trajectory_container->Insert(adc_trajectory);
 
   ADEBUG << "Received a planning message [" << adc_trajectory.ShortDebugString()
@@ -230,7 +230,7 @@ void Prediction::RunOnce(const PerceptionObstacles& perception_obstacles) {
   ObstaclesContainer* obstacles_container = dynamic_cast<ObstaclesContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PERCEPTION_OBSTACLES));
-  CHECK_NOTNULL(obstacles_container);
+  CHECK(obstacles_container);
   obstacles_container->Insert(perception_obstacles);
 
   ADEBUG << "Received a perception message ["
@@ -242,8 +242,8 @@ void Prediction::RunOnce(const PerceptionObstacles& perception_obstacles) {
   ADCTrajectoryContainer* adc_container = dynamic_cast<ADCTrajectoryContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PLANNING_TRAJECTORY));
-  CHECK_NOTNULL(pose_container);
-  CHECK_NOTNULL(adc_container);
+  CHECK(pose_container);
+  CHECK(adc_container);
 
   PerceptionObstacle* adc = pose_container->ToPerceptionObstacle();
   if (adc != nullptr) {

--- a/modules/prediction/predictor/free_move/free_move_predictor.cc
+++ b/modules/prediction/predictor/free_move/free_move_predictor.cc
@@ -38,7 +38,7 @@ using ::apollo::perception::PerceptionObstacle;
 void FreeMovePredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 
   const Feature& feature = obstacle->latest_feature();

--- a/modules/prediction/predictor/lane_sequence/lane_sequence_predictor.cc
+++ b/modules/prediction/predictor/lane_sequence/lane_sequence_predictor.cc
@@ -37,7 +37,7 @@ using apollo::hdmap::LaneInfo;
 void LaneSequencePredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 
   const Feature& feature = obstacle->latest_feature();

--- a/modules/prediction/predictor/move_sequence/move_sequence_predictor.cc
+++ b/modules/prediction/predictor/move_sequence/move_sequence_predictor.cc
@@ -51,7 +51,7 @@ using ::apollo::prediction::math_util::EvaluateQuinticPolynomial;
 void MoveSequencePredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 
   const Feature& feature = obstacle->latest_feature();

--- a/modules/prediction/predictor/predictor_manager.cc
+++ b/modules/prediction/predictor/predictor_manager.cc
@@ -136,7 +136,7 @@ void PredictorManager::Run(const PerceptionObstacles& perception_obstacles) {
           ContainerManager::instance()->GetContainer(
               AdapterConfig::PLANNING_TRAJECTORY));
 
-  CHECK_NOTNULL(obstacles_container);
+  CHECK(obstacles_container);
 
   Predictor* predictor = nullptr;
   for (const auto& perception_obstacle :
@@ -195,7 +195,7 @@ void PredictorManager::Run(const PerceptionObstacles& perception_obstacles) {
         predictor->Predict(obstacle);
         if (FLAGS_enable_trim_prediction_trajectory &&
             obstacle->type() == PerceptionObstacle::VEHICLE) {
-          CHECK_NOTNULL(adc_trajectory_container);
+          CHECK(adc_trajectory_container);
           predictor->TrimTrajectories(obstacle, adc_trajectory_container);
         }
         for (const auto& trajectory : predictor->trajectories()) {

--- a/modules/prediction/predictor/predictor_manager_test.cc
+++ b/modules/prediction/predictor/predictor_manager_test.cc
@@ -68,7 +68,7 @@ TEST_F(PredictorManagerTest, General) {
   ObstaclesContainer* obstacles_container = dynamic_cast<ObstaclesContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PERCEPTION_OBSTACLES));
-  CHECK_NOTNULL(obstacles_container);
+  CHECK(obstacles_container);
   obstacles_container->Insert(perception_obstacles_);
 
   EvaluatorManager::instance()->Run(perception_obstacles_);

--- a/modules/prediction/predictor/regional/regional_predictor.cc
+++ b/modules/prediction/predictor/regional/regional_predictor.cc
@@ -70,7 +70,7 @@ double CrossProduct(const Eigen::Vector2d& vec1, const Eigen::Vector2d& vec2) {
 void RegionalPredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 
   const Feature& feature = obstacle->latest_feature();

--- a/modules/prediction/predictor/sequence/sequence_predictor.cc
+++ b/modules/prediction/predictor/sequence/sequence_predictor.cc
@@ -43,7 +43,7 @@ using ::apollo::hdmap::LaneInfo;
 void SequencePredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 }
 
@@ -165,8 +165,8 @@ double SequencePredictor::GetLaneChangeDistanceWithADC(
   ADCTrajectoryContainer* adc_container = dynamic_cast<ADCTrajectoryContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PLANNING_TRAJECTORY));
-  CHECK_NOTNULL(pose_container);
-  CHECK_NOTNULL(adc_container);
+  CHECK(pose_container);
+  CHECK(adc_container);
 
   if (!adc_container->HasOverlap(lane_sequence)) {
     ADEBUG << "The sequence [" << ToString(lane_sequence)

--- a/modules/prediction/predictor/single_lane/single_lane_predictor.cc
+++ b/modules/prediction/predictor/single_lane/single_lane_predictor.cc
@@ -36,7 +36,7 @@ using apollo::hdmap::LaneInfo;
 void SingleLanePredictor::Predict(Obstacle* obstacle) {
   Clear();
 
-  CHECK_NOTNULL(obstacle);
+  CHECK(obstacle);
   CHECK_GT(obstacle->history_size(), 0);
 
   const Feature& feature = obstacle->latest_feature();

--- a/modules/tools/fuzz/prediction/evaluator_manager_fuzz.cc
+++ b/modules/tools/fuzz/prediction/evaluator_manager_fuzz.cc
@@ -58,7 +58,7 @@ void EvaluatorManagerFuzz::target(PerceptionObstacles obstacles) {
   ObstaclesContainer* obstacles_container = dynamic_cast<ObstaclesContainer*>(
       ContainerManager::instance()->GetContainer(
           AdapterConfig::PERCEPTION_OBSTACLES));
-  CHECK_NOTNULL(obstacles_container);
+  CHECK(obstacles_container);
   obstacles_container->Insert(obstacles);
 
   EvaluatorManager::instance()->Init(prediction_conf_);

--- a/modules/tools/manual_traffic_light/manual_traffic_light.cc
+++ b/modules/tools/manual_traffic_light/manual_traffic_light.cc
@@ -91,7 +91,7 @@ bool GetAllTrafficLights(std::vector<SignalInfoConstPtr> *traffic_lights) {
 
 bool GetTrafficLightsWithinDistance(
     std::vector<SignalInfoConstPtr> *traffic_lights) {
-  CHECK_NOTNULL(traffic_lights);
+  CHECK(traffic_lights);
   AdapterManager::Observe();
   if (AdapterManager::GetLocalization()->Empty()) {
     AERROR << "No localization received";
@@ -118,7 +118,7 @@ bool GetTrafficLightsWithinDistance(
 bool CreateTrafficLightDetection(const std::vector<SignalInfoConstPtr> &signals,
                                  TrafficLight::Color color,
                                  TrafficLightDetection *detection) {
-  CHECK_NOTNULL(detection);
+  CHECK(detection);
   for (const auto &iter : signals) {
     auto *light = detection->add_traffic_light();
     light->set_color(color);

--- a/modules/tools/navi_generator/backend/util/quad_tiles_maker.cc
+++ b/modules/tools/navi_generator/backend/util/quad_tiles_maker.cc
@@ -33,7 +33,7 @@ bool QuadTilesMaker::MakeQuadTile(const double lat, const double lon,
                                   const double altitude,
                                   const std::size_t level,
                                   QuadTile* const quad_tile) {
-  CHECK_NOTNULL(quad_tile);
+  CHECK(quad_tile);
   if (level < 1) {
     AERROR << "Cannot handle desired level " << level << " (< 1)";
     return false;
@@ -94,8 +94,8 @@ bool QuadTilesMaker::MakeQuadTile(const double lat, const double lon,
 bool QuadTilesMaker::IdAsString(const std::size_t level,
                                 QuadTile* const quad_tile,
                                 std::string* const id_string) {
-  CHECK_NOTNULL(quad_tile);
-  CHECK_NOTNULL(id_string);
+  CHECK(quad_tile);
+  CHECK(id_string);
   if (level < 1) {
     AERROR << "Cannot handle desired level " << level << " (< 1)";
     return false;
@@ -121,8 +121,8 @@ bool QuadTilesMaker::IdAsString(const std::size_t level,
 bool QuadTilesMaker::IdAsUint32(const std::size_t level,
                                 QuadTile* const quad_tile,
                                 std::uint32_t* const id_uint32) {
-  CHECK_NOTNULL(quad_tile);
-  CHECK_NOTNULL(id_uint32);
+  CHECK(quad_tile);
+  CHECK(id_uint32);
   if (level < 1) {
     AERROR << "Cannot handle desired level " << level << " (< 1)";
     return false;
@@ -143,7 +143,7 @@ bool QuadTilesMaker::IdAsUint32(const std::size_t level,
 
 bool QuadTilesMaker::MakePosition(double lat, double lon, double altitude,
                                   Position* const pos) {
-  CHECK_NOTNULL(pos);
+  CHECK(pos);
   if (lat < -90.0 || lat > 90.0 || lon <= -180.0 || lon > 180.0) {
     AERROR << "The latitude: " << lat << ", longitude: " << lon
            << ", altitude: " << altitude << " is out of range.";

--- a/modules/tools/navi_generator/backend/util/trajectory_smoother.cc
+++ b/modules/tools/navi_generator/backend/util/trajectory_smoother.cc
@@ -203,7 +203,7 @@ bool TrajectorySmoother::CreateAnchorPoints(
     const planning::ReferencePoint& init_point,
     const planning::ReferenceLine& ref_line,
     std::vector<planning::AnchorPoint>* anchor_points) {
-  CHECK_NOTNULL(anchor_points);
+  CHECK(anchor_points);
 
   int num_of_anchors = std::max(
       2, static_cast<int>(ref_line.Length() /


### PR DESCRIPTION
It's better to use CHECK_NOTNULL, when the pointer is being used on the same line. There are gcc warnings, when compiling DCHECK_NOTNULL with optimization: https://github.com/google/glog/blob/master/src/glog/logging.h.in#L1061.

The transformation was applied with

```
git grep -l 'CHECK_NOTNULL' | xargs sed -i -r 's/CHECK_NOTNULL\(([^)]+)\);/CHECK(\1);/g'
```

on mac (BSD sed), it's
```
git grep -l 'CHECK_NOTNULL' | xargs sed -i '' -E 's/CHECK_NOTNULL\(([^)]+)\);/CHECK(\1);/g'
```