### PR TITLE
Tools: modified calibration script to allow starting from stationary position as well

### DIFF
--- a/modules/tools/calibration/process.py
+++ b/modules/tools/calibration/process.py
@@ -48,16 +48,25 @@ def get_start_index(data):
     if np.all(data['vehicle_speed'] == 0):
         return 0
 
-    start_ind = np.where(data['brake_percentage'] == 40)[0][0]
+    start_ind = np.where(data['brake_percentage'] == 40)
 
-    ind = start_ind
-    while ind < len(data):
-        if data['brake_percentage'][
-                ind] == 40:  # or data['vehicle_speed'][ind] == 0.0:
-            ind = ind + 1
-        else:
-            break
-    return ind
+    if len(start_ind[0] > 0):
+        ind = start_ind[0][0]
+        while ind < len(data):
+            if data['brake_percentage'][ind] == 40:
+                ind += 1
+            else:
+                break
+        return ind
+    
+    else:
+        ind = 0
+        while ind < len(data):
+            if abs(data['vehicle_speed'][ind]) < 0.01:
+                ind += 1
+            else:
+                break
+        return ind
 
 
 def process(data):


### PR DESCRIPTION
The processing.py script finds the first usable index by searching for the last entry where the brake percentage is at (exactly) 40. This is only useful for a case where the stationary vehicle always keeps the brake at 40 percent. I've added an additional check for cases where a brake percentage of 40 is not present in the data. In these cases, the velocity of the vehicle will be used to find the index of the first entry to be used for calibration.