### PR TITLE
Transform: Add init test to avoid shared linking error.

### DIFF
--- a/modules/transform/BUILD
+++ b/modules/transform/BUILD
@@ -48,6 +48,16 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "static_transform_component_test",
+    size = "small",
+    srcs = ["static_transform_component_test.cc"],
+    deps = [
+        ":static_transform_component_lib",
+        "@gtest//:main",
+    ],
+)
+
 cc_binary(
     name = "libstatic_transform_component.so",
     linkshared = True,

--- a/modules/transform/static_transform_component.cc
+++ b/modules/transform/static_transform_component.cc
@@ -30,19 +30,19 @@ bool StaticTransformComponent::Init() {
   attr.set_channel_name("/tf_static");
   attr.mutable_qos_profile()->CopyFrom(
       cyber::transport::QosProfileConf::QOS_PROFILE_TF_STATIC);
-  writer_ = node_->CreateWriter<apollo::transform::TransformStampeds>(attr);
+  writer_ = node_->CreateWriter<TransformStampeds>(attr);
   SendTransforms();
   return true;
 }
 
 void StaticTransformComponent::SendTransforms() {
-  std::vector<apollo::transform::TransformStamped> tranform_stamped_vec;
+  std::vector<TransformStamped> tranform_stamped_vec;
   for (auto& extrinsic_file : conf_.extrinsic_file()) {
     if (extrinsic_file.enable()) {
       AINFO << "Broadcast static transform, frame id ["
             << extrinsic_file.frame_id() << "], child frame id ["
             << extrinsic_file.child_frame_id() << "]";
-      apollo::transform::TransformStamped transform;
+      TransformStamped transform;
       if (ParseFromYaml(extrinsic_file.file_path(), &transform)) {
         tranform_stamped_vec.emplace_back(transform);
       }
@@ -52,8 +52,7 @@ void StaticTransformComponent::SendTransforms() {
 }
 
 bool StaticTransformComponent::ParseFromYaml(
-    const std::string& file_path,
-    apollo::transform::TransformStamped* transform_stamped) {
+    const std::string& file_path, TransformStamped* transform_stamped) {
   if (!cyber::common::PathExists(file_path)) {
     AERROR << "Extrinsic yaml file is noe exists: " << file_path;
     return false;
@@ -84,7 +83,7 @@ bool StaticTransformComponent::ParseFromYaml(
 }
 
 void StaticTransformComponent::SendTransform(
-    const std::vector<apollo::transform::TransformStamped>& msgtf) {
+    const std::vector<TransformStamped>& msgtf) {
   for (auto it_in = msgtf.begin(); it_in != msgtf.end(); ++it_in) {
     bool match_found = false;
     int size = transform_stampeds_.transforms_size();
@@ -103,8 +102,7 @@ void StaticTransformComponent::SendTransform(
       *ts = *it_in;
     }
   }
-  writer_->Write(std::make_shared<apollo::transform::TransformStampeds>(
-      transform_stampeds_));
+  writer_->Write(std::make_shared<TransformStampeds>(transform_stampeds_));
 }
 
 }  // namespace transform

--- a/modules/transform/static_transform_component_test.cc
+++ b/modules/transform/static_transform_component_test.cc
@@ -13,39 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *****************************************************************************/
+#include "modules/transform/static_transform_component.h"
 
-#pragma once
-
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "cyber/component/component.h"
-#include "modules/transform/proto/static_transform_conf.pb.h"
-#include "modules/transform/proto/transform.pb.h"
+#include "cyber/init.h"
+#include "gtest/gtest.h"
 
 namespace apollo {
 namespace transform {
 
-class StaticTransformComponent final : public apollo::cyber::Component<> {
- public:
-  StaticTransformComponent() = default;
-  ~StaticTransformComponent() = default;
-
- public:
-  bool Init() override;
-
- private:
-  void SendTransforms();
-  void SendTransform(const std::vector<TransformStamped>& msgtf);
-  bool ParseFromYaml(const std::string& file_path, TransformStamped* transform);
-
-  apollo::static_transform::Conf conf_;
-  std::shared_ptr<cyber::Writer<TransformStampeds>> writer_;
-  TransformStampeds transform_stampeds_;
-};
-
-CYBER_REGISTER_COMPONENT(StaticTransformComponent)
+TEST(TransformComponentTest, Init) {
+  cyber::Init("transform_component_test");
+  StaticTransformComponent component;
+}
 
 }  // namespace transform
 }  // namespace apollo


### PR DESCRIPTION
Without this unit test, the building still passes if you remove "@yaml_cpp//:yaml" from cc_library(static_transform_component_lib), while cyber cannot load it because of missing symbol definition.
So we should add a test which is static linked to guarantee that all dependencies are added.