### PR TITLE
update demo guide

### DIFF
--- a/docs/demo_guide/README.md
+++ b/docs/demo_guide/README.md
@@ -3,7 +3,7 @@
 Apollo provides a method to run simulation if you do not have the required
 hardware.
 
-Set up the docker release environment by following the instructions in the
+First Fork and then Clone Apollo's GitHub code and then Set up the docker release environment by following the instructions in the
 [Install docker](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md#docker)
 section of the
 [Build and Release](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md)

--- a/docs/demo_guide/README_cn.md
+++ b/docs/demo_guide/README_cn.md
@@ -2,7 +2,7 @@
 
 如果你没有车辆及车载硬件， Apollo还提供了一个计算机模拟环境，可用于演示和代码调试。 
 
-线下演示需要设置docker的release环境，请参照 [how_to_build_and_release](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md)文档中的[Install docker](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md#docker)章节。
+线下演示首先要Fork并且Clone Apollo在GitHub的代码，然后需要设置docker的release环境，请参照 [how_to_build_and_release](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md)文档中的[Install docker](https://github.com/ApolloAuto/apollo/blob/master/docs/howto/how_to_build_and_release.md#docker)章节。
 
 Apollo演示的安装步骤：
 


### PR DESCRIPTION
When people jump directly to the demo guide, Fork and then Clone Apollo's GitHub code would be ignored, which will lead to some kind of misunderstanding.