### PR TITLE
\e is not universally understood as an escape sequence

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -18,12 +18,15 @@
 
 APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
+BOLD='\033[1m'
 RED='\033[0;31m'
-YELLOW='\e[33m'
+GREEN='\033[32m'
+WHITE='\033[34m'
+YELLOW='\033[33m'
 NO_COLOR='\033[0m'
 
 function info() {
-  (>&2 echo -e "[\e[34m\e[1mINFO\e[0m] $*")
+  (>&2 echo -e "[${WHITE}${BOLD}INFO${NO_COLOR}] $*")
 }
 
 function error() {
@@ -35,7 +38,7 @@ function warning() {
 }
 
 function ok() {
-  (>&2 echo -e "[\e[32m\e[1m OK \e[0m] $*")
+  (>&2 echo -e "[${GREEN}${BOLD} OK ${NO_COLOR}] $*")
 }
 
 function print_delim() {


### PR DESCRIPTION
a few scripts generate incorrect ANSI escape sequence, for example, on master:
```
> bash docker/scripts/dev_start.sh
[\e[34m\e[1mINFO\e[0m] Start pulling docker image apolloauto/apollo:dev-x86_64-20181210_1500 ...
dev-x86_64-20181210_1500: Pulling from apolloauto/apollo
```

With this change:
```
bash docker/scripts/dev_start.sh

[**INFO**] Start pulling docker image apolloauto/apollo:dev-x86_64-20181210_1500 ...

```