### PR TITLE
CANBus: add the WEY vehicle

### DIFF
--- a/modules/canbus/common/canbus_gflags.cc
+++ b/modules/canbus/common/canbus_gflags.cc
@@ -49,3 +49,8 @@ DEFINE_int32(guardian_cmd_pending_queue_size, 10,
              "Max guardian cmd pending queue size");
 DEFINE_int32(control_cmd_pending_queue_size, 10,
              "Max control cmd pending queue size");
+
+// enable use acceleration or pedal
+// TODO(ChaoMa) : default: use pedal
+DEFINE_bool(use_acceleration, false,
+       "switch to use acceleration instead of throttle pedal and brake pedal");

--- a/modules/canbus/common/canbus_gflags.cc
+++ b/modules/canbus/common/canbus_gflags.cc
@@ -49,8 +49,3 @@ DEFINE_int32(guardian_cmd_pending_queue_size, 10,
              "Max guardian cmd pending queue size");
 DEFINE_int32(control_cmd_pending_queue_size, 10,
              "Max control cmd pending queue size");
-
-// enable use acceleration or pedal
-// TODO(ChaoMa) : default: use pedal
-DEFINE_bool(use_acceleration, false,
-       "switch to use acceleration instead of throttle pedal and brake pedal");

--- a/modules/canbus/common/canbus_gflags.h
+++ b/modules/canbus/common/canbus_gflags.h
@@ -42,6 +42,3 @@ DECLARE_bool(receive_guardian);
 
 DECLARE_int32(guardian_cmd_pending_queue_size);
 DECLARE_int32(control_cmd_pending_queue_size);
-
-// use acceleration or pedal
-DECLARE_bool(use_acceleration);

--- a/modules/canbus/conf/canbus.conf
+++ b/modules/canbus/conf/canbus.conf
@@ -2,4 +2,3 @@
 --canbus_conf_file=/apollo/modules/canbus/conf/canbus_conf.pb.txt
 --noenable_chassis_detail_pub
 --noreceive_guardian
---use_acceleration=false

--- a/modules/canbus/conf/canbus.conf
+++ b/modules/canbus/conf/canbus.conf
@@ -2,3 +2,4 @@
 --canbus_conf_file=/apollo/modules/canbus/conf/canbus_conf.pb.txt
 --noenable_chassis_detail_pub
 --noreceive_guardian
+--use_acceleration=false

--- a/modules/canbus/proto/BUILD
+++ b/modules/canbus/proto/BUILD
@@ -16,6 +16,7 @@ proto_library(
         "ge3.proto",
         "lexus.proto",
         "transit.proto",
+        "wey.proto",
         "vehicle_parameter.proto",
     ],
     deps = [

--- a/modules/canbus/proto/chassis_detail.proto
+++ b/modules/canbus/proto/chassis_detail.proto
@@ -6,6 +6,7 @@ import "modules/canbus/proto/chassis.proto";
 import "modules/canbus/proto/ge3.proto";
 import "modules/canbus/proto/lexus.proto";
 import "modules/canbus/proto/transit.proto";
+import "modules/canbus/proto/wey.proto";
 
 message ChassisDetail {
   enum Type {
@@ -33,6 +34,7 @@ message ChassisDetail {
   optional Lexus lexus = 19;
   optional Transit transit = 20;
   optional Ge3 ge3 = 21;
+  optional Wey wey = 22;
 }
 
 // CheckResponseSignal

--- a/modules/canbus/proto/vehicle_parameter.proto
+++ b/modules/canbus/proto/vehicle_parameter.proto
@@ -11,6 +11,7 @@ message VehicleParameter {
     LEXUS = 2;
     TRANSIT = 3;
     GE3 = 4;
+    WEY = 5;
   }
 
   optional VehicleBrand brand = 1;

--- a/modules/canbus/proto/wey.proto
+++ b/modules/canbus/proto/wey.proto
@@ -1,0 +1,599 @@
+syntax = "proto2";
+
+package apollo.canbus;
+
+message Ads_shifter_115 {
+// Control Message
+  enum Ads_shiftmodeType {
+    ADS_SHIFTMODE_INVALID = 0;
+    ADS_SHIFTMODE_VALID = 1;
+  }
+  enum Ads_targetgearType {
+    ADS_TARGETGEAR_N = 0;
+    ADS_TARGETGEAR_R = 1;
+    ADS_TARGETGEAR_P = 2;
+    ADS_TARGETGEAR_D = 3;
+  }
+  // ADS Shift Mode [] [0|1]
+  optional Ads_shiftmodeType ads_shiftmode = 1;
+  // ADS Target Gear [] [0|0]
+  optional Ads_targetgearType ads_targetgear = 2;
+}
+
+message Ads_eps_113 {
+// Control Message
+  enum Ads_epsmodeType {
+    ADS_EPSMODE_DISABLE = 0;
+    ADS_EPSMODE_ACTIVE = 2;
+  }
+  // EPS Mode [] [0|3]
+  optional Ads_epsmodeType ads_epsmode = 1;
+  // Steering Wheel Target Angle [deg] [-800|838.3]
+  optional double ads_reqepstargetangle = 2;
+}
+
+message Status_310 {
+// Report Message
+  enum LongitudeaccvalidType {
+    LONGITUDEACCVALID_INVALID = 0;
+    LONGITUDEACCVALID_VALID = 1;
+  }
+  enum LateralaccevalidType {
+    LATERALACCEVALID_INVALID = 0;
+    LATERALACCEVALID_VALID = 1;
+  }
+  enum VehdynyawratevalidType {
+    VEHDYNYAWRATEVALID_INVALID = 0;
+    VEHDYNYAWRATEVALID_VALID = 1;
+  }
+  enum FlwheelspdvalidType {
+    FLWHEELSPDVALID_INVALID = 0;
+    FLWHEELSPDVALID_VALID = 1;
+  }
+  enum FrwheelspdvalidType {
+    FRWHEELSPDVALID_INVALID = 0;
+    FRWHEELSPDVALID_VALID = 1;
+  }
+  enum RlwheelspdvalidType {
+    RLWHEELSPDVALID_INVALID = 0;
+    RLWHEELSPDVALID_VALID = 1;
+  }
+  enum RrwheelspdvalidType {
+    RRWHEELSPDVALID_INVALID = 0;
+    RRWHEELSPDVALID_VALID = 1;
+  }
+  enum VehiclespdvalidType {
+    VEHICLESPDVALID_INVALID = 0;
+    VEHICLESPDVALID_VALID = 1;
+  }
+  enum LongitudedrivingmodeType {
+    LONGITUDEDRIVINGMODE_MANUALMODE = 0;
+    LONGITUDEDRIVINGMODE_AUTOMATICSTANDBY = 1;
+    LONGITUDEDRIVINGMODE_AUTOMATICACCELERATION = 2;
+    LONGITUDEDRIVINGMODE_AUTOMATICDECELERATION = 3;
+  }
+  enum EngspdvalidType {
+    ENGSPDVALID_INVALID = 0;
+    ENGSPDVALID_VALID = 1;
+    ENGSPDVALID_INIT_VALUE = 2;
+    ENGSPDVALID_RESERVED = 3;
+  }
+  enum AccepedaloverrideType {
+    ACCEPEDALOVERRIDE_NOT_OVERRIDE = 0;
+    ACCEPEDALOVERRIDE_OVERRIDE = 1;
+  }
+  enum BrakepedalstatusType {
+    BRAKEPEDALSTATUS_NOT_PRESSED = 0;
+    BRAKEPEDALSTATUS_PRESSED = 1;
+    BRAKEPEDALSTATUS_RESERVED1 = 2;
+    BRAKEPEDALSTATUS_ERROR = 3;
+  }
+  enum EspbrakelightstsType {
+    ESPBRAKELIGHTSTS_OFF = 0;
+    ESPBRAKELIGHTSTS_ON = 1;
+  }
+  enum EpbswtpositionvalidType {
+    EPBSWTPOSITIONVALID_VALID = 0;
+    EPBSWTPOSITIONVALID_NOT_VALID = 1;
+  }
+  enum EpbstsType {
+    EPBSTS_RELEASED = 0;
+    EPBSTS_CLOSED = 1;
+    EPBSTS_IN_PROGRESS = 2;
+    EPBSTS_UNKNOWN = 3;
+  }
+  enum CurrentgearvalidType {
+    CURRENTGEARVALID_INVALID = 0;
+    CURRENTGEARVALID_VALID = 1;
+  }
+  enum EpstrqsnsrstsType {
+    EPSTRQSNSRSTS_NORMAL = 0;
+    EPSTRQSNSRSTS_ABNORMAL = 1;
+  }
+  enum Eps_interferdetdvalidType {
+    EPS_INTERFERDETDVALID_INVALID = 0;
+    EPS_INTERFERDETDVALID_VALID = 1;
+  }
+  enum EpshandsdetnstsType {
+    EPSHANDSDETNSTS_HANDSOFF_NOT_DETECTED = 0;
+    EPSHANDSDETNSTS_HANDOFFF_DETECTED = 1;
+  }
+  enum Eps_handsdetnstsvalidType {
+    EPS_HANDSDETNSTSVALID_INVALID = 0;
+    EPS_HANDSDETNSTSVALID_VALID = 1;
+  }
+  enum SteerwheelanglesignType {
+    STEERWHEELANGLESIGN_LEFT_POSITIVE = 0;
+    STEERWHEELANGLESIGN_RIGHT_NEGATIVE = 1;
+  }
+  enum SteerwheelspdsignType {
+    STEERWHEELSPDSIGN_LEFT_POSITIVE = 0;
+    STEERWHEELSPDSIGN_RIGHT_NEGATIVE = 1;
+  }
+  enum DriverdoorstsType {
+    DRIVERDOORSTS_CLOSED = 0;
+    DRIVERDOORSTS_OPEN = 1;
+  }
+  enum RldoorstsType {
+    RLDOORSTS_CLOSED = 0;
+    RLDOORSTS_OPEN = 1;
+  }
+  enum PassengerdoorstsType {
+    PASSENGERDOORSTS_CLOSED = 0;
+    PASSENGERDOORSTS_OPEN = 1;
+  }
+  enum RrdoorstsType {
+    RRDOORSTS_CLOSED = 0;
+    RRDOORSTS_OPEN = 1;
+  }
+  enum FrontfoglmpstsType {
+    FRONTFOGLMPSTS_OFF = 0;
+    FRONTFOGLMPSTS_ON = 1;
+    FRONTFOGLMPSTS_RESERVED = 2;
+    FRONTFOGLMPSTS_NOT_AVAILABLE = 3;
+  }
+  enum RearfoglmpstsType {
+    REARFOGLMPSTS_OFF = 0;
+    REARFOGLMPSTS_ON = 1;
+  }
+  enum LowbeamstsType {
+    LOWBEAMSTS_OFF = 0;
+    LOWBEAMSTS_ON = 1;
+  }
+  enum HighbeamstsType {
+    HIGHBEAMSTS_OFF = 0;
+    HIGHBEAMSTS_ON = 1;
+  }
+  enum LeftturnlampstsType {
+    LEFTTURNLAMPSTS_OFF = 0;
+    LEFTTURNLAMPSTS_ON = 1;
+  }
+  enum RightturnlampstsType {
+    RIGHTTURNLAMPSTS_OFF = 0;
+    RIGHTTURNLAMPSTS_ON = 1;
+  }
+  enum Bcm_availstsType {
+    BCM_AVAILSTS_MANUAL_MODE = 0;
+    BCM_AVAILSTS_AUTONOMOUS_MODE = 1;
+    BCM_AVAILSTS_RESERVED1 = 2;
+    BCM_AVAILSTS_RESERVED2 = 3;
+  }
+  enum BrakelmpstsType {
+    BRAKELMPSTS_OFF = 0;
+    BRAKELMPSTS_ON = 1;
+  }
+  // Longitude acceleration valid [] [0|1]
+  optional LongitudeaccvalidType longitudeaccvalid = 1;
+  // Indicates Lateral Signal State [] [0|1]
+  optional LateralaccevalidType lateralaccevalid = 2;
+  // Vehicle yaw rate valid [] [0|1]
+  optional VehdynyawratevalidType vehdynyawratevalid = 3;
+  // Front right wheel speed valid [] [0|1]
+  optional FlwheelspdvalidType flwheelspdvalid = 4;
+  // Front right wheel speed valid [] [0|1]
+  optional FrwheelspdvalidType frwheelspdvalid = 5;
+  // Rear left wheel speed valid [] [0|1]
+  optional RlwheelspdvalidType rlwheelspdvalid = 6;
+  // Rear right wheel speed valid [] [0|1]
+  optional RrwheelspdvalidType rrwheelspdvalid = 7;
+  // Quality/fault information to current Vehicle speed information [] [0|1]
+  optional VehiclespdvalidType vehiclespdvalid = 8;
+  // This signal indicates if ECM control for  ADS torque request is active or not. [] [0|3]
+  optional LongitudedrivingmodeType longitudedrivingmode = 9;
+  // Engine speed valid [] [0|2]
+  optional EngspdvalidType engspdvalid = 10;
+  // Detect Acceleration Pedal Override [] [0|1]
+  optional AccepedaloverrideType accepedaloverride = 11;
+  // indicates the brake pedal is pressed or not or incorrect for plausibility check. [] [0|3]
+  optional BrakepedalstatusType brakepedalstatus = 12;
+  // Brake light lamp(on/off),come from ESP [] [0|1]
+  optional EspbrakelightstsType espbrakelightsts = 13;
+  // EPB switch position signal valid [] [0|1]
+  optional EpbswtpositionvalidType epbswtpositionvalid = 14;
+  // EPB status [] [0|3]
+  optional EpbstsType epbsts = 15;
+  // Current gear valid [] [0|1]
+  optional CurrentgearvalidType currentgearvalid = 16;
+  // EPS torque sensor status [] [0|1]
+  optional EpstrqsnsrstsType epstrqsnsrsts = 17;
+  // Driver Steering Interference Detected Validity [] [0|1]
+  optional Eps_interferdetdvalidType eps_interferdetdvalid = 18;
+  // Hands Off Steering Wheel Detection status [] [0|1]
+  optional EpshandsdetnstsType epshandsdetnsts = 19;
+  // Hands Off Steering Wheel Detection status Validity [] [0|1]
+  optional Eps_handsdetnstsvalidType eps_handsdetnstsvalid = 20;
+  // sign of steering wheel angle [] [0|1]
+  optional SteerwheelanglesignType steerwheelanglesign = 21;
+  // sign of steering wheel speed  [] [0|1]
+  optional SteerwheelspdsignType steerwheelspdsign = 22;
+  // Driver door status. [] [0|1]
+  optional DriverdoorstsType driverdoorsts = 23;
+  // Left rear door status [] [0|1]
+  optional RldoorstsType rldoorsts = 24;
+  // Passenger door status. [] [0|1]
+  optional PassengerdoorstsType passengerdoorsts = 25;
+  // Right   rear door status [] [0|1]
+  optional RrdoorstsType rrdoorsts = 26;
+  // Front fog lamp status [] [0|3]
+  optional FrontfoglmpstsType frontfoglmpsts = 27;
+  // Rear fog lamp status [] [0|1]
+  optional RearfoglmpstsType rearfoglmpsts = 28;
+  // Low beam status [] [0|1]
+  optional LowbeamstsType lowbeamsts = 29;
+  // High beam status [] [0|1]
+  optional HighbeamstsType highbeamsts = 30;
+  // Left turn lamp status [] [0|1]
+  optional LeftturnlampstsType leftturnlampsts = 31;
+  // Right turn lamp status [] [0|1]
+  optional RightturnlampstsType rightturnlampsts = 32;
+  // The work status of BCM [] [0|3]
+  optional Bcm_availstsType bcm_availsts = 33;
+  // Break Lamp status [] [0|1]
+  optional BrakelmpstsType brakelmpsts = 34;
+}
+
+message Vin_resp3_393 {
+// Report Message
+  // [] [0|255]
+  optional int32 vin16 = 1;
+}
+
+message Vin_resp2_392 {
+// Report Message
+  // [] [0|255]
+  optional int32 vin15 = 1;
+  // [] [0|255]
+  optional int32 vin14 = 2;
+  // [] [0|255]
+  optional int32 vin13 = 3;
+  // [] [0|255]
+  optional int32 vin12 = 4;
+  // [] [0|255]
+  optional int32 vin11 = 5;
+  // [] [0|255]
+  optional int32 vin10 = 6;
+  // [] [0|255]
+  optional int32 vin09 = 7;
+  // [] [0|255]
+  optional int32 vin08 = 8;
+}
+
+message Vin_resp1_391 {
+// Report Message
+  // [] [0|255]
+  optional int32 vin07 = 1;
+  // [] [0|255]
+  optional int32 vin06 = 2;
+  // [] [0|255]
+  optional int32 vin05 = 3;
+  // [] [0|255]
+  optional int32 vin04 = 4;
+  // [] [0|255]
+  optional int32 vin03 = 5;
+  // [] [0|255]
+  optional int32 vin02 = 6;
+  // [] [0|255]
+  optional int32 vin00 = 7;
+  // [] [0|255]
+  optional int32 vin01 = 8;
+}
+
+message Ads_req_vin_390 {
+// Control Message
+  enum Req_vin_signalType {
+    REQ_VIN_SIGNAL_NO_REQUEST = 0;
+    REQ_VIN_SIGNAL_REQUEST = 1;
+  }
+  // [] [0|255]
+  optional Req_vin_signalType req_vin_signal = 1;
+}
+
+message Ads1_111 {
+// Control Message
+  enum Ads_dectostopType {
+    ADS_DECTOSTOP_NO_DEMAND = 0;
+    ADS_DECTOSTOP_DEMAND = 1;
+  }
+  enum Ads_modeType {
+    ADS_MODE_OFF_MODE = 0;
+    ADS_MODE_ACTIVE_MODE = 3;
+  }
+  enum Ads_driveoff_reqType {
+    ADS_DRIVEOFF_REQ_NO_DEMAND = 0;
+    ADS_DRIVEOFF_REQ_DEMAND = 1;
+  }
+  enum Ads_aeb_tgtdecel_reqType {
+    ADS_AEB_TGTDECEL_REQ_NO_DEMAND = 0;
+    ADS_AEB_TGTDECEL_REQ_DEMAND = 1;
+  }
+  // ADS request ESP/VLC to decelerate untill standstill. [] [0|1]
+  optional Ads_dectostopType ads_dectostop = 1;
+  // The status of the ADS control unit.The ADS mode should be contained in every message sent by ADS [] [0|31]
+  optional Ads_modeType ads_mode = 2;
+  // ADS target acceleration for transmission [m/s2] [-7|5.75]
+  optional double ads_taracce = 3;
+  // ACC request ESP drive off [] [0|1]
+  optional Ads_driveoff_reqType ads_driveoff_req = 4;
+  // target deceleration value from AEB [m/s2] [-16|16]
+  optional double ads_aeb_taracce = 5;
+  // Request of the AEB deceleration control. [] [0|1]
+  optional Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req = 6;
+}
+
+message Fbs2_240 {
+// Report Message
+  enum FlwheeldirectionType {
+    FLWHEELDIRECTION_INVALID = 0;
+    FLWHEELDIRECTION_FORWARD = 1;
+    FLWHEELDIRECTION_BACKWARD = 2;
+    FLWHEELDIRECTION_STOP = 3;
+  }
+  enum RlwheeldrivedirectionType {
+    RLWHEELDRIVEDIRECTION_INVALID = 0;
+    RLWHEELDRIVEDIRECTION_FORWARD = 1;
+    RLWHEELDRIVEDIRECTION_BACKWARD = 2;
+    RLWHEELDRIVEDIRECTION_STOP = 3;
+  }
+  enum RrwheeldirectionType {
+    RRWHEELDIRECTION_INVALID = 0;
+    RRWHEELDIRECTION_FORWARD = 1;
+    RRWHEELDIRECTION_BACKWARD = 2;
+    RRWHEELDIRECTION_STOP = 3;
+  }
+  // Front left wheel Moving direction [] [0|3]
+  optional FlwheeldirectionType flwheeldirection = 1;
+  // Front right wheel speed [Km/h] [0|299.98125]
+  optional double frwheelspd = 2;
+  // Rear left wheel  Moving direction [] [0|3]
+  optional RlwheeldrivedirectionType rlwheeldrivedirection = 3;
+  // Rear left wheel speed [Km/h] [0|299.98125]
+  optional double rlwheelspd = 4;
+  // Rear right wheel Moving direction [] [0|3]
+  optional RrwheeldirectionType rrwheeldirection = 5;
+  // Rear right wheel speed [Km/h] [0|299.98125]
+  optional double rrwheelspd = 6;
+  // Current Vehicle speed information [Km/h] [0|299.98125]
+  optional double vehiclespd = 7;
+}
+
+message Fbs1_243 {
+// Report Message
+  enum FrwheeldirectionType {
+    FRWHEELDIRECTION_INVALID = 0;
+    FRWHEELDIRECTION_FORWARD = 1;
+    FRWHEELDIRECTION_BACKWARD = 2;
+    FRWHEELDIRECTION_STOP = 3;
+  }
+  // Longitude acceleration [m/s^2] [-21.592|21.592]
+  optional double longitudeacce = 1;
+  // Indicates Lateral Acceleration [m/s^2] [-21.592|21.592]
+  optional double lateralacce = 2;
+  // Vehicle yaw rate [rad/s] [-2.093|2.093]
+  optional double vehdynyawrate = 3;
+  // Front left wheel speed [Km/h] [0|299.98125]
+  optional double flwheelspd = 4;
+  // Front right wheel  Moving direction [] [0|3]
+  optional FrwheeldirectionType frwheeldirection = 5;
+}
+
+message Fbs4_235 {
+// Report Message
+  // angle of steering wheel  [deg] [0|780]
+  optional double steerwheelangle = 1;
+  // steering wheel rotation speed [deg/s] [0|1016]
+  optional double steerwheelspd = 2;
+}
+
+message Fail_241 {
+// Report Message
+  enum EngfailType {
+    ENGFAIL_NO_FAIL = 0;
+    ENGFAIL_FAIL = 1;
+  }
+  enum EspfailType {
+    ESPFAIL_NO_FAILURE = 0;
+    ESPFAIL_FAILURE = 1;
+  }
+  enum EpbfailType {
+    EPBFAIL_UNDEFINED = 0;
+    EPBFAIL_NO_ERROR = 1;
+    EPBFAIL_ERROR = 2;
+    EPBFAIL_DIAGNOSIS = 3;
+  }
+  enum ShiftfailType {
+    SHIFTFAIL_NO_FAIL = 0;
+    SHIFTFAIL_TRANSMISSION_MALFUNCTION = 1;
+    SHIFTFAIL_TRANSMISSION_P_ENGAGEMENT_FAULT = 2;
+    SHIFTFAIL_TRANSMISSION_P_DISENGAGEMENT_FAULT = 3;
+    SHIFTFAIL_RESERVED = 4;
+    SHIFTFAIL_TRANSMISSION_LIMIT_FUNCTION = 15;
+  }
+  enum EpsfailType {
+    EPSFAIL_NO_FAULT = 0;
+    EPSFAIL_FAULT = 1;
+  }
+  // Engine Fail status [] [0|1]
+  optional EngfailType engfail = 1;
+  // ESP fault [] [0|1]
+  optional EspfailType espfail = 2;
+  // error indication of EPB system [] [0|3]
+  optional EpbfailType epbfail = 3;
+  // Driver display failure messages [] [0|15]
+  optional ShiftfailType shiftfail = 4;
+  // Electrical steering fail status [] [0|1]
+  optional EpsfailType epsfail = 5;
+}
+
+message Fbs3_237 {
+// Report Message
+  enum EpbswtichpositionType {
+    EPBSWTICHPOSITION_NEUTRAL = 0;
+    EPBSWTICHPOSITION_RELEASE = 1;
+    EPBSWTICHPOSITION_APPLY = 2;
+    EPBSWTICHPOSITION_RESERVED1 = 3;
+  }
+  enum CurrentgearType {
+    CURRENTGEAR_P = 0;
+    CURRENTGEAR_R = 1;
+    CURRENTGEAR_N = 2;
+    CURRENTGEAR_D = 3;
+  }
+  enum Eps_streeingmodeType {
+    EPS_STREEINGMODE_MANUAL = 0;
+    EPS_STREEINGMODE_AUTOMATIC_AVAIL = 1;
+    EPS_STREEINGMODE_MANUAL_FROM_DRVNTERFERENCE = 2;
+    EPS_STREEINGMODE_MANUAL_FROM_EPS_FAILED_DETECTED = 3;
+    EPS_STREEINGMODE_TEMPORARY_INHIBITED = 4;
+    EPS_STREEINGMODE_RESERVED1 = 5;
+    EPS_STREEINGMODE_RESERVED2 = 6;
+    EPS_STREEINGMODE_RESERVED3 = 7;
+  }
+  enum EpscurrmodType {
+    EPSCURRMOD_NORMAL_MODE = 0;
+    EPSCURRMOD_SPORT_MODE = 1;
+    EPSCURRMOD_COMFORT_MODE = 2;
+    EPSCURRMOD_MODESELECTIONNOTPOSSIBLE = 3;
+    EPSCURRMOD_NO_DISPLAY = 4;
+    EPSCURRMOD_CONDITIONNOTMEET = 5;
+    EPSCURRMOD_RESERVED1 = 6;
+  }
+  // Engine speed [rpm] [0|8198.875]
+  optional double engspd = 1;
+  // Acceleration Pedal Position [%] [0|100.3935]
+  optional double accpedalpos = 2;
+  // EPB Switch position information [] [0|3]
+  optional EpbswtichpositionType epbswtichposition = 3;
+  // To indicate which gear the DCT is in now  [] [0|3]
+  optional CurrentgearType currentgear = 4;
+  // Driver Steering Interference Detected [] [0|7]
+  optional Eps_streeingmodeType eps_streeingmode = 5;
+  // Value of driver input torque [Nm] [-22.78|22.96]
+  optional double epsdrvinputtrqvalue = 6;
+  // Value of consumed current by EPS [A] [127|127]
+  optional double epsconsumedcurrvalue = 7;
+  // Applied steering mode currently [] [0|7]
+  optional EpscurrmodType epscurrmod = 8;
+}
+
+message Ads3_38e {
+// Control Message
+  enum Ads_bcm_workstsType {
+    ADS_BCM_WORKSTS_DISABLE = 0;
+    ADS_BCM_WORKSTS_ENABLE = 1;
+    ADS_BCM_WORKSTS_ACTIVE = 2;
+    ADS_BCM_WORKSTS_FAILED = 3;
+  }
+  enum Ads_bcmworkstsvalidType {
+    ADS_BCMWORKSTSVALID_INVALID = 0;
+    ADS_BCMWORKSTSVALID_VALID = 1;
+  }
+  enum Ads_reqcontrolbcmType {
+    ADS_REQCONTROLBCM_NO_REQUEST = 0;
+    ADS_REQCONTROLBCM_REQUEST = 1;
+  }
+  enum HighbeamtonType {
+    HIGHBEAMTON_TURN_OFF = 0;
+    HIGHBEAMTON_TURN_ON = 1;
+  }
+  enum DippedbeamonType {
+    DIPPEDBEAMON_TURN_OFF = 0;
+    DIPPEDBEAMON_TURN_ON = 1;
+  }
+  enum TurnllightonType {
+    TURNLLIGHTON_TURN_OFF = 0;
+    TURNLLIGHTON_TURN_LEFT_ON = 1;
+    TURNLLIGHTON_TURN_RIGHT_ON = 2;
+    TURNLLIGHTON_RESERVED = 3;
+  }
+  enum EmergencylightonType {
+    EMERGENCYLIGHTON_TURN_OFF = 0;
+    EMERGENCYLIGHTON_TURN_ON = 1;
+  }
+  enum FfoglamponType {
+    FFOGLAMPON_TURN_OFF = 0;
+    FFOGLAMPON_TURN_ON = 1;
+  }
+  enum RfoglamponType {
+    RFOGLAMPON_TURN_OFF = 0;
+    RFOGLAMPON_TURN_ON = 1;
+  }
+  enum BrakelightType {
+    BRAKELIGHT_TURN_OFF = 0;
+    BRAKELIGHT_TURN_ON = 1;
+  }
+  enum HornonType {
+    HORNON_TURN_OFF = 0;
+    HORNON_TURN_ON = 1;
+  }
+  enum FwindshieldwiperType {
+    FWINDSHIELDWIPER_TURN_OFF = 0;
+    FWINDSHIELDWIPER_TURN_ON = 1;
+  }
+  enum RwindshieldwiperType {
+    RWINDSHIELDWIPER_TURN_OFF = 0;
+    RWINDSHIELDWIPER_TURN_ON = 1;
+  }
+  // The work status of ADS control unit.This signal should be contained in every message sent by ADS. [] [0|3]
+  optional Ads_bcm_workstsType ads_bcm_worksts = 1;
+  // This Signal reflect the ADS_WorkSts Signal is Valid OR not [] [0|1]
+  optional Ads_bcmworkstsvalidType ads_bcmworkstsvalid = 2;
+  // Vehicle Task request.If ADS request control BCM [] [0|1]
+  optional Ads_reqcontrolbcmType ads_reqcontrolbcm = 3;
+  // Open theHigh Beam light [] [0|1]
+  optional HighbeamtonType highbeamton = 4;
+  // Open the dipped Beam light [] [0|1]
+  optional DippedbeamonType dippedbeamon = 5;
+  // Open the Turn light [] [0|3]
+  optional TurnllightonType turnllighton = 6;
+  // Open the emergency light [] [0|1]
+  optional EmergencylightonType emergencylighton = 7;
+  // Open the front fog light [] [0|1]
+  optional FfoglamponType ffoglampon = 8;
+  // Open the rear fog ligh [] [0|1]
+  optional RfoglamponType rfoglampon = 9;
+  // Open the brake light [] [0|1]
+  optional BrakelightType brakelight = 10;
+  // Open the horn voice [] [0|1]
+  optional HornonType hornon = 11;
+  // Open front window shield wiper [] [0|1]
+  optional FwindshieldwiperType fwindshieldwiper = 12;
+  // Open rear window shield wiper [] [0|1]
+  optional RwindshieldwiperType rwindshieldwiper = 13;
+}
+
+message Wey {
+  optional Ads_shifter_115 ads_shifter_115 = 1; // control message
+  optional Ads_eps_113 ads_eps_113 = 2; // control message
+  optional Status_310 status_310 = 3; // report message
+  optional Vin_resp3_393 vin_resp3_393 = 4; // report message
+  optional Vin_resp2_392 vin_resp2_392 = 5; // report message
+  optional Vin_resp1_391 vin_resp1_391 = 6; // report message
+  optional Ads_req_vin_390 ads_req_vin_390 = 7; // control message
+  optional Ads1_111 ads1_111 = 8; // control message
+  optional Fbs2_240 fbs2_240 = 9; // report message
+  optional Fbs1_243 fbs1_243 = 10; // report message
+  optional Fbs4_235 fbs4_235 = 11; // report message
+  optional Fail_241 fail_241 = 12; // report message
+  optional Fbs3_237 fbs3_237 = 13; // report message
+  optional Ads3_38e ads3_38e = 14; // control message
+}

--- a/modules/canbus/testdata/conf/wey_canbus_conf_test.pb.txt
+++ b/modules/canbus/testdata/conf/wey_canbus_conf_test.pb.txt
@@ -1,0 +1,13 @@
+vehicle_parameter {
+  brand: WEY
+  max_enable_fail_attempt: 5
+  driving_mode: COMPLETE_AUTO_DRIVE
+}
+
+can_card_parameter {
+  brand:ESD_CAN
+  type: PCI_CARD
+  channel_id: CHANNEL_ID_ZERO
+}
+
+enable_debug_mode: false

--- a/modules/canbus/tools/BUILD
+++ b/modules/canbus/tools/BUILD
@@ -25,6 +25,8 @@ cc_binary(
         "//modules/common",
         "//modules/common/adapters:adapter_gflags",
         "//modules/control/proto:control_proto",
+        "//modules/canbus/common:canbus_common",
+        "//modules/common/configs:vehicle_config_helper",
     ],
 )
 

--- a/modules/canbus/tools/BUILD
+++ b/modules/canbus/tools/BUILD
@@ -27,6 +27,7 @@ cc_binary(
         "//modules/control/proto:control_proto",
         "//modules/canbus/common:canbus_common",
         "//modules/common/configs:vehicle_config_helper",
+        "//modules/canbus/vehicle:vehicle_controller_base",
     ],
 )
 

--- a/modules/canbus/tools/teleop.cc
+++ b/modules/canbus/tools/teleop.cc
@@ -32,8 +32,8 @@
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/common/time/time.h"
 #include "modules/common/util/message_util.h"
-#include "modules/canbus/common/canbus_gflags.h"
 #include "modules/common/configs/vehicle_config_helper.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
 
 
 // gflags
@@ -41,6 +41,11 @@ DEFINE_double(throttle_inc_delta, 2.0,
               "throttle pedal command delta percentage.");
 DEFINE_double(brake_inc_delta, 2.0, "brake pedal delta percentage");
 DEFINE_double(steer_inc_delta, 2.0, "steer delta percentage");
+// TODO(ALL) : switch the acceleration cmd or pedal cmd
+// default : use pedal cmd
+DEFINE_bool(use_acceleration, false,
+       "switch to use acceleration instead of throttle pedal and brake pedal");
+
 
 namespace {
 

--- a/modules/canbus/tools/teleop.cc
+++ b/modules/canbus/tools/teleop.cc
@@ -133,9 +133,9 @@ class Teleop {
     char c = 0;
     int32_t level = 0;
     double brake = 0;
-    double brake_1 = 0;
     double throttle = 0;
-    double throttle_1 = 0;
+    double acc = 0;
+    double dec = 0;
     double steering = 0;
     struct termios cooked_;
     struct termios raw_;
@@ -177,25 +177,27 @@ class Teleop {
             }
           if (brake > 1e-6) {
             brake = GetCommand(brake, -FLAGS_brake_inc_delta);
-            if (FLAGS_use_acceleration) {
-              brake_1 = brake / 100 * vehicle_params_.max_deceleration();
-              control_command_.set_acceleration(brake_1);
-              control_command_.set_brake(brake_1);
-            } else {
+            if (!FLAGS_use_acceleration) {
               control_command_.set_brake(brake);
+            } else {
+              dec = brake / 100 * vehicle_params_.max_deceleration();
+              control_command_.set_acceleration(dec);
             }
           } else {
             throttle = GetCommand(throttle, FLAGS_throttle_inc_delta);
-            if (FLAGS_use_acceleration) {
-              throttle_1 = throttle / 100 * vehicle_params_.max_acceleration();
-              control_command_.set_acceleration(throttle_1);
-              control_command_.set_throttle(throttle_1);
-            } else {
+            if (!FLAGS_use_acceleration) {
               control_command_.set_throttle(throttle);
+            } else {
+              acc = throttle / 100 * vehicle_params_.max_acceleration();
+              control_command_.set_acceleration(acc);
             }
           }
-          AINFO << "Throttle = " << control_command_.throttle()
-                << ", Brake = " << control_command_.brake();
+          if (!FLAGS_use_acceleration) {
+            AINFO << "Throttle = " << control_command_.throttle()
+                  << ", Brake = " << control_command_.brake();
+          } else {
+            AINFO << "Acceleration = " << control_command_.acceleration();
+          }
           break;
         case KEYCODE_DN1:  // decelerate
         case KEYCODE_DN2:
@@ -205,25 +207,27 @@ class Teleop {
             }
           if (throttle > 1e-6) {
             throttle = GetCommand(throttle, -FLAGS_throttle_inc_delta);
-            if (FLAGS_use_acceleration) {
-              throttle_1 = throttle / 100 * vehicle_params_.max_acceleration();
-              control_command_.set_acceleration(throttle_1);
-              control_command_.set_throttle(throttle_1);
-            } else {
+            if (!FLAGS_use_acceleration) {
               control_command_.set_throttle(throttle);
+            } else {
+              acc = throttle / 100 * vehicle_params_.max_acceleration();
+              control_command_.set_acceleration(acc);
             }
           } else {
             brake = GetCommand(brake, FLAGS_brake_inc_delta);
-            if (FLAGS_use_acceleration) {
-              brake_1 = brake / 100 * vehicle_params_.max_deceleration();
-              control_command_.set_acceleration(brake_1);
-              control_command_.set_brake(brake_1);
-            } else {
+            if (!FLAGS_use_acceleration) {
               control_command_.set_brake(brake);
+            } else {
+              dec = brake / 100 * vehicle_params_.max_deceleration();
+              control_command_.set_acceleration(dec);
             }
           }
-          AINFO << "Throttle = " << control_command_.throttle()
-                << ", Brake = " << control_command_.brake();
+          if (!FLAGS_use_acceleration) {
+            AINFO << "Throttle = " << control_command_.throttle()
+                  << ", Brake = " << control_command_.brake();
+          } else {
+            AINFO << "Acceleration = " << control_command_.acceleration();
+          }
           break;
         case KEYCODE_LF1:  // left
         case KEYCODE_LF2:

--- a/modules/canbus/vehicle/BUILD
+++ b/modules/canbus/vehicle/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "//modules/drivers/canbus/can_comm:can_sender",
         "//modules/drivers/canbus/can_comm:message_manager_base",
         "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/common:canbus_common",
     ],
 )
 
@@ -53,6 +54,7 @@ cc_library(
         "//modules/canbus/vehicle/lincoln:lincoln_vehicle_factory",
         "//modules/canbus/vehicle/transit:transit_vehicle_factory",
         "//modules/canbus/vehicle/ge3:ge3_vehicle_factory",
+        "//modules/canbus/vehicle/wey:wey_vehicle_factory",
         "//modules/common/util:factory",
     ],
 )

--- a/modules/canbus/vehicle/BUILD
+++ b/modules/canbus/vehicle/BUILD
@@ -18,7 +18,6 @@ cc_library(
         "//modules/drivers/canbus/can_comm:can_sender",
         "//modules/drivers/canbus/can_comm:message_manager_base",
         "//modules/drivers/canbus/common:canbus_common",
-        "//modules/canbus/common:canbus_common",
     ],
 )
 

--- a/modules/canbus/vehicle/ge3/ge3_controller.cc
+++ b/modules/canbus/vehicle/ge3/ge3_controller.cc
@@ -572,6 +572,17 @@ void Ge3Controller::Steer(double angle) {
   pc_eps_204_->set_pc_steerangreq(real_angle)->set_pc_steerspdreq(500);
 }
 
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void Ge3Controller::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
 // steering with new angle speed
 // angle:-99.99~0.00~99.99, unit:, left:-, right:+
 // angle_spd:0.00~99.99, unit:deg/s

--- a/modules/canbus/vehicle/ge3/ge3_controller.h
+++ b/modules/canbus/vehicle/ge3/ge3_controller.h
@@ -82,6 +82,10 @@ class Ge3Controller final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/gem/gem_controller.cc
+++ b/modules/canbus/vehicle/gem/gem_controller.cc
@@ -399,6 +399,17 @@ void GemController::Throttle(double pedal) {
   accel_cmd_67_->set_accel_cmd(pedal / 100.0);
 }
 
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void GemController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
 // gem default, -470 ~ 470, left:+, right:-
 // need to be compatible with control module, so reverse
 // steering with old angle speed

--- a/modules/canbus/vehicle/gem/gem_controller.h
+++ b/modules/canbus/vehicle/gem/gem_controller.h
@@ -88,6 +88,10 @@ class GemController final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/lexus/lexus_controller.cc
+++ b/modules/canbus/vehicle/lexus/lexus_controller.cc
@@ -465,6 +465,17 @@ void LexusController::Throttle(double pedal) {
   accel_cmd_100_->set_accel_cmd(pedal);
 }
 
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void LexusController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
 // lexus default, -470 ~ 470, left:+, right:-
 // need to be compatible with control module, so reverse
 // steering with old angle speed

--- a/modules/canbus/vehicle/lexus/lexus_controller.h
+++ b/modules/canbus/vehicle/lexus/lexus_controller.h
@@ -87,6 +87,10 @@ class LexusController final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/lincoln/lincoln_controller.cc
+++ b/modules/canbus/vehicle/lincoln/lincoln_controller.cc
@@ -552,6 +552,17 @@ void LincolnController::Throttle(double pedal) {
   throttle_62_->set_pedal(pedal);
 }
 
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void LincolnController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
 // lincoln default, -470 ~ 470, left:+, right:-
 // need to be compatible with control module, so reverse
 // steering with old angle speed

--- a/modules/canbus/vehicle/lincoln/lincoln_controller.h
+++ b/modules/canbus/vehicle/lincoln/lincoln_controller.h
@@ -108,6 +108,10 @@ class LincolnController final : public VehicleController {
   // gas:0.00~99.99 unit:%
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:%, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/transit/transit_controller.cc
+++ b/modules/canbus/vehicle/transit/transit_controller.cc
@@ -431,6 +431,17 @@ void TransitController::Throttle(double pedal) {
   }
 }
 
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void TransitController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
 // transit default, -470 ~ 470, left:+, right:-
 // need to be compatible with control module, so reverse
 // steering with old angle speed

--- a/modules/canbus/vehicle/transit/transit_controller.h
+++ b/modules/canbus/vehicle/transit/transit_controller.h
@@ -85,6 +85,10 @@ class TransitController final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/vehicle_controller.cc
+++ b/modules/canbus/vehicle/vehicle_controller.cc
@@ -15,7 +15,6 @@
  *****************************************************************************/
 
 #include "modules/canbus/vehicle/vehicle_controller.h"
-#include "modules/canbus/common/canbus_gflags.h"
 
 #include "cyber/common/log.h"
 
@@ -127,16 +126,9 @@ ErrorCode VehicleController::Update(const ControlCommand &command) {
   if (driving_mode_ == Chassis::COMPLETE_AUTO_DRIVE ||
       driving_mode_ == Chassis::AUTO_SPEED_ONLY) {
     Gear(control_command.gear_location());
-    if (!FLAGS_use_acceleration) {
-      Throttle(control_command.throttle());
-      Brake(control_command.brake());
-    } else {
-     if (control_command.acceleration() >= 0) {
-      Throttle(control_command.throttle());
-      } else {
-      Brake(control_command.brake());
-      }
-    }
+    Throttle(control_command.throttle());
+    Acceleration(control_command.acceleration());
+    Brake(control_command.brake());
     SetEpbBreak(control_command);
     SetLimits();
   }

--- a/modules/canbus/vehicle/vehicle_controller.cc
+++ b/modules/canbus/vehicle/vehicle_controller.cc
@@ -15,6 +15,7 @@
  *****************************************************************************/
 
 #include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/canbus/common/canbus_gflags.h"
 
 #include "cyber/common/log.h"
 
@@ -126,8 +127,16 @@ ErrorCode VehicleController::Update(const ControlCommand &command) {
   if (driving_mode_ == Chassis::COMPLETE_AUTO_DRIVE ||
       driving_mode_ == Chassis::AUTO_SPEED_ONLY) {
     Gear(control_command.gear_location());
-    Throttle(control_command.throttle());
-    Brake(control_command.brake());
+    if (!FLAGS_use_acceleration) {
+      Throttle(control_command.throttle());
+      Brake(control_command.brake());
+    } else {
+     if (control_command.acceleration() >= 0) {
+      Throttle(control_command.throttle());
+      } else {
+      Brake(control_command.brake());
+      }
+    }
     SetEpbBreak(control_command);
     SetLimits();
   }

--- a/modules/canbus/vehicle/vehicle_controller.h
+++ b/modules/canbus/vehicle/vehicle_controller.h
@@ -127,6 +127,12 @@ class VehicleController {
   virtual void Throttle(double throttle) = 0;
 
   /*
+   * @brief drive with new acceleration/deceleration:-7.0~7.0, unit:m/s^2,
+   * acc:-7.0~7.0, unit:m/s^2
+   */
+  virtual void Acceleration(double acc) = 0;
+
+  /*
    * @brief steering with old angle speed angle:-99.99~0.00~99.99, unit:%,
    * left:+, right:-
    */

--- a/modules/canbus/vehicle/vehicle_factory.cc
+++ b/modules/canbus/vehicle/vehicle_factory.cc
@@ -21,6 +21,7 @@
 #include "modules/canbus/vehicle/lincoln/lincoln_vehicle_factory.h"
 #include "modules/canbus/vehicle/transit/transit_vehicle_factory.h"
 #include "modules/canbus/vehicle/ge3/ge3_vehicle_factory.h"
+#include "modules/canbus/vehicle/wey/wey_vehicle_factory.h"
 
 namespace apollo {
 namespace canbus {
@@ -40,6 +41,9 @@ void VehicleFactory::RegisterVehicleFactory() {
   });
   Register(VehicleParameter::GE3, []() -> AbstractVehicleFactory * {
     return new Ge3VehicleFactory();
+  });
+  Register(VehicleParameter::WEY, []() -> AbstractVehicleFactory * {
+    return new WeyVehicleFactory();
   });
 }
 

--- a/modules/canbus/vehicle/wey/BUILD
+++ b/modules/canbus/vehicle/wey/BUILD
@@ -1,0 +1,91 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "wey_vehicle_factory",
+    srcs = [
+        "wey_vehicle_factory.cc",
+    ],
+    hdrs = [
+        "wey_vehicle_factory.h",
+    ],
+    deps = [
+        ":wey_controller",
+        ":wey_message_manager",
+        "//modules/canbus/vehicle:abstract_vehicle_factory",
+    ],
+)
+
+cc_test(
+    name = "wey_vehicle_factory_test",
+    size = "small",
+    srcs = ["wey_vehicle_factory_test.cc"],
+    deps = [
+        ":wey_vehicle_factory",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "wey_message_manager",
+    srcs = [
+        "wey_message_manager.cc",
+    ],
+    hdrs = [
+        "wey_message_manager.h",
+    ],
+    deps = [
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+    ],
+)
+
+cc_test(
+    name = "wey_message_manager_test",
+    size = "small",
+    srcs = [
+        "wey_message_manager_test.cc",
+    ],
+    deps = [
+        ":wey_message_manager",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "wey_controller",
+    srcs = [
+        "wey_controller.cc",
+    ],
+    hdrs = [
+        "wey_controller.h",
+    ],
+    deps = [
+        ":wey_message_manager",
+        "//modules/drivers/canbus/can_comm:can_sender",
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle:vehicle_controller_base",
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+    ],
+)
+
+cc_test(
+    name = "wey_controller_test",
+    size = "small",
+    data = ["//modules/canbus:canbus_testdata"],
+    srcs = [
+        "wey_controller_test.cc",
+    ],
+    deps = [
+        ":wey_controller",
+        "//modules/common/util:util",
+        "@gtest//:main",
+    ],
+)
+
+cpplint()

--- a/modules/canbus/vehicle/wey/protocol/BUILD
+++ b/modules/canbus/vehicle/wey/protocol/BUILD
@@ -1,0 +1,213 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "canbus_wey_protocol",
+    srcs = [
+      "ads_eps_113.cc",
+      "ads_req_vin_390.cc",
+      "ads_shifter_115.cc",
+      "ads1_111.cc",
+      "ads3_38e.cc",
+      "fail_241.cc",
+      "fbs1_243.cc",
+      "fbs2_240.cc",
+      "fbs3_237.cc",
+      "fbs4_235.cc",
+      "status_310.cc",
+      "vin_resp1_391.cc",
+      "vin_resp2_392.cc",
+      "vin_resp3_393.cc",
+    ],
+    hdrs = [
+      "ads_eps_113.h",
+      "ads_req_vin_390.h",
+      "ads_shifter_115.h",
+      "ads1_111.h",
+      "ads3_38e.h",
+      "fail_241.h",
+      "fbs1_243.h",
+      "fbs2_240.h",
+      "fbs3_237.h",
+      "fbs4_235.h",
+      "status_310.h",
+      "vin_resp1_391.h",
+      "vin_resp2_392.h",
+      "vin_resp3_393.h",
+    ],
+    deps = [
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+    ],
+)
+
+cc_test(
+    name = "ads1_111_test",
+    size = "small",
+    srcs = [
+        "ads1_111_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ads3_38e_test",
+    size = "small",
+    srcs = [
+        "ads3_38e_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ads_eps_113_test",
+    size = "small",
+    srcs = [
+        "ads_eps_113_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ads_req_vin_390_test",
+    size = "small",
+    srcs = [
+        "ads_req_vin_390_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ads_shifter_115_test",
+    size = "small",
+    srcs = [
+        "ads_shifter_115_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "fail_241_test",
+    size = "small",
+    srcs = [
+        "fail_241_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "fbs1_243_test",
+    size = "small",
+    srcs = [
+        "fbs1_243_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "fbs2_240_test",
+    size = "small",
+    srcs = [
+        "fbs2_240_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "fbs3_237_test",
+    size = "small",
+    srcs = [
+        "fbs3_237_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "fbs4_235_test",
+    size = "small",
+    srcs = [
+        "fbs4_235_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "status_310_test",
+    size = "small",
+    srcs = [
+        "status_310_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "vin_resp1_391_test",
+    size = "small",
+    srcs = [
+        "vin_resp1_391_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "vin_resp2_392_test",
+    size = "small",
+    srcs = [
+        "vin_resp2_392_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "vin_resp3_393_test",
+    size = "small",
+    srcs = [
+        "vin_resp3_393_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
+        "@gtest//:main",
+    ],
+)
+cpplint()

--- a/modules/canbus/vehicle/wey/protocol/ads1_111.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads1_111.cc
@@ -1,0 +1,187 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads1_111.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Ads1111::ID = 0x111;
+
+// public
+Ads1111::Ads1111() { Reset(); }
+
+uint32_t Ads1111::GetPeriod() const {
+  // TODO(ChaoMa) :modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Ads1111::UpdateData(uint8_t* data) {
+  set_p_ads_dectostop(data, ads_dectostop_);
+  set_p_ads_mode(data, ads_mode_);
+  set_p_ads_taracce(data, ads_taracce_);
+  set_p_ads_driveoff_req(data, ads_driveoff_req_);
+  set_p_ads_aeb_taracce(data, ads_aeb_taracce_);
+  set_p_ads_aeb_tgtdecel_req(data, ads_aeb_tgtdecel_req_);
+}
+
+void Ads1111::Reset() {
+  // TODO(ChaoMa) :you should check this manually
+  ads_dectostop_ = Ads1_111::ADS_DECTOSTOP_NO_DEMAND;
+  ads_mode_ = Ads1_111::ADS_MODE_OFF_MODE;
+  ads_taracce_ = 0.0;
+  ads_driveoff_req_ = Ads1_111::ADS_DRIVEOFF_REQ_NO_DEMAND;
+  ads_aeb_taracce_ = 0.0;
+  ads_aeb_tgtdecel_req_ = Ads1_111::ADS_AEB_TGTDECEL_REQ_NO_DEMAND;
+}
+
+Ads1111* Ads1111::set_ads_dectostop(
+    Ads1_111::Ads_dectostopType ads_dectostop) {
+  ads_dectostop_ = ads_dectostop;
+  return this;
+}
+
+// config detail: {'description': 'ADS request ESP/VLC to decelerate untill
+// standstill.', 'enum': {0: 'ADS_DECTOSTOP_NO_DEMAND', 1:
+// 'ADS_DECTOSTOP_DEMAND'}, 'precision': 1.0, 'len': 1, 'name': 'ADS_DecToStop',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 17,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Ads1111::set_p_ads_dectostop(uint8_t* data,
+    Ads1_111::Ads_dectostopType ads_dectostop) {
+  int x = ads_dectostop;
+
+  Byte to_set(data + 2);
+  to_set.set_value(static_cast<uint8_t>(x), 1, 1);
+}
+
+
+Ads1111* Ads1111::set_ads_mode(
+    Ads1_111::Ads_modeType ads_mode) {
+  ads_mode_ = ads_mode;
+  return this;
+}
+
+// config detail: {'description': 'The status of the ADS control unit.
+// The ADS mode should be contained in every message sent by ADS', 'enum':
+// {0: 'ADS_MODE_OFF_MODE', 3: 'ADS_MODE_ACTIVE_MODE'}, 'precision': 1.0,
+// 'len': 5, 'name': 'ADS_Mode', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|31]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads1111::set_p_ads_mode(uint8_t* data,
+    Ads1_111::Ads_modeType ads_mode) {
+  int x = ads_mode;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 3, 5);
+}
+
+
+Ads1111* Ads1111::set_ads_taracce(
+    double ads_taracce) {
+  ads_taracce_ = ads_taracce;
+  return this;
+}
+
+// config detail: {'description': 'ADS target acceleration for transmission',
+// 'offset': -7.0, 'precision': 0.05, 'len': 8, 'name': 'ADS_TarAcce',
+// 'is_signed_var': False, 'physical_range': '[-7|5.75]', 'bit': 15, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+void Ads1111::set_p_ads_taracce(uint8_t* data,
+    double ads_taracce) {
+  ads_taracce = ProtocolData::BoundedValue(-7.0, 5.75, ads_taracce);
+  int x = static_cast<int>((ads_taracce - -7.000000) / 0.050000);
+
+  Byte to_set(data + 1);
+  to_set.set_value(static_cast<uint8_t>(x), 0, 8);
+}
+
+
+Ads1111* Ads1111::set_ads_driveoff_req(
+    Ads1_111::Ads_driveoff_reqType ads_driveoff_req) {
+  ads_driveoff_req_ = ads_driveoff_req;
+  return this;
+}
+
+// config detail: {'description': 'ACC request ESP drive off', 'enum': {0:
+// 'ADS_DRIVEOFF_REQ_NO_DEMAND', 1: 'ADS_DRIVEOFF_REQ_DEMAND'}, 'precision':1.0,
+// 'len': 1, 'name': 'ADS_Driveoff_Req', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 1, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads1111::set_p_ads_driveoff_req(uint8_t* data,
+    Ads1_111::Ads_driveoff_reqType ads_driveoff_req) {
+  int x = ads_driveoff_req;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 1, 1);
+}
+
+
+Ads1111* Ads1111::set_ads_aeb_taracce(
+    double ads_aeb_taracce) {
+  ads_aeb_taracce_ = ads_aeb_taracce;
+  return this;
+}
+
+// config detail: {'description': 'target deceleration value from AEB',
+// 'offset': -16.0, 'precision': 0.000488, 'len': 16, 'name': 'ADS_AEB_TarAcce',
+// 'is_signed_var': False, 'physical_range': '[-16|16]', 'bit': 39, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+void Ads1111::set_p_ads_aeb_taracce(uint8_t* data,
+    double ads_aeb_taracce) {
+  ads_aeb_taracce = ProtocolData::BoundedValue(-16.0, 16.0, ads_aeb_taracce);
+  int x = static_cast<int>((ads_aeb_taracce - -16.000000) / 0.000488);
+  uint8_t t = 0;
+
+  t = static_cast<uint8_t>(x & 0xFF);
+  Byte to_set0(data + 5);
+  to_set0.set_value(t, 0, 8);
+  x >>= 8;
+
+  t = static_cast<uint8_t>(x & 0xFF);
+  Byte to_set1(data + 4);
+  to_set1.set_value(t, 0, 8);
+}
+
+
+Ads1111* Ads1111::set_ads_aeb_tgtdecel_req(
+    Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req) {
+  ads_aeb_tgtdecel_req_ = ads_aeb_tgtdecel_req;
+  return this;
+}
+
+// config detail: {'description': 'Request of the AEB deceleration control.',
+// 'enum': {0: 'ADS_AEB_TGTDECEL_REQ_NO_DEMAND', 1:
+// 'ADS_AEB_TGTDECEL_REQ_DEMAND'}, 'precision': 1.0, 'len': 1,
+// 'name': 'ADS_AEB_TgtDecel_Req', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order':'motorola',
+// 'physical_unit': ''}
+void Ads1111::set_p_ads_aeb_tgtdecel_req(uint8_t* data,
+    Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req) {
+  int x = ads_aeb_tgtdecel_req;
+
+  Byte to_set(data + 3);
+  to_set.set_value(static_cast<uint8_t>(x), 7, 1);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads1_111.h
+++ b/modules/canbus/vehicle/wey/protocol/ads1_111.h
@@ -131,9 +131,9 @@ class Ads1111 : public ::apollo::drivers::canbus::ProtocolData<
  private:
   Ads1_111::Ads_dectostopType ads_dectostop_;
   Ads1_111::Ads_modeType ads_mode_;
-  double ads_taracce_;
+  double ads_taracce_ = 0.0;
   Ads1_111::Ads_driveoff_reqType ads_driveoff_req_;
-  double ads_aeb_taracce_;
+  double ads_aeb_taracce_ = 0.0;
   Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req_;
 };
 

--- a/modules/canbus/vehicle/wey/protocol/ads1_111.h
+++ b/modules/canbus/vehicle/wey/protocol/ads1_111.h
@@ -1,0 +1,143 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Ads1111 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Ads1111();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'ADS request ESP/VLC to decelerate untill
+  // standstill.', 'enum': {0: 'ADS_DECTOSTOP_NO_DEMAND', 1:
+  // 'ADS_DECTOSTOP_DEMAND'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_DecToStop', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 17, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads1111* set_ads_dectostop(Ads1_111::Ads_dectostopType ads_dectostop);
+
+  // config detail: {'description': 'The status of the ADS control unit.The ADS
+  // mode should be contained in every message sent by ADS', 'enum': {0:
+  // 'ADS_MODE_OFF_MODE', 3: 'ADS_MODE_ACTIVE_MODE'}, 'precision': 1.0, 'len':
+  // 5, 'name': 'ADS_Mode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|31]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads1111* set_ads_mode(Ads1_111::Ads_modeType ads_mode);
+
+  // config detail: {'description': 'ADS target acceleration for transmission',
+  // 'offset': -7.0, 'precision': 0.05, 'len': 8, 'name': 'ADS_TarAcce',
+  // 'is_signed_var': False, 'physical_range': '[-7|5.75]', 'bit': 15, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+  Ads1111* set_ads_taracce(double ads_taracce);
+
+  // config detail: {'description': 'ACC request ESP drive off', 'enum': {0:
+  // 'ADS_DRIVEOFF_REQ_NO_DEMAND', 1: 'ADS_DRIVEOFF_REQ_DEMAND'}, 'precision':
+  // 1.0, 'len': 1, 'name': 'ADS_Driveoff_Req', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 1, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Ads1111* set_ads_driveoff_req(
+                              Ads1_111::Ads_driveoff_reqType ads_driveoff_req);
+
+  // config detail: {'description': 'target deceleration value from AEB',
+  // 'offset': -16.0, 'precision': 0.000488, 'len': 16, 'name':
+  // 'ADS_AEB_TarAcce', 'is_signed_var': False, 'physical_range': '[-16|16]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+  Ads1111* set_ads_aeb_taracce(double ads_aeb_taracce);
+
+  // config detail: {'description': 'Request of the AEB deceleration control.',
+  // 'enum': {0: 'ADS_AEB_TGTDECEL_REQ_NO_DEMAND', 1:
+  // 'ADS_AEB_TGTDECEL_REQ_DEMAND'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_AEB_TgtDecel_Req', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads1111* set_ads_aeb_tgtdecel_req(
+                      Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req);
+
+ private:
+  // config detail: {'description': 'ADS request ESP/VLC to decelerate untill
+  // standstill.', 'enum': {0: 'ADS_DECTOSTOP_NO_DEMAND', 1:
+  // 'ADS_DECTOSTOP_DEMAND'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_DecToStop', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|1]', 'bit': 17, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_dectostop(uint8_t* data,
+                           Ads1_111::Ads_dectostopType ads_dectostop);
+
+  // config detail: {'description': 'The status of the ADS control unit.The
+  // ADS mode should be contained in every message sent by ADS', 'enum': {0:
+  // 'ADS_MODE_OFF_MODE', 3: 'ADS_MODE_ACTIVE_MODE'}, 'precision': 1.0,
+  // 'len': 5, 'name': 'ADS_Mode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|31]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_mode(uint8_t* data, Ads1_111::Ads_modeType ads_mode);
+
+  // config detail: {'description': 'ADS target acceleration for transmission',
+  // 'offset': -7.0, 'precision': 0.05, 'len': 8, 'name': 'ADS_TarAcce',
+  // 'is_signed_var': False, 'physical_range': '[-7|5.75]', 'bit': 15,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+  void set_p_ads_taracce(uint8_t* data, double ads_taracce);
+
+  // config detail: {'description': 'ACC request ESP drive off', 'enum': {0:
+  // 'ADS_DRIVEOFF_REQ_NO_DEMAND', 1: 'ADS_DRIVEOFF_REQ_DEMAND'}, 'precision':
+  // 1.0, 'len': 1, 'name': 'ADS_Driveoff_Req', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 1, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_ads_driveoff_req(uint8_t* data,
+                              Ads1_111::Ads_driveoff_reqType ads_driveoff_req);
+
+  // config detail: {'description': 'target deceleration value from AEB',
+  // 'offset': -16.0, 'precision': 0.000488, 'len': 16, 'name':
+  // 'ADS_AEB_TarAcce', 'is_signed_var': False, 'physical_range': '[-16|16]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s2'}
+  void set_p_ads_aeb_taracce(uint8_t* data, double ads_aeb_taracce);
+
+  // config detail: {'description': 'Request of the AEB deceleration control.',
+  // 'enum': {0: 'ADS_AEB_TGTDECEL_REQ_NO_DEMAND', 1:
+  // 'ADS_AEB_TGTDECEL_REQ_DEMAND'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_AEB_TgtDecel_Req', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_aeb_tgtdecel_req(uint8_t* data,
+                      Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req);
+
+ private:
+  Ads1_111::Ads_dectostopType ads_dectostop_;
+  Ads1_111::Ads_modeType ads_mode_;
+  double ads_taracce_;
+  Ads1_111::Ads_driveoff_reqType ads_driveoff_req_;
+  double ads_aeb_taracce_;
+  Ads1_111::Ads_aeb_tgtdecel_reqType ads_aeb_tgtdecel_req_;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/wey/protocol/ads1_111_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads1_111_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads1_111.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Ads1111Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ads1111Test, reset) {
+  uint8_t data[8] = {0x67, 0x62, 0x63, 0x64, 0x51, 0x52, 0x53, 0x54};
+  Ads1111 ads1;
+  EXPECT_EQ(ads1.GetPeriod(), 20 * 1000);
+  ads1.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000101);
+  EXPECT_EQ(data[1], 0b10001100);
+  EXPECT_EQ(data[2], 0b01100001);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b10000000);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b01010011);
+  EXPECT_EQ(data[7], 0b01010100);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads3_38e.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads3_38e.cc
@@ -1,0 +1,334 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads3_38e.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Ads338e::ID = 0x38E;
+
+// public
+Ads338e::Ads338e() { Reset(); }
+
+uint32_t Ads338e::GetPeriod() const {
+  // TODO(ChaoMa) :modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Ads338e::UpdateData(uint8_t* data) {
+  set_p_ads_bcm_worksts(data, ads_bcm_worksts_);
+  set_p_ads_bcmworkstsvalid(data, ads_bcmworkstsvalid_);
+  set_p_ads_reqcontrolbcm(data, ads_reqcontrolbcm_);
+  set_p_highbeamton(data, highbeamton_);
+  set_p_dippedbeamon(data, dippedbeamon_);
+  set_p_turnllighton(data, turnllighton_);
+  set_p_emergencylighton(data, emergencylighton_);
+  set_p_ffoglampon(data, ffoglampon_);
+  set_p_rfoglampon(data, rfoglampon_);
+  set_p_brakelight(data, brakelight_);
+  set_p_hornon(data, hornon_);
+  set_p_fwindshieldwiper(data, fwindshieldwiper_);
+  set_p_rwindshieldwiper(data, rwindshieldwiper_);
+}
+
+void Ads338e::Reset() {
+  // TODO(ChaoMa) you should check this manually
+  ads_bcm_worksts_ = Ads3_38e::ADS_BCM_WORKSTS_DISABLE;
+  ads_bcmworkstsvalid_ = Ads3_38e::ADS_BCMWORKSTSVALID_INVALID;
+  ads_reqcontrolbcm_ = Ads3_38e::ADS_REQCONTROLBCM_NO_REQUEST;
+  highbeamton_ = Ads3_38e::HIGHBEAMTON_TURN_OFF;
+  dippedbeamon_ = Ads3_38e::DIPPEDBEAMON_TURN_OFF;
+  turnllighton_ = Ads3_38e::TURNLLIGHTON_TURN_OFF;
+  emergencylighton_ = Ads3_38e::EMERGENCYLIGHTON_TURN_OFF;
+  ffoglampon_ = Ads3_38e::FFOGLAMPON_TURN_OFF;
+  rfoglampon_ = Ads3_38e::RFOGLAMPON_TURN_OFF;
+  brakelight_ = Ads3_38e::BRAKELIGHT_TURN_OFF;
+  hornon_ = Ads3_38e::HORNON_TURN_OFF;
+  fwindshieldwiper_ = Ads3_38e::FWINDSHIELDWIPER_TURN_OFF;
+  rwindshieldwiper_ = Ads3_38e::RWINDSHIELDWIPER_TURN_OFF;
+}
+
+Ads338e* Ads338e::set_ads_bcm_worksts(
+    Ads3_38e::Ads_bcm_workstsType ads_bcm_worksts) {
+  ads_bcm_worksts_ = ads_bcm_worksts;
+  return this;
+}
+
+// config detail: {'description': 'The work status of ADS control unit.
+// This signal should be contained in every message sent by ADS.', 'enum':
+// {0: 'ADS_BCM_WORKSTS_DISABLE', 1: 'ADS_BCM_WORKSTS_ENABLE',
+// 2: 'ADS_BCM_WORKSTS_ACTIVE', 3: 'ADS_BCM_WORKSTS_FAILED'}, 'precision': 1.0,
+// 'len': 2, 'name': 'ADS_BCM_WorkSts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|3]', 'bit': 6, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_ads_bcm_worksts(uint8_t* data,
+    Ads3_38e::Ads_bcm_workstsType ads_bcm_worksts) {
+  int x = ads_bcm_worksts;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 5, 2);
+}
+
+
+Ads338e* Ads338e::set_ads_bcmworkstsvalid(
+    Ads3_38e::Ads_bcmworkstsvalidType ads_bcmworkstsvalid) {
+  ads_bcmworkstsvalid_ = ads_bcmworkstsvalid;
+  return this;
+}
+
+// config detail: {'description': 'This Signal reflect the ADS_WorkSts Signal
+// is Valid OR not', 'enum': {0: 'ADS_BCMWORKSTSVALID_INVALID',
+// 1: 'ADS_BCMWORKSTSVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+// 'ADS_BCMWorkStsValid','is_signed_var': False, 'offset': 0.0,'physical_range':
+// '[0|1]', 'bit': 7, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Ads338e::set_p_ads_bcmworkstsvalid(uint8_t* data,
+    Ads3_38e::Ads_bcmworkstsvalidType ads_bcmworkstsvalid) {
+  int x = ads_bcmworkstsvalid;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 7, 1);
+}
+
+
+Ads338e* Ads338e::set_ads_reqcontrolbcm(
+    Ads3_38e::Ads_reqcontrolbcmType ads_reqcontrolbcm) {
+  ads_reqcontrolbcm_ = ads_reqcontrolbcm;
+  return this;
+}
+
+// config detail: {'description': 'Vehicle Task request.If ADS request control
+// BCM', 'enum': {0: 'ADS_REQCONTROLBCM_NO_REQUEST', 1:
+// 'ADS_REQCONTROLBCM_REQUEST'}, 'precision': 1.0, 'len': 1, 'name':
+// 'ADS_ReqControlBCM', 'is_signed_var':False, 'offset': 0.0, 'physical_range':
+// '[0|1]', 'bit': 8, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Ads338e::set_p_ads_reqcontrolbcm(uint8_t* data,
+    Ads3_38e::Ads_reqcontrolbcmType ads_reqcontrolbcm) {
+  int x = ads_reqcontrolbcm;
+
+  Byte to_set(data + 1);
+  to_set.set_value(static_cast<uint8_t>(x), 0, 1);
+}
+
+
+Ads338e* Ads338e::set_highbeamton(
+    Ads3_38e::HighbeamtonType highbeamton) {
+  highbeamton_ = highbeamton;
+  return this;
+}
+
+// config detail: {'description': 'Open theHigh Beam light', 'enum': {0:
+// 'HIGHBEAMTON_TURN_OFF', 1: 'HIGHBEAMTON_TURN_ON'}, 'precision': 1.0,
+// 'len': 1, 'name': 'HighBeamtON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 11, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_highbeamton(uint8_t* data,
+    Ads3_38e::HighbeamtonType highbeamton) {
+  int x = highbeamton;
+
+  Byte to_set(data + 1);
+  to_set.set_value(static_cast<uint8_t>(x), 3, 1);
+}
+
+
+Ads338e* Ads338e::set_dippedbeamon(
+    Ads3_38e::DippedbeamonType dippedbeamon) {
+  dippedbeamon_ = dippedbeamon;
+  return this;
+}
+
+// config detail: {'description': 'Open the dipped Beam light', 'enum': {0:
+// 'DIPPEDBEAMON_TURN_OFF', 1: 'DIPPEDBEAMON_TURN_ON'}, 'precision': 1.0,
+// 'len': 1, 'name': 'DippedBeamON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 12, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_dippedbeamon(uint8_t* data,
+    Ads3_38e::DippedbeamonType dippedbeamon) {
+  int x = dippedbeamon;
+
+  Byte to_set(data + 1);
+  to_set.set_value(static_cast<uint8_t>(x), 4, 1);
+}
+
+
+Ads338e* Ads338e::set_turnllighton(
+    Ads3_38e::TurnllightonType turnllighton) {
+  turnllighton_ = turnllighton;
+  return this;
+}
+
+// config detail: {'description': 'Open the Turn light', 'enum': {0:
+// 'TURNLLIGHTON_TURN_OFF', 1: 'TURNLLIGHTON_TURN_LEFT_ON', 2:
+// 'TURNLLIGHTON_TURN_RIGHT_ON', 3: 'TURNLLIGHTON_RESERVED'}, 'precision': 1.0,
+// 'len': 2, 'name': 'TurnlLightON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|3]', 'bit': 17, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_turnllighton(uint8_t* data,
+    Ads3_38e::TurnllightonType turnllighton) {
+  int x = turnllighton;
+
+  Byte to_set(data + 2);
+  to_set.set_value(static_cast<uint8_t>(x), 0, 2);
+}
+
+
+Ads338e* Ads338e::set_emergencylighton(
+    Ads3_38e::EmergencylightonType emergencylighton) {
+  emergencylighton_ = emergencylighton;
+  return this;
+}
+
+// config detail: {'description': 'Open the emergency light', 'enum': {0:
+// 'EMERGENCYLIGHTON_TURN_OFF', 1: 'EMERGENCYLIGHTON_TURN_ON'},'precision':1.0,
+// 'len': 1, 'name': 'EmergencyLightON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 45, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_emergencylighton(uint8_t* data,
+    Ads3_38e::EmergencylightonType emergencylighton) {
+  int x = emergencylighton;
+
+  Byte to_set(data + 5);
+  to_set.set_value(static_cast<uint8_t>(x), 5, 1);
+}
+
+
+Ads338e* Ads338e::set_ffoglampon(
+    Ads3_38e::FfoglamponType ffoglampon) {
+  ffoglampon_ = ffoglampon;
+  return this;
+}
+
+// config detail: {'description': 'Open the front fog light', 'enum': {0:
+// 'FFOGLAMPON_TURN_OFF', 1: 'FFOGLAMPON_TURN_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'FFogLampON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 46, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_ffoglampon(uint8_t* data,
+    Ads3_38e::FfoglamponType ffoglampon) {
+  int x = ffoglampon;
+
+  Byte to_set(data + 5);
+  to_set.set_value(static_cast<uint8_t>(x), 6, 1);
+}
+
+
+Ads338e* Ads338e::set_rfoglampon(
+    Ads3_38e::RfoglamponType rfoglampon) {
+  rfoglampon_ = rfoglampon;
+  return this;
+}
+
+// config detail: {'description': 'Open the rear fog ligh', 'enum': {0:
+// 'RFOGLAMPON_TURN_OFF', 1: 'RFOGLAMPON_TURN_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'RFogLampON', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 47, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_rfoglampon(uint8_t* data,
+    Ads3_38e::RfoglamponType rfoglampon) {
+  int x = rfoglampon;
+
+  Byte to_set(data + 5);
+  to_set.set_value(static_cast<uint8_t>(x), 7, 1);
+}
+
+
+Ads338e* Ads338e::set_brakelight(
+    Ads3_38e::BrakelightType brakelight) {
+  brakelight_ = brakelight;
+  return this;
+}
+
+// config detail: {'description': 'Open the brake light', 'enum': {0:
+// 'BRAKELIGHT_TURN_OFF', 1: 'BRAKELIGHT_TURN_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'BrakeLight', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 48, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_brakelight(uint8_t* data,
+    Ads3_38e::BrakelightType brakelight) {
+  int x = brakelight;
+
+  Byte to_set(data + 6);
+  to_set.set_value(static_cast<uint8_t>(x), 0, 1);
+}
+
+
+Ads338e* Ads338e::set_hornon(
+    Ads3_38e::HornonType hornon) {
+  hornon_ = hornon;
+  return this;
+}
+
+// config detail: {'description': 'Open the horn voice', 'enum': {0:
+// 'HORNON_TURN_OFF', 1: 'HORNON_TURN_ON'}, 'precision': 1.0, 'len': 1, 'name':
+// 'HornON', 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+// 'bit': 49, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Ads338e::set_p_hornon(uint8_t* data,
+    Ads3_38e::HornonType hornon) {
+  int x = hornon;
+
+  Byte to_set(data + 6);
+  to_set.set_value(static_cast<uint8_t>(x), 1, 1);
+}
+
+
+Ads338e* Ads338e::set_fwindshieldwiper(
+    Ads3_38e::FwindshieldwiperType fwindshieldwiper) {
+  fwindshieldwiper_ = fwindshieldwiper;
+  return this;
+}
+
+// config detail: {'description': 'Open front window shield wiper', 'enum': {0:
+// 'FWINDSHIELDWIPER_TURN_OFF', 1: 'FWINDSHIELDWIPER_TURN_ON'},'precision':1.0,
+// 'len': 1, 'name': 'Fwindshieldwiper', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 50, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_fwindshieldwiper(uint8_t* data,
+    Ads3_38e::FwindshieldwiperType fwindshieldwiper) {
+  int x = fwindshieldwiper;
+
+  Byte to_set(data + 6);
+  to_set.set_value(static_cast<uint8_t>(x), 2, 1);
+}
+
+
+Ads338e* Ads338e::set_rwindshieldwiper(
+    Ads3_38e::RwindshieldwiperType rwindshieldwiper) {
+  rwindshieldwiper_ = rwindshieldwiper;
+  return this;
+}
+
+// config detail: {'description': 'Open rear window shield wiper', 'enum': {0:
+// 'RWINDSHIELDWIPER_TURN_OFF', 1: 'RWINDSHIELDWIPER_TURN_ON'},'precision':1.0,
+// 'len': 1, 'name': 'Rwindshieldwiper', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 60, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Ads338e::set_p_rwindshieldwiper(uint8_t* data,
+    Ads3_38e::RwindshieldwiperType rwindshieldwiper) {
+  int x = rwindshieldwiper;
+
+  Byte to_set(data + 7);
+  to_set.set_value(static_cast<uint8_t>(x), 4, 1);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads3_38e.h
+++ b/modules/canbus/vehicle/wey/protocol/ads3_38e.h
@@ -1,0 +1,266 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Ads338e : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Ads338e();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'The work status of ADS control unit.
+  // This signal should be contained in every message sent by ADS.', 'enum':
+  // {0: 'ADS_BCM_WORKSTS_DISABLE', 1: 'ADS_BCM_WORKSTS_ENABLE',
+  // 2: 'ADS_BCM_WORKSTS_ACTIVE', 3:'ADS_BCM_WORKSTS_FAILED'},'precision': 1.0,
+  // 'len': 2, 'name': 'ADS_BCM_WorkSts', 'is_signed_var': False,'offset': 0.0,
+  // 'physical_range': '[0|3]', 'bit': 6, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_ads_bcm_worksts(Ads3_38e::Ads_bcm_workstsType ads_bcm_worksts);
+
+  // config detail: {'description': 'This Signal reflect the ADS_WorkSts Signal
+  // is Valid OR not', 'enum': {0: 'ADS_BCMWORKSTSVALID_INVALID',
+  // 1: 'ADS_BCMWORKSTSVALID_VALID'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'ADS_BCMWorkStsValid', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_ads_bcmworkstsvalid(
+                Ads3_38e::Ads_bcmworkstsvalidType ads_bcmworkstsvalid);
+
+  // config detail: {'description': 'Vehicle Task request.If ADS request
+  // control BCM', 'enum': {0: 'ADS_REQCONTROLBCM_NO_REQUEST',
+  // 1: 'ADS_REQCONTROLBCM_REQUEST'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_ReqControlBCM', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 8, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_ads_reqcontrolbcm(
+                Ads3_38e::Ads_reqcontrolbcmType ads_reqcontrolbcm);
+
+  // config detail: {'description': 'Open theHigh Beam light', 'enum':
+  // {0: 'HIGHBEAMTON_TURN_OFF', 1: 'HIGHBEAMTON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'HighBeamtON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 11, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_highbeamton(Ads3_38e::HighbeamtonType highbeamton);
+
+  // config detail: {'description': 'Open the dipped Beam light', 'enum':
+  // {0: 'DIPPEDBEAMON_TURN_OFF', 1: 'DIPPEDBEAMON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'DippedBeamON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 12, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_dippedbeamon(Ads3_38e::DippedbeamonType dippedbeamon);
+
+  // config detail: {'description': 'Open the Turn light', 'enum':
+  // {0: 'TURNLLIGHTON_TURN_OFF', 1: 'TURNLLIGHTON_TURN_LEFT_ON',
+  // 2: 'TURNLLIGHTON_TURN_RIGHT_ON', 3: 'TURNLLIGHTON_RESERVED'},
+  // 'precision': 1.0, 'len': 2, 'name': 'TurnlLightON', 'is_signed_var':False,
+  // 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 17, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Ads338e* set_turnllighton(Ads3_38e::TurnllightonType turnllighton);
+
+  // config detail: {'description': 'Open the emergency light', 'enum':
+  // {0: 'EMERGENCYLIGHTON_TURN_OFF', 1: 'EMERGENCYLIGHTON_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'EmergencyLightON', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 45, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Ads338e* set_emergencylighton(
+                        Ads3_38e::EmergencylightonType emergencylighton);
+
+  // config detail: {'description': 'Open the front fog light', 'enum':
+  // {0: 'FFOGLAMPON_TURN_OFF', 1: 'FFOGLAMPON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'FFogLampON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 46, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_ffoglampon(Ads3_38e::FfoglamponType ffoglampon);
+
+  // config detail: {'description': 'Open the rear fog ligh', 'enum':
+  // {0: 'RFOGLAMPON_TURN_OFF', 1: 'RFOGLAMPON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'RFogLampON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 47, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_rfoglampon(Ads3_38e::RfoglamponType rfoglampon);
+
+  // config detail: {'description': 'Open the brake light', 'enum':
+  // {0: 'BRAKELIGHT_TURN_OFF', 1: 'BRAKELIGHT_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'BrakeLight', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 48, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_brakelight(Ads3_38e::BrakelightType brakelight);
+
+  // config detail: {'description': 'Open the horn voice', 'enum':
+  // {0: 'HORNON_TURN_OFF', 1: 'HORNON_TURN_ON'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'HornON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 49, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Ads338e* set_hornon(Ads3_38e::HornonType hornon);
+
+  // config detail: {'description': 'Open front window shield wiper', 'enum':
+  // {0: 'FWINDSHIELDWIPER_TURN_OFF', 1: 'FWINDSHIELDWIPER_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'Fwindshieldwiper', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 50, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Ads338e* set_fwindshieldwiper(
+                      Ads3_38e::FwindshieldwiperType fwindshieldwiper);
+
+  // config detail: {'description': 'Open rear window shield wiper', 'enum':
+  // {0: 'RWINDSHIELDWIPER_TURN_OFF', 1: 'RWINDSHIELDWIPER_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'Rwindshieldwiper', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 60, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Ads338e* set_rwindshieldwiper(
+                      Ads3_38e::RwindshieldwiperType rwindshieldwiper);
+
+ private:
+  // config detail: {'description': 'The work status of ADS control unit.
+  // This signal should be contained in every message sent by ADS.', 'enum':
+  // {0: 'ADS_BCM_WORKSTS_DISABLE', 1: 'ADS_BCM_WORKSTS_ENABLE',
+  // 2: 'ADS_BCM_WORKSTS_ACTIVE', 3: 'ADS_BCM_WORKSTS_FAILED'},
+  // 'precision': 1.0, 'len': 2, 'name': 'ADS_BCM_WorkSts', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 6, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_ads_bcm_worksts(uint8_t* data,
+                        Ads3_38e::Ads_bcm_workstsType ads_bcm_worksts);
+
+  // config detail: {'description': 'This Signal reflect the ADS_WorkSts Signal
+  // is Valid OR not', 'enum': {0: 'ADS_BCMWORKSTSVALID_INVALID',
+  // 1: 'ADS_BCMWORKSTSVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'ADS_BCMWorkStsValid', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_bcmworkstsvalid(uint8_t* data,
+                        Ads3_38e::Ads_bcmworkstsvalidType ads_bcmworkstsvalid);
+
+  // config detail: {'description': 'Vehicle Task request.If ADS request
+  // control BCM', 'enum': {0: 'ADS_REQCONTROLBCM_NO_REQUEST',
+  // 1: 'ADS_REQCONTROLBCM_REQUEST'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'ADS_ReqControlBCM', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 8, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_reqcontrolbcm(uint8_t* data,
+                        Ads3_38e::Ads_reqcontrolbcmType ads_reqcontrolbcm);
+
+  // config detail: {'description': 'Open theHigh Beam light', 'enum':
+  // {0: 'HIGHBEAMTON_TURN_OFF', 1: 'HIGHBEAMTON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'HighBeamtON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 11, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_highbeamton(uint8_t* data, Ads3_38e::HighbeamtonType highbeamton);
+
+  // config detail: {'description': 'Open the dipped Beam light', 'enum':
+  // {0: 'DIPPEDBEAMON_TURN_OFF', 1: 'DIPPEDBEAMON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'DippedBeamON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 12, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_dippedbeamon(uint8_t* data,
+                        Ads3_38e::DippedbeamonType dippedbeamon);
+
+  // config detail: {'description': 'Open the Turn light', 'enum':
+  // {0: 'TURNLLIGHTON_TURN_OFF', 1: 'TURNLLIGHTON_TURN_LEFT_ON',
+  // 2: 'TURNLLIGHTON_TURN_RIGHT_ON', 3: 'TURNLLIGHTON_RESERVED'},
+  // 'precision': 1.0, 'len': 2, 'name': 'TurnlLightON', 'is_signed_var':False,
+  // 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 17, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_turnllighton(uint8_t* data,
+                        Ads3_38e::TurnllightonType turnllighton);
+
+  // config detail: {'description': 'Open the emergency light', 'enum':
+  // {0: 'EMERGENCYLIGHTON_TURN_OFF', 1: 'EMERGENCYLIGHTON_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'EmergencyLightON',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+  // 'bit': 45, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_emergencylighton(uint8_t* data,
+                        Ads3_38e::EmergencylightonType emergencylighton);
+
+  // config detail: {'description': 'Open the front fog light', 'enum':
+  // {0: 'FFOGLAMPON_TURN_OFF', 1: 'FFOGLAMPON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'FFogLampON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 46, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ffoglampon(uint8_t* data,
+                        Ads3_38e::FfoglamponType ffoglampon);
+
+  // config detail: {'description': 'Open the rear fog ligh', 'enum':
+  // {0: 'RFOGLAMPON_TURN_OFF', 1: 'RFOGLAMPON_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'RFogLampON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 47, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_rfoglampon(uint8_t* data,
+                        Ads3_38e::RfoglamponType rfoglampon);
+
+  // config detail: {'description': 'Open the brake light', 'enum':
+  // {0: 'BRAKELIGHT_TURN_OFF', 1: 'BRAKELIGHT_TURN_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'BrakeLight', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 48, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_brakelight(uint8_t* data, Ads3_38e::BrakelightType brakelight);
+
+  // config detail: {'description': 'Open the horn voice', 'enum':
+  // {0: 'HORNON_TURN_OFF', 1: 'HORNON_TURN_ON'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'HornON', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 49, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_hornon(uint8_t* data, Ads3_38e::HornonType hornon);
+
+  // config detail: {'description': 'Open front window shield wiper', 'enum':
+  // {0: 'FWINDSHIELDWIPER_TURN_OFF', 1: 'FWINDSHIELDWIPER_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'Fwindshieldwiper', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 50,'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_fwindshieldwiper(uint8_t* data,
+                        Ads3_38e::FwindshieldwiperType fwindshieldwiper);
+
+  // config detail: {'description': 'Open rear window shield wiper', 'enum':
+  // {0: 'RWINDSHIELDWIPER_TURN_OFF', 1: 'RWINDSHIELDWIPER_TURN_ON'},
+  // 'precision': 1.0, 'len': 1, 'name': 'Rwindshieldwiper', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 60,'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_rwindshieldwiper(uint8_t* data,
+                        Ads3_38e::RwindshieldwiperType rwindshieldwiper);
+
+ private:
+  Ads3_38e::Ads_bcm_workstsType ads_bcm_worksts_;
+  Ads3_38e::Ads_bcmworkstsvalidType ads_bcmworkstsvalid_;
+  Ads3_38e::Ads_reqcontrolbcmType ads_reqcontrolbcm_;
+  Ads3_38e::HighbeamtonType highbeamton_;
+  Ads3_38e::DippedbeamonType dippedbeamon_;
+  Ads3_38e::TurnllightonType turnllighton_;
+  Ads3_38e::EmergencylightonType emergencylighton_;
+  Ads3_38e::FfoglamponType ffoglampon_;
+  Ads3_38e::RfoglamponType rfoglampon_;
+  Ads3_38e::BrakelightType brakelight_;
+  Ads3_38e::HornonType hornon_;
+  Ads3_38e::FwindshieldwiperType fwindshieldwiper_;
+  Ads3_38e::RwindshieldwiperType rwindshieldwiper_;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/wey/protocol/ads3_38e_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads3_38e_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads3_38e.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Ads338eTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ads338eTest, reset) {
+  uint8_t data[8] = {0x67, 0x62, 0x63, 0x64, 0x51, 0x52, 0x53, 0x54};
+  Ads338e ads3;
+  EXPECT_EQ(ads3.GetPeriod(), 20 * 1000);
+  ads3.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000111);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100000);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b01010000);
+  EXPECT_EQ(data[7], 0b01000100);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_eps_113.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_eps_113.cc
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_eps_113.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Adseps113::ID = 0x113;
+
+// public
+Adseps113::Adseps113() { Reset(); }
+
+uint32_t Adseps113::GetPeriod() const {
+  // TODO(ChaoMa) :modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Adseps113::UpdateData(uint8_t* data) {
+  set_p_ads_epsmode(data, ads_epsmode_);
+  set_p_ads_reqepstargetangle(data, ads_reqepstargetangle_);
+}
+
+void Adseps113::Reset() {
+  // TODO(ChaoMa) :you should check this manually
+  ads_epsmode_ = Ads_eps_113::ADS_EPSMODE_DISABLE;
+  ads_reqepstargetangle_ = 0.0;
+}
+
+Adseps113* Adseps113::set_ads_epsmode(
+    Ads_eps_113::Ads_epsmodeType ads_epsmode) {
+  ads_epsmode_ = ads_epsmode;
+  return this;
+}
+
+// config detail: {'description': 'EPS Mode', 'enum': {0: 'ADS_EPSMODE_DISABLE'
+// 2: 'ADS_EPSMODE_ACTIVE'}, 'precision': 1.0, 'len': 2, 'name': 'ADS_EPSMode',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 7,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Adseps113::set_p_ads_epsmode(uint8_t* data,
+    Ads_eps_113::Ads_epsmodeType ads_epsmode) {
+  int x = ads_epsmode;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 6, 2);
+}
+
+
+Adseps113* Adseps113::set_ads_reqepstargetangle(
+    double ads_reqepstargetangle) {
+  ads_reqepstargetangle_ = ads_reqepstargetangle;
+  return this;
+}
+
+// config detail: {'description': 'Steering Wheel Target Angle', 'offset':
+// -800.0, 'precision': 0.1, 'len': 14, 'name': 'ADS_ReqEPSTargetAngle',
+// 'is_signed_var': False, 'physical_range': '[-800|838.3]', 'bit': 15,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'deg'}
+void Adseps113::set_p_ads_reqepstargetangle(uint8_t* data,
+    double ads_reqepstargetangle) {
+  ads_reqepstargetangle = ProtocolData::BoundedValue(-800.0, 838.3,
+                                                     ads_reqepstargetangle);
+  int x = static_cast<int>((ads_reqepstargetangle - -800.000000) / 0.100000);
+  uint8_t t = 0;
+
+  t = static_cast<uint8_t>(x & 0x3F);
+  Byte to_set0(data + 2);
+  to_set0.set_value(t, 2, 6);
+  x >>= 6;
+
+  t = static_cast<uint8_t>(x & 0xFF);
+  Byte to_set1(data + 1);
+  to_set1.set_value(t, 0, 8);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_eps_113.h
+++ b/modules/canbus/vehicle/wey/protocol/ads_eps_113.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adseps113 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Adseps113();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'EPS Mode', 'enum': {0:
+  // 'ADS_EPSMODE_DISABLE', 2: 'ADS_EPSMODE_ACTIVE'}, 'precision': 1.0,
+  // 'len': 2, 'name': 'ADS_EPSMode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|3]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Adseps113* set_ads_epsmode(Ads_eps_113::Ads_epsmodeType ads_epsmode);
+
+  // config detail: {'description': 'Steering Wheel Target Angle', 'offset':
+  // -800.0, 'precision': 0.1, 'len': 14, 'name': 'ADS_ReqEPSTargetAngle',
+  // 'is_signed_var': False, 'physical_range': '[-800|838.3]', 'bit': 15,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'deg'}
+  Adseps113* set_ads_reqepstargetangle(double ads_reqepstargetangle);
+
+ private:
+  // config detail: {'description': 'EPS Mode', 'enum': {0:
+  // 'ADS_EPSMODE_DISABLE', 2: 'ADS_EPSMODE_ACTIVE'}, 'precision': 1.0,
+  // 'len': 2, 'name': 'ADS_EPSMode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|3]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_epsmode(uint8_t* data, Ads_eps_113::
+                                                Ads_epsmodeType ads_epsmode);
+
+  // config detail: {'description': 'Steering Wheel Target Angle',
+  // 'offset': -800.0, 'precision': 0.1, 'len': 14, 'name':
+  // 'ADS_ReqEPSTargetAngle', 'is_signed_var': False, 'physical_range':
+  // '[-800|838.3]', 'bit': 15, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': 'deg'}
+  void set_p_ads_reqepstargetangle(uint8_t* data, double ads_reqepstargetangle);
+
+ private:
+  Ads_eps_113::Ads_epsmodeType ads_epsmode_;
+  double ads_reqepstargetangle_;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/wey/protocol/ads_eps_113.h
+++ b/modules/canbus/vehicle/wey/protocol/ads_eps_113.h
@@ -67,7 +67,7 @@ class Adseps113 : public ::apollo::drivers::canbus::ProtocolData<
 
  private:
   Ads_eps_113::Ads_epsmodeType ads_epsmode_;
-  double ads_reqepstargetangle_;
+  double ads_reqepstargetangle_ = 0.0;
 };
 
 }  // namespace wey

--- a/modules/canbus/vehicle/wey/protocol/ads_eps_113_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_eps_113_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_eps_113.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adseps113Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Adseps113Test, reset) {
+  uint8_t data[8] = {0x67, 0x62, 0x63, 0x64, 0x51, 0x52, 0x53, 0x54};
+  Adseps113 adseps;
+  EXPECT_EQ(adseps.GetPeriod(), 20 * 1000);
+  adseps.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00100111);
+  EXPECT_EQ(data[1], 0b01111101);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01010001);
+  EXPECT_EQ(data[5], 0b01010010);
+  EXPECT_EQ(data[6], 0b01010011);
+  EXPECT_EQ(data[7], 0b01010100);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_req_vin_390.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_req_vin_390.cc
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Adsreqvin390::ID = 0x390;
+
+// public
+Adsreqvin390::Adsreqvin390() { Reset(); }
+
+uint32_t Adsreqvin390::GetPeriod() const {
+  // TODO(ChaoMa) :modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Adsreqvin390::UpdateData(uint8_t* data) {
+  set_p_req_vin_signal(data, req_vin_signal_);
+}
+
+void Adsreqvin390::Reset() {
+  // TODO(ChaoMa) :you should check this manually
+  req_vin_signal_ = Ads_req_vin_390::REQ_VIN_SIGNAL_NO_REQUEST;
+}
+
+Adsreqvin390* Adsreqvin390::set_req_vin_signal(
+    Ads_req_vin_390::Req_vin_signalType req_vin_signal) {
+  req_vin_signal_ = req_vin_signal;
+  return this;
+}
+
+// config detail: {'name': 'Req_VIN_Signal', 'enum': {
+// 0: 'REQ_VIN_SIGNAL_NO_REQUEST', 1: 'REQ_VIN_SIGNAL_REQUEST'},
+// 'precision': 1.0, 'len': 8, 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|255]', 'bit': 7,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Adsreqvin390::set_p_req_vin_signal(uint8_t* data,
+    Ads_req_vin_390::Req_vin_signalType req_vin_signal) {
+  int x = req_vin_signal;
+
+  Byte to_set(data + 0);
+  to_set.set_value(static_cast<uint8_t>(x), 0, 8);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h
+++ b/modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adsreqvin390 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Adsreqvin390();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'Req_VIN_Signal', 'enum': {0:
+  // 'REQ_VIN_SIGNAL_NO_REQUEST', 1: 'REQ_VIN_SIGNAL_REQUEST'}, 'precision':
+  // 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|255]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Adsreqvin390* set_req_vin_signal(Ads_req_vin_390::
+                                   Req_vin_signalType req_vin_signal);
+
+ private:
+  // config detail: {'name': 'Req_VIN_Signal', 'enum': {0:
+  // 'REQ_VIN_SIGNAL_NO_REQUEST', 1: 'REQ_VIN_SIGNAL_REQUEST'}, 'precision':
+  // 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|255]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_req_vin_signal(uint8_t* data,
+                        Ads_req_vin_390::Req_vin_signalType req_vin_signal);
+
+ private:
+  Ads_req_vin_390::Req_vin_signalType req_vin_signal_;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_req_vin_390_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_req_vin_390_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adsreqvin390Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Adsreqvin390Test, reset) {
+  uint8_t data[8] = {0x67, 0x62, 0x63, 0x64, 0x51, 0x52, 0x53, 0x54};
+  Adsreqvin390 vin_req;
+  EXPECT_EQ(vin_req.GetPeriod(), 20 * 1000);
+  vin_req.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01010001);
+  EXPECT_EQ(data[5], 0b01010010);
+  EXPECT_EQ(data[6], 0b01010011);
+  EXPECT_EQ(data[7], 0b01010100);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_shifter_115.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_shifter_115.cc
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_shifter_115.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Adsshifter115::ID = 0x115;
+
+// public
+Adsshifter115::Adsshifter115() { Reset(); }
+
+uint32_t Adsshifter115::GetPeriod() const {
+  // TODO(ChaoMa) :modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Adsshifter115::UpdateData(uint8_t* data) {
+  set_p_ads_shiftmode(data, ads_shiftmode_);
+  set_p_ads_targetgear(data, ads_targetgear_);
+}
+
+void Adsshifter115::Reset() {
+  // TODO(ChaoMa) :you should check this manually
+  ads_shiftmode_ = Ads_shifter_115::ADS_SHIFTMODE_INVALID;
+  ads_targetgear_ = Ads_shifter_115::ADS_TARGETGEAR_N;
+}
+
+Adsshifter115* Adsshifter115::set_ads_shiftmode(
+    Ads_shifter_115::Ads_shiftmodeType ads_shiftmode) {
+  ads_shiftmode_ = ads_shiftmode;
+  return this;
+}
+
+// config detail: {'description': 'ADS Shift Mode', 'enum':
+// {0: 'ADS_SHIFTMODE_INVALID', 1: 'ADS_SHIFTMODE_VALID'}, 'precision': 1.0,
+// 'len': 4, 'name': 'ADS_ShiftMode', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+void Adsshifter115::set_p_ads_shiftmode(uint8_t* data,
+    Ads_shifter_115::Ads_shiftmodeType ads_shiftmode) {
+  int x = ads_shiftmode;
+
+  Byte to_set(data + 3);
+  to_set.set_value(static_cast<uint8_t>(x), 4, 4);
+}
+
+
+Adsshifter115* Adsshifter115::set_ads_targetgear(
+    Ads_shifter_115::Ads_targetgearType ads_targetgear) {
+  ads_targetgear_ = ads_targetgear;
+  return this;
+}
+
+// config detail: {'description': 'ADS Target Gear', 'enum':
+// {0: 'ADS_TARGETGEAR_N', 1: 'ADS_TARGETGEAR_R', 2: 'ADS_TARGETGEAR_P',
+// 3: 'ADS_TARGETGEAR_D'}, 'precision': 1.0, 'len': 2, 'name': 'ADS_TargetGear',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|0]', 'bit': 38,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Adsshifter115::set_p_ads_targetgear(uint8_t* data,
+    Ads_shifter_115::Ads_targetgearType ads_targetgear) {
+  int x = ads_targetgear;
+
+  Byte to_set(data + 4);
+  to_set.set_value(static_cast<uint8_t>(x), 5, 2);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/ads_shifter_115.h
+++ b/modules/canbus/vehicle/wey/protocol/ads_shifter_115.h
@@ -1,0 +1,80 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adsshifter115 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Adsshifter115();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'ADS Shift Mode', 'enum': {0:
+  // 'ADS_SHIFTMODE_INVALID', 1: 'ADS_SHIFTMODE_VALID'}, 'precision': 1.0,
+  // 'len': 4, 'name': 'ADS_ShiftMode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Adsshifter115* set_ads_shiftmode(Ads_shifter_115::
+                                   Ads_shiftmodeType ads_shiftmode);
+
+  // config detail: {'description': 'ADS Target Gear', 'enum': {0:
+  // 'ADS_TARGETGEAR_N', 1: 'ADS_TARGETGEAR_R', 2: 'ADS_TARGETGEAR_P', 3:
+  // 'ADS_TARGETGEAR_D'}, 'precision': 1.0, 'len': 2, 'name': 'ADS_TargetGear',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|0]',
+  // 'bit': 38, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Adsshifter115* set_ads_targetgear(Ads_shifter_115::
+                                    Ads_targetgearType ads_targetgear);
+
+ private:
+  // config detail: {'description': 'ADS Shift Mode', 'enum': {0:
+  // 'ADS_SHIFTMODE_INVALID', 1: 'ADS_SHIFTMODE_VALID'}, 'precision': 1.0,
+  // 'len': 4, 'name': 'ADS_ShiftMode', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_ads_shiftmode(uint8_t* data, Ads_shifter_115::
+                           Ads_shiftmodeType ads_shiftmode);
+
+  // config detail: {'description': 'ADS Target Gear', 'enum': {0:
+  // 'ADS_TARGETGEAR_N', 1: 'ADS_TARGETGEAR_R', 2: 'ADS_TARGETGEAR_P', 3:
+  // 'ADS_TARGETGEAR_D'}, 'precision': 1.0, 'len': 2, 'name': 'ADS_TargetGear',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|0]',
+  // 'bit': 38, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_ads_targetgear(uint8_t* data, Ads_shifter_115::
+                            Ads_targetgearType ads_targetgear);
+
+ private:
+  Ads_shifter_115::Ads_shiftmodeType ads_shiftmode_;
+  Ads_shifter_115::Ads_targetgearType ads_targetgear_;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/wey/protocol/ads_shifter_115_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/ads_shifter_115_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/ads_shifter_115.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Adsshifter115Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Adsshifter115Test, reset) {
+  uint8_t data[8] = {0x67, 0x62, 0x63, 0x64, 0x51, 0x52, 0x53, 0x54};
+  Adsshifter115 ads_shift;
+  EXPECT_EQ(ads_shift.GetPeriod(), 20 * 1000);
+  ads_shift.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01100111);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b01010010);
+  EXPECT_EQ(data[6], 0b01010011);
+  EXPECT_EQ(data[7], 0b01010100);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fail_241.cc
+++ b/modules/canbus/vehicle/wey/protocol/fail_241.cc
@@ -1,0 +1,119 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fail_241.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Fail241::Fail241() {}
+const int32_t Fail241::ID = 0x241;
+
+void Fail241::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_fail_241()->
+                                  set_engfail(engfail(bytes, length));
+  chassis->mutable_wey()->mutable_fail_241()->
+                                  set_espfail(espfail(bytes, length));
+  chassis->mutable_wey()->mutable_fail_241()->
+                                  set_epbfail(epbfail(bytes, length));
+  chassis->mutable_wey()->mutable_fail_241()->
+                                  set_shiftfail(shiftfail(bytes, length));
+  chassis->mutable_wey()->mutable_fail_241()->
+                                  set_epsfail(epsfail(bytes, length));
+}
+
+// config detail: {'description': 'Engine Fail status', 'enum': {0:
+// 'ENGFAIL_NO_FAIL', 1: 'ENGFAIL_FAIL'}, 'precision': 1.0, 'len': 1, 'name':
+// 'engfail', 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+// 'bit': 7, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fail_241::EngfailType Fail241::engfail(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(7, 1);
+
+  Fail_241::EngfailType ret =  static_cast<Fail_241::EngfailType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'ESP fault', 'enum': {0:'ESPFAIL_NO_FAILURE',
+// 1: 'ESPFAIL_FAILURE'}, 'precision': 1.0, 'len': 1, 'name': 'espfail',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 14,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fail_241::EspfailType Fail241::espfail(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(6, 1);
+
+  Fail_241::EspfailType ret =  static_cast<Fail_241::EspfailType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'error indication of EPB system', 'enum': {0:
+// 'EPBFAIL_UNDEFINED', 1: 'EPBFAIL_NO_ERROR', 2: 'EPBFAIL_ERROR', 3:
+// 'EPBFAIL_DIAGNOSIS'}, 'precision': 1.0, 'len': 2, 'name': 'epbfail',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 35,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fail_241::EpbfailType Fail241::epbfail(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(2, 2);
+
+  Fail_241::EpbfailType ret =  static_cast<Fail_241::EpbfailType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Driver display failure messages', 'enum': {0:
+// 'SHIFTFAIL_NO_FAIL', 1: 'SHIFTFAIL_TRANSMISSION_MALFUNCTION', 2:
+// 'SHIFTFAIL_TRANSMISSION_P_ENGAGEMENT_FAULT', 3:
+// 'SHIFTFAIL_TRANSMISSION_P_DISENGAGEMENT_FAULT', 4: 'SHIFTFAIL_RESERVED',
+// 15: 'SHIFTFAIL_TRANSMISSION_LIMIT_FUNCTION'}, 'precision': 1.0, 'len': 4,
+// 'name': 'shiftfail', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|15]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Fail_241::ShiftfailType Fail241::shiftfail(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(4, 4);
+
+  Fail_241::ShiftfailType ret =  static_cast<Fail_241::ShiftfailType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Electrical steering fail status', 'enum':
+// {0: 'EPSFAIL_NO_FAULT', 1: 'EPSFAIL_FAULT'}, 'precision': 1.0, 'len': 1,
+// 'name': 'epsfail', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 21, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Fail_241::EpsfailType Fail241::epsfail(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(5, 1);
+
+  Fail_241::EpsfailType ret =  static_cast<Fail_241::EpsfailType>(x);
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fail_241.h
+++ b/modules/canbus/vehicle/wey/protocol/fail_241.h
@@ -1,0 +1,81 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fail241 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Fail241();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Engine Fail status', 'enum': {0:
+  // 'ENGFAIL_NO_FAIL', 1: 'ENGFAIL_FAIL'}, 'precision': 1.0, 'len': 1,'name':
+  // 'EngFail', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|1]', 'bit': 7, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Fail_241::EngfailType engfail(const std::uint8_t* bytes,
+                                 const int32_t length) const;
+
+  // config detail: {'description': 'ESP fault', 'enum': {0:
+  // 'ESPFAIL_NO_FAILURE', 1: 'ESPFAIL_FAILURE'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'ESPFail', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 14, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Fail_241::EspfailType espfail(const std::uint8_t* bytes,
+                                 const int32_t length) const;
+
+  // config detail: {'description': 'error indication of EPB system', 'enum':
+  // {0: 'EPBFAIL_UNDEFINED', 1: 'EPBFAIL_NO_ERROR', 2: 'EPBFAIL_ERROR', 3:
+  // 'EPBFAIL_DIAGNOSIS'}, 'precision': 1.0, 'len': 2, 'name': 'EPBFail',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+  // 'bit': 35, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fail_241::EpbfailType epbfail(const std::uint8_t* bytes,
+                                 const int32_t length) const;
+
+  // config detail: {'description': 'Driver display failure messages', 'enum':
+  // {0: 'SHIFTFAIL_NO_FAIL', 1: 'SHIFTFAIL_TRANSMISSION_MALFUNCTION',
+  // 2: 'SHIFTFAIL_TRANSMISSION_P_ENGAGEMENT_FAULT',
+  // 3: 'SHIFTFAIL_TRANSMISSION_P_DISENGAGEMENT_FAULT', 4:'SHIFTFAIL_RESERVED',
+  // 15: 'SHIFTFAIL_TRANSMISSION_LIMIT_FUNCTION'}, 'precision': 1.0, 'len': 4,
+  // 'name': 'ShiftFail', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|15]', 'bit': 31, 'type': 'enum', 'order':'motorola',
+  // 'physical_unit': ''}
+  Fail_241::ShiftfailType shiftfail(const std::uint8_t* bytes,
+                                     const int32_t length) const;
+
+  // config detail: {'description': 'Electrical steering fail status', 'enum':
+  // {0: 'EPSFAIL_NO_FAULT', 1: 'EPSFAIL_FAULT'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'EPSFail', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 21, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Fail_241::EpsfailType epsfail(const std::uint8_t* bytes,
+                                 const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fail_241_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/fail_241_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fail_241.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fail241Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Fail241Test, reset) {
+  Fail241 fail1;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x95, 0x12, 0x13, 0x14};
+
+  fail1.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fail_241().engfail(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fail_241().espfail(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fail_241().epbfail(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fail_241().shiftfail(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fail_241().epsfail(), 1);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs1_243.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs1_243.cc
@@ -1,0 +1,135 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs1_243.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Fbs1243::Fbs1243() {}
+const int32_t Fbs1243::ID = 0x243;
+
+void Fbs1243::Parse(const std::uint8_t* bytes, int32_t length,
+                                            ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_fbs1_243()->set_longitudeacce(
+                                          longitudeacce(bytes, length));
+  chassis->mutable_wey()->mutable_fbs1_243()->set_lateralacce(
+                                          lateralacce(bytes, length));
+  chassis->mutable_wey()->mutable_fbs1_243()->set_vehdynyawrate(
+                                          vehdynyawrate(bytes, length));
+  chassis->mutable_wey()->mutable_fbs1_243()->set_flwheelspd(
+                                          flwheelspd(bytes, length));
+  chassis->mutable_wey()->mutable_fbs1_243()->set_frwheeldirection(
+                                          frwheeldirection(bytes, length));
+}
+
+// config detail: {'description': 'Longitude acceleration', 'offset': -21.592,
+// 'precision': 0.00098, 'len': 16, 'name': 'longitudeacce', 'is_signed_var':
+// False, 'physical_range': '[-21.592|21.592]', 'bit': 7, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'm/s^2'}
+double Fbs1243::longitudeacce(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.000980 + -21.592000;
+  return ret;
+}
+
+// config detail: {'description': 'Indicates Lateral Acceleration', 'offset':
+// -21.592, 'precision': 0.00098, 'len': 16, 'name': 'lateralacce',
+// 'is_signed_var': False, 'physical_range': '[-21.592|21.592]', 'bit': 23,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s^2'}
+double Fbs1243::lateralacce(const std::uint8_t* bytes,
+                                       int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.000980 + -21.592000;
+  return ret;
+}
+
+// config detail: {'description': 'Vehicle yaw rate', 'offset': -2.093,
+// 'precision': 0.00024, 'len': 16, 'name': 'vehdynyawrate', 'is_signed_var':
+// False, 'physical_range': '[-2.093|2.093]', 'bit': 39, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'rad/s'}
+double Fbs1243::vehdynyawrate(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.000240 + -2.093000;
+  return ret;
+}
+
+// config detail: {'description': 'Front left wheel speed', 'offset': 0.0,
+// 'precision': 0.05625, 'len': 13, 'name': 'flwheelspd', 'is_signed_var':
+// False, 'physical_range': '[0|299.98125]', 'bit': 55, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'Km/h'}
+double Fbs1243::flwheelspd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(3, 5);
+  x <<= 5;
+  x |= t;
+
+  double ret = x * 0.056250;
+  return ret;
+}
+
+// config detail: {'description': 'Front right wheel  Moving direction',
+// 'enum': {0: 'FRWHEELDIRECTION_INVALID', 1: 'FRWHEELDIRECTION_FORWARD',
+// 2: 'FRWHEELDIRECTION_BACKWARD', 3: 'FRWHEELDIRECTION_STOP'}, 'precision':
+// 1.0, 'len': 2, 'name': 'frwheeldirection', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 57, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Fbs1_243::FrwheeldirectionType Fbs1243::frwheeldirection(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 2);
+
+  Fbs1_243::FrwheeldirectionType ret =
+                          static_cast<Fbs1_243::FrwheeldirectionType>(x);
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs1_243.h
+++ b/modules/canbus/vehicle/wey/protocol/fbs1_243.h
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs1243 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Fbs1243();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Longitude acceleration', 'offset': -21.592,
+  // 'precision': 0.00098, 'len': 16, 'name': 'LongitudeAcce',
+  // 'is_signed_var': False, 'physical_range': '[-21.592|21.592]', 'bit': 7,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s^2'}
+  double longitudeacce(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Indicates Lateral Acceleration',
+  // 'offset': -21.592, 'precision': 0.00098, 'len': 16, 'name': 'LateralAcce',
+  // 'is_signed_var': False, 'physical_range': '[-21.592|21.592]', 'bit': 23,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'm/s^2'}
+  double lateralacce(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Vehicle yaw rate', 'offset': -2.093,
+  // 'precision': 0.00024, 'len': 16, 'name': 'VehDynYawRate',
+  // 'is_signed_var': False, 'physical_range': '[-2.093|2.093]', 'bit': 39,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'rad/s'}
+  double vehdynyawrate(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front left wheel speed', 'offset': 0.0,
+  // 'precision': 0.05625, 'len': 13, 'name': 'FLWheelSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|299.98125]', 'bit': 55,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+  double flwheelspd(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front right wheel  Moving direction',
+  // 'enum': {0: 'FRWHEELDIRECTION_INVALID', 1: 'FRWHEELDIRECTION_FORWARD',
+  // 2: 'FRWHEELDIRECTION_BACKWARD', 3: 'FRWHEELDIRECTION_STOP'},
+  // 'precision': 1.0, 'len': 2, 'name': 'FRWheelDirection',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+  // 'bit': 57, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fbs1_243::FrwheeldirectionType frwheeldirection(const std::uint8_t* bytes,
+                                                   const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs1_243_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs1_243_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs1_243.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs1243Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Fbs1243Test, reset) {
+  Fbs1243 fbs1;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
+
+  fbs1.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs1_243().longitudeacce(), 12.59432);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs1_243().lateralacce(), -13.04542);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs1_243().vehdynyawrate(), -1.0442);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs1_243().flwheelspd(), 34.3125);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs1_243().frwheeldirection(), 0);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs2_240.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs2_240.cc
@@ -1,0 +1,169 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs2_240.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Fbs2240::Fbs2240() {}
+const int32_t Fbs2240::ID = 0x240;
+
+void Fbs2240::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_fbs2_240()->set_flwheeldirection(
+                                         flwheeldirection(bytes, length));
+  chassis->mutable_wey()->mutable_fbs2_240()->set_frwheelspd(
+                                         frwheelspd(bytes, length));
+  chassis->mutable_wey()->mutable_fbs2_240()->set_rlwheeldrivedirection(
+                                         rlwheeldrivedirection(bytes, length));
+  chassis->mutable_wey()->mutable_fbs2_240()->set_rlwheelspd(
+                                         rlwheelspd(bytes, length));
+  chassis->mutable_wey()->mutable_fbs2_240()->set_rrwheeldirection(
+                                         rrwheeldirection(bytes, length));
+  chassis->mutable_wey()->mutable_fbs2_240()->set_rrwheelspd(
+                                         rrwheelspd(bytes, length));
+  // change km/h to m/s
+  chassis->mutable_wey()->mutable_fbs2_240()->set_vehiclespd(
+                                         vehiclespd(bytes, length) / 3.6);
+}
+
+// config detail: {'description': 'Front left wheel Moving direction',
+// 'enum': {0: 'FLWHEELDIRECTION_INVALID', 1: 'FLWHEELDIRECTION_FORWARD',
+// 2: 'FLWHEELDIRECTION_BACKWARD', 3: 'FLWHEELDIRECTION_STOP'},
+// 'precision': 1.0, 'len': 2, 'name': 'flwheeldirection',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+// 'bit': 57, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fbs2_240::FlwheeldirectionType Fbs2240::flwheeldirection(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 2);
+
+  Fbs2_240::FlwheeldirectionType ret = static_cast<
+                                        Fbs2_240::FlwheeldirectionType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Front right wheel speed', 'offset': 0.0,
+// 'precision': 0.05625, 'len': 13, 'name': 'frwheelspd',
+// 'is_signed_var': False, 'physical_range': '[0|299.98125]', 'bit': 7,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+double Fbs2240::frwheelspd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(3, 5);
+  x <<= 5;
+  x |= t;
+
+  double ret = x * 0.056250;
+  return ret;
+}
+
+// config detail: {'description': 'Rear left wheel  Moving direction', 'enum':
+// {0: 'RLWHEELDRIVEDIRECTION_INVALID', 1: 'RLWHEELDRIVEDIRECTION_FORWARD',
+// 2: 'RLWHEELDRIVEDIRECTION_BACKWARD', 3: 'RLWHEELDRIVEDIRECTION_STOP'},
+// 'precision': 1.0, 'len': 2, 'name': 'rlwheeldrivedirection',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+// 'bit': 9, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fbs2_240::RlwheeldrivedirectionType Fbs2240::rlwheeldrivedirection(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 2);
+
+  Fbs2_240::RlwheeldrivedirectionType ret = static_cast<
+                                      Fbs2_240::RlwheeldrivedirectionType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Rear left wheel speed', 'offset': 0.0,
+// 'precision': 0.05625, 'len': 13, 'name':'rlwheelspd','is_signed_var': False,
+// 'physical_range': '[0|299.98125]', 'bit': 23, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'Km/h'}
+double Fbs2240::rlwheelspd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(3, 5);
+  x <<= 5;
+  x |= t;
+
+  double ret = x * 0.056250;
+  return ret;
+}
+
+// config detail: {'description': 'Rear right wheel Moving direction', 'enum':
+// {0: 'RRWHEELDIRECTION_INVALID', 1: 'RRWHEELDIRECTION_FORWARD',
+// 2: 'RRWHEELDIRECTION_BACKWARD', 3: 'RRWHEELDIRECTION_STOP'},'precision':1.0,
+// 'len': 2, 'name': 'rrwheeldirection', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|3]', 'bit': 25, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Fbs2_240::RrwheeldirectionType Fbs2240::rrwheeldirection(
+                             const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 2);
+
+  Fbs2_240::RrwheeldirectionType ret =
+                                static_cast<Fbs2_240::RrwheeldirectionType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Rear right wheel speed', 'offset': 0.0,
+// 'precision': 0.05625, 'len': 13, 'name': 'rrwheelspd','is_signed_var':False,
+// 'physical_range': '[0|299.98125]', 'bit': 39, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'Km/h'}
+double Fbs2240::rrwheelspd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(3, 5);
+  x <<= 5;
+  x |= t;
+
+  double ret = x * 0.056250;
+  return ret;
+}
+
+// config detail: {'description': 'Current Vehicle speed information','offset':
+// 0.0, 'precision': 0.05625, 'len': 13, 'name': 'vehiclespd',
+// 'is_signed_var': False, 'physical_range': '[0|299.98125]', 'bit': 55,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+double Fbs2240::vehiclespd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(3, 5);
+  x <<= 5;
+  x |= t;
+
+  double ret = x * 0.056250;
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs2_240.h
+++ b/modules/canbus/vehicle/wey/protocol/fbs2_240.h
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs2240 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Fbs2240();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Front left wheel Moving direction',
+  // 'enum': {0: 'FLWHEELDIRECTION_INVALID', 1: 'FLWHEELDIRECTION_FORWARD',
+  // 2: 'FLWHEELDIRECTION_BACKWARD', 3: 'FLWHEELDIRECTION_STOP'},
+  // 'precision': 1.0, 'len': 2, 'name': 'FLWheelDirection',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+  // 'bit': 57, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fbs2_240::FlwheeldirectionType flwheeldirection(
+                     const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front right wheel speed', 'offset': 0.0,
+  // 'precision': 0.05625, 'len': 13, 'name': 'FRWheelSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|299.98125]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+  double frwheelspd(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear left wheel  Moving direction',
+  // 'enum': {0: 'RLWHEELDRIVEDIRECTION_INVALID',
+  // 1: 'RLWHEELDRIVEDIRECTION_FORWARD', 2: 'RLWHEELDRIVEDIRECTION_BACKWARD',
+  // 3: 'RLWHEELDRIVEDIRECTION_STOP'}, 'precision': 1.0, 'len': 2, 'name':
+  // 'RLWheelDriveDirection', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|3]', 'bit': 9, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Fbs2_240::RlwheeldrivedirectionType rlwheeldrivedirection(
+                      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear left wheel speed', 'offset': 0.0,
+  // 'precision': 0.05625, 'len': 13, 'name': 'RLWheelSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|299.98125]',
+  // 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+  double rlwheelspd(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear right wheel Moving direction',
+  // 'enum': {0: 'RRWHEELDIRECTION_INVALID', 1: 'RRWHEELDIRECTION_FORWARD',
+  // 2: 'RRWHEELDIRECTION_BACKWARD', 3: 'RRWHEELDIRECTION_STOP'},
+  // 'precision': 1.0, 'len': 2, 'name': 'RRWheelDirection',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]'
+  // 'bit': 25, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fbs2_240::RrwheeldirectionType rrwheeldirection(
+                      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear right wheel speed', 'offset': 0.0,
+  // 'precision': 0.05625, 'len': 13, 'name': 'RRWheelSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|299.98125]', 'bit': 39,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+  double rrwheelspd(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current Vehicle speed information',
+  // 'offset': 0.0, 'precision': 0.05625, 'len': 13, 'name': 'VehicleSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|299.98125]', 'bit': 55,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'Km/h'}
+  double vehiclespd(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs2_240_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs2_240_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs2_240.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs2240Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Fbs2240Test, reset) {
+  Fbs2240 fbs2;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
+
+  fbs2.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().flwheeldirection(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().frwheelspd(), 245.25);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().rlwheeldrivedirection(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().rlwheelspd(), 61.3125);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().rrwheeldirection(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs2_240().rrwheelspd(), 30.7125);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs3_237.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs3_237.cc
@@ -1,0 +1,177 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs3_237.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Fbs3237::Fbs3237() {}
+const int32_t Fbs3237::ID = 0x237;
+
+void Fbs3237::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_fbs3_237()->set_engspd(
+                                          engspd(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_accpedalpos(
+                                          accpedalpos(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_epbswtichposition(
+                                          epbswtichposition(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_currentgear(
+                                          currentgear(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_eps_streeingmode(
+                                          eps_streeingmode(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_epsdrvinputtrqvalue(
+                                         epsdrvinputtrqvalue(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_epsconsumedcurrvalue(
+                                        epsconsumedcurrvalue(bytes, length));
+  chassis->mutable_wey()->mutable_fbs3_237()->set_epscurrmod(
+                                          epscurrmod(bytes, length));
+  // Added for response check
+  chassis->mutable_check_response()->set_is_eps_online(
+                                        eps_streeingmode(bytes, length) == 1);
+}
+
+// config detail: {'description': 'Engine speed', 'offset': 0.0,
+// 'precision': 0.125, 'len': 16, 'name': 'engspd', 'is_signed_var': False,
+// 'physical_range': '[0|8198.875]', 'bit': 7, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': 'rpm'}
+double Fbs3237::engspd(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.125000;
+  return ret;
+}
+
+// config detail: {'description': 'Acceleration Pedal Position', 'offset': 0.0,
+// 'precision': 0.3937, 'len': 8, 'name': 'accpedalpos', 'is_signed_var':False,
+// 'physical_range': '[0|100.3935]', 'bit': 23, 'type': 'double',
+// 'order': 'motorola', 'physical_unit': '%'}
+double Fbs3237::accpedalpos(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  double ret = x * 0.393700;
+  return ret;
+}
+
+// config detail: {'description': 'EPB Switch position information', 'enum':
+// {0: 'EPBSWTICHPOSITION_NEUTRAL', 1: 'EPBSWTICHPOSITION_RELEASE',
+// 2: 'EPBSWTICHPOSITION_APPLY', 3: 'EPBSWTICHPOSITION_RESERVED1'},
+// 'precision': 1.0, 'len': 2, 'name': 'epbswtichposition', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 31, 'type':
+// 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fbs3_237::EpbswtichpositionType Fbs3237::epbswtichposition(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(6, 2);
+
+  Fbs3_237::EpbswtichpositionType ret =
+                             static_cast<Fbs3_237::EpbswtichpositionType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'To indicate which gear the DCT is in now ',
+// 'enum': {0: 'CURRENTGEAR_P', 1: 'CURRENTGEAR_R', 2: 'CURRENTGEAR_N',
+// 3: 'CURRENTGEAR_D'}, 'precision': 1.0, 'len': 2, 'name': 'currentgear',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 39,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fbs3_237::CurrentgearType Fbs3237::currentgear(
+                         const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(6, 2);
+
+  Fbs3_237::CurrentgearType ret =  static_cast<Fbs3_237::CurrentgearType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Driver Steering Interference Detected',
+// 'enum': {0: 'EPS_STREEINGMODE_MANUAL', 1:'EPS_STREEINGMODE_AUTOMATIC_AVAIL',
+// 2: 'EPS_STREEINGMODE_MANUAL_FROM_DRVNTERFERENCE',
+// 3: 'EPS_STREEINGMODE_MANUAL_FROM_EPS_FAILED_DETECTED',
+// 4: 'EPS_STREEINGMODE_TEMPORARY_INHIBITED', 5: 'EPS_STREEINGMODE_RESERVED1',
+// 6: 'EPS_STREEINGMODE_RESERVED2', 7: 'EPS_STREEINGMODE_RESERVED3'},
+// 'precision': 1.0, 'len': 3, 'name':'eps_streeingmode','is_signed_var':False,
+// 'offset': 0.0, 'physical_range': '[0|7]', 'bit': 34, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Fbs3_237::Eps_streeingmodeType Fbs3237::eps_streeingmode(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 3);
+
+  Fbs3_237::Eps_streeingmodeType ret =
+                            static_cast<Fbs3_237::Eps_streeingmodeType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Value of driver input torque',
+// 'offset': -22.78,'precision': 0.1794,'len': 8, 'name':'epsdrvinputtrqvalue',
+// 'is_signed_var': False, 'physical_range': '[-22.78|22.96]', 'bit': 47,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'Nm'}
+double Fbs3237::epsdrvinputtrqvalue(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  double ret = x * 0.179400 + -22.780000;
+  return ret;
+}
+
+// config detail: {'description': 'Value of consumed current by EPS',
+// 'offset': 0.0, 'precision': 0.5, 'len': 8, 'name': 'epsconsumedcurrvalue',
+// 'is_signed_var': False, 'physical_range': '[127|127]', 'bit': 55,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': 'A'}
+double Fbs3237::epsconsumedcurrvalue(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  double ret = x * 0.500000;
+  return ret;
+}
+
+// config detail: {'description': 'Applied steering mode currently', 'enum':
+// {0: 'EPSCURRMOD_NORMAL_MODE', 1: 'EPSCURRMOD_SPORT_MODE',
+// 2: 'EPSCURRMOD_COMFORT_MODE', 3: 'EPSCURRMOD_MODESELECTIONNOTPOSSIBLE',
+// 4: 'EPSCURRMOD_NO_DISPLAY', 5: 'EPSCURRMOD_CONDITIONNOTMEET',
+// 6: 'EPSCURRMOD_RESERVED1'}, 'precision': 1.0, 'len': 3, 'name':'epscurrmod',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|7]', 'bit': 61,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Fbs3_237::EpscurrmodType Fbs3237::epscurrmod(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(3, 3);
+
+  Fbs3_237::EpscurrmodType ret =  static_cast<Fbs3_237::EpscurrmodType>(x);
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs3_237.h
+++ b/modules/canbus/vehicle/wey/protocol/fbs3_237.h
@@ -1,0 +1,104 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs3237 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Fbs3237();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Engine speed', 'offset': 0.0,
+  // 'precision': 0.125, 'len': 16, 'name': 'EngSpd', 'is_signed_var': False,
+  // 'physical_range': '[0|8198.875]', 'bit': 7, 'type': 'double',
+  // 'order': 'motorola', 'physical_unit': 'rpm'}
+  double engspd(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description':'Acceleration Pedal Position','offset':0.0,
+  // 'precision': 0.3937, 'len': 8, 'name': 'AccPedalPos', 'is_signed_var':
+  // False, 'physical_range': '[0|100.3935]', 'bit': 23, 'type': 'double',
+  // 'order': 'motorola', 'physical_unit': '%'}
+  double accpedalpos(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'EPB Switch position information', 'enum':
+  // {0: 'EPBSWTICHPOSITION_NEUTRAL', 1: 'EPBSWTICHPOSITION_RELEASE',
+  // 2: 'EPBSWTICHPOSITION_APPLY', 3: 'EPBSWTICHPOSITION_RESERVED1'},
+  // 'precision': 1.0, 'len': 2, 'name': 'EPBSwtichPosition', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 31, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Fbs3_237::EpbswtichpositionType epbswtichposition(
+                      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail:{'description': 'To indicate which gear the DCT is in now ',
+  // 'enum': {0: 'CURRENTGEAR_P', 1: 'CURRENTGEAR_R', 2: 'CURRENTGEAR_N',
+  // 3: 'CURRENTGEAR_D'}, 'precision': 1.0, 'len': 2, 'name': 'CurrentGear',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]','bit':39,
+  // 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fbs3_237::CurrentgearType currentgear(const std::uint8_t* bytes,
+                                                 const int32_t length) const;
+
+  // config detail: {'description': 'Driver Steering Interference Detected',
+  // 'enum': {0:'EPS_STREEINGMODE_MANUAL',1:'EPS_STREEINGMODE_AUTOMATIC_AVAIL',
+  // 2: 'EPS_STREEINGMODE_MANUAL_FROM_DRVNTERFERENCE',
+  // 3: 'EPS_STREEINGMODE_MANUAL_FROM_EPS_FAILED_DETECTED',
+  // 4: 'EPS_STREEINGMODE_TEMPORARY_INHIBITED', 5:'EPS_STREEINGMODE_RESERVED1',
+  // 6: 'EPS_STREEINGMODE_RESERVED2', 7: 'EPS_STREEINGMODE_RESERVED3'},
+  // 'precision': 1.0, 'len': 3, 'name': 'EPS_StreeingMode', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|7]', 'bit': 34, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Fbs3_237::Eps_streeingmodeType eps_streeingmode(
+                        const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Value of driver input torque',
+  // 'offset': -22.78, 'precision': 0.1794, 'len': 8, 'name':
+  // 'EPSDrvInputTrqValue', 'is_signed_var': False,
+  // 'physical_range': '[-22.78|22.96]', 'bit': 47, 'type': 'double',
+  // 'order': 'motorola', 'physical_unit': 'Nm'}
+  double epsdrvinputtrqvalue(
+                        const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Value of consumed current by EPS',
+  // 'offset': 0.0, 'precision': 0.5, 'len': 8, 'name': 'EPSConsumedCurrValue',
+  // 'is_signed_var': False, 'physical_range': '[127|127]', 'bit': 55,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': 'A'}
+  double epsconsumedcurrvalue(
+                        const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Applied steering mode currently',
+  // 'enum': {0: 'EPSCURRMOD_NORMAL_MODE', 1: 'EPSCURRMOD_SPORT_MODE',
+  // 2: 'EPSCURRMOD_COMFORT_MODE', 3: 'EPSCURRMOD_MODESELECTIONNOTPOSSIBLE',
+  // 4: 'EPSCURRMOD_NO_DISPLAY', 5: 'EPSCURRMOD_CONDITIONNOTMEET',
+  // 6: 'EPSCURRMOD_RESERVED1'}, 'precision': 1.0,'len': 3,'name':'EPSCurrMod',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|7]',
+  // 'bit': 61, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Fbs3_237::EpscurrmodType epscurrmod(
+                        const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs3_237_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs3_237_test.cc
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs3_237.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs3237Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Fbs3237Test, reset) {
+  Fbs3237 fbs3;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0xFE, 0x14};
+
+  fbs3.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().engspd(), 4360.5);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().accpedalpos(), 13.3858);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().epbswtichposition(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().currentgear(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().eps_streeingmode(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().epsdrvinputtrqvalue(),
+                   -19.5508);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().epsconsumedcurrvalue(),
+                   127);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs3_237().epscurrmod(), 2);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs4_235.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs4_235.cc
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs4_235.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Fbs4235::Fbs4235() {}
+const int32_t Fbs4235::ID = 0x235;
+
+void Fbs4235::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_fbs4_235()->set_steerwheelangle(
+                                              steerwheelangle(bytes, length));
+  chassis->mutable_wey()->mutable_fbs4_235()->set_steerwheelspd(
+                                              steerwheelspd(bytes, length));
+}
+
+// config detail: {'description': 'angle of steering wheel ',
+// 'offset': 0.0, 'precision': 0.1, 'len': 15, 'name': 'steerwheelangle',
+// 'is_signed_var': False, 'physical_range': '[0|780]', 'bit': 15,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': '\xa1\xe3'}
+double Fbs4235::steerwheelangle(
+                        const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 2);
+  int32_t t = t1.get_byte(1, 7);
+  x <<= 7;
+  x |= t;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+
+// config detail: {'description': 'steering wheel rotation speed',
+// 'offset': 0.0, 'precision': 0.1, 'len': 15, 'name': 'steerwheelspd',
+// 'is_signed_var': False, 'physical_range': '[0|1016]', 'bit': 39,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': '\xa1\xe3/s'}
+double Fbs4235::steerwheelspd(
+                       const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(1, 7);
+  x <<= 7;
+  x |= t;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs4_235.h
+++ b/modules/canbus/vehicle/wey/protocol/fbs4_235.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs4235 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Fbs4235();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'angle of steering wheel ', 'offset': 0.0,
+  // 'precision': 0.1, 'len': 15, 'name': 'SteerWheelAngle',
+  // 'is_signed_var': False, 'physical_range': '[0|780]', 'bit': 15,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': '\xa1\xe3'}
+  double steerwheelangle(const std::uint8_t* bytes,
+                                                const int32_t length) const;
+
+  // config detail: {'description': 'steering wheel rotation speed',
+  // 'offset': 0.0, 'precision': 0.1, 'len': 15, 'name': 'SteerWheelSpd',
+  // 'is_signed_var': False, 'physical_range': '[0|1016]', 'bit': 39,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': '\xa1\xe3/s'}
+  double steerwheelspd(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/fbs4_235_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/fbs4_235_test.cc
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/fbs4_235.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Fbs4235Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Fbs4235Test, reset) {
+  Fbs4235 fbs4;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x04, 0x03, 0x02, 0x01, 0x11, 0x12, 0x13, 0x14};
+
+  fbs4.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs4_235().steerwheelangle(), 38.5);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().fbs4_235().steerwheelspd(), 218.5);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/status_310.cc
+++ b/modules/canbus/vehicle/wey/protocol/status_310.cc
@@ -1,0 +1,625 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/status_310.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Status310::Status310() {}
+const int32_t Status310::ID = 0x310;
+
+void Status310::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_status_310()->
+                set_longitudeaccvalid(longitudeaccvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_lateralaccevalid(lateralaccevalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_vehdynyawratevalid(vehdynyawratevalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_flwheelspdvalid(flwheelspdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->set_frwheelspdvalid(
+                frwheelspdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rlwheelspdvalid(rlwheelspdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rrwheelspdvalid(rrwheelspdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_vehiclespdvalid(vehiclespdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+            set_longitudedrivingmode(longitudedrivingmode(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_engspdvalid(engspdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_accepedaloverride(accepedaloverride(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_brakepedalstatus(brakepedalstatus(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_espbrakelightsts(espbrakelightsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+              set_epbswtpositionvalid(epbswtpositionvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_epbsts(epbsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_currentgearvalid(currentgearvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_epstrqsnsrsts(epstrqsnsrsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+          set_eps_interferdetdvalid(eps_interferdetdvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_epshandsdetnsts(epshandsdetnsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+          set_eps_handsdetnstsvalid(eps_handsdetnstsvalid(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+              set_steerwheelanglesign(steerwheelanglesign(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_steerwheelspdsign(steerwheelspdsign(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_driverdoorsts(driverdoorsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rldoorsts(rldoorsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_passengerdoorsts(passengerdoorsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rrdoorsts(rrdoorsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_frontfoglmpsts(frontfoglmpsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rearfoglmpsts(rearfoglmpsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_lowbeamsts(lowbeamsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_highbeamsts(highbeamsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_leftturnlampsts(leftturnlampsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_rightturnlampsts(rightturnlampsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_bcm_availsts(bcm_availsts(bytes, length));
+  chassis->mutable_wey()->mutable_status_310()->
+                set_brakelmpsts(brakelmpsts(bytes, length));
+  // Added for response check
+  chassis->mutable_check_response()->
+                set_is_esp_online(longitudedrivingmode(bytes, length) != 0);
+  chassis->mutable_check_response()->
+                set_is_vcu_online(longitudedrivingmode(bytes, length) != 0);
+}
+
+// config detail: {'description': 'Longitude acceleration valid', 'enum':
+// {0: 'LONGITUDEACCVALID_INVALID', 1: 'LONGITUDEACCVALID_VALID'},
+// 'precision': 1.0, 'len': 1, 'name': 'longitudeaccvalid', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::LongitudeaccvalidType Status310::longitudeaccvalid(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(7, 1);
+
+  Status_310::LongitudeaccvalidType ret =
+                          static_cast<Status_310::LongitudeaccvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Indicates Lateral Signal State',
+// 'enum': {0: 'LATERALACCEVALID_INVALID', 1: 'LATERALACCEVALID_VALID'},
+// 'precision': 1.0, 'len': 1,'name':'lateralaccevalid','is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 7, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::LateralaccevalidType Status310::lateralaccevalid(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(7, 1);
+
+  Status_310::LateralaccevalidType ret =
+                              static_cast<Status_310::LateralaccevalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Vehicle yaw rate valid', 'enum':
+// {0: 'VEHDYNYAWRATEVALID_INVALID', 1: 'VEHDYNYAWRATEVALID_VALID'},
+// 'precision': 1.0, 'len': 1, 'name': 'vehdynyawratevalid', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 6, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::VehdynyawratevalidType Status310::vehdynyawratevalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(6, 1);
+
+  Status_310::VehdynyawratevalidType ret =
+                            static_cast<Status_310::VehdynyawratevalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Front right wheel speed valid',
+// 'enum': {0: 'FLWHEELSPDVALID_INVALID', 1: 'FLWHEELSPDVALID_VALID'},
+// 'precision': 1.0, 'len': 1, 'name': 'flwheelspdvalid','is_signed_var':False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 5, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::FlwheelspdvalidType Status310::flwheelspdvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(5, 1);
+
+  Status_310::FlwheelspdvalidType ret =
+                              static_cast<Status_310::FlwheelspdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Front right wheel speed valid',
+// 'enum': {0: 'FRWHEELSPDVALID_INVALID', 1: 'FRWHEELSPDVALID_VALID'},
+// 'precision': 1.0, 'len': 1, 'name':'frwheelspdvalid','is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 53, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::FrwheelspdvalidType Status310::frwheelspdvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(5, 1);
+
+  Status_310::FrwheelspdvalidType ret =
+                            static_cast<Status_310::FrwheelspdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Rear left wheel speed valid', 'enum':
+// {0: 'RLWHEELSPDVALID_INVALID', 1: 'RLWHEELSPDVALID_VALID'},'precision': 1.0,
+// 'len': 1, 'name': 'rlwheelspdvalid', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 3, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::RlwheelspdvalidType Status310::rlwheelspdvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(3, 1);
+
+  Status_310::RlwheelspdvalidType ret =
+                            static_cast<Status_310::RlwheelspdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Rear right wheel speed valid', 'enum':
+// {0: 'RRWHEELSPDVALID_INVALID', 1: 'RRWHEELSPDVALID_VALID'},'precision': 1.0,
+// 'len': 1, 'name': 'rrwheelspdvalid', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 2, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::RrwheelspdvalidType Status310::rrwheelspdvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(2, 1);
+
+  Status_310::RrwheelspdvalidType ret =
+                            static_cast<Status_310::RrwheelspdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Quality/fault information to current Vehicle
+// speed information', 'enum': {0: 'VEHICLESPDVALID_INVALID',
+// 1: 'VEHICLESPDVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+// 'vehiclespdvalid', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+// '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Status_310::VehiclespdvalidType Status310::vehiclespdvalid(
+                             const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 1);
+
+  Status_310::VehiclespdvalidType ret =
+                             static_cast<Status_310::VehiclespdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'This signal indicates if ECM control for ADS
+// torque request is active or not.', 'enum':
+// {0: 'LONGITUDEDRIVINGMODE_MANUALMODE',
+// 1: 'LONGITUDEDRIVINGMODE_AUTOMATICSTANDBY',
+// 2: 'LONGITUDEDRIVINGMODE_AUTOMATICACCELERATION',
+// 3: 'LONGITUDEDRIVINGMODE_AUTOMATICDECELERATION'}, 'precision': 1.0,'len': 2,
+// 'name': 'longitudedrivingmode', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|3]', 'bit': 14, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::LongitudedrivingmodeType Status310::longitudedrivingmode(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(5, 2);
+
+  Status_310::LongitudedrivingmodeType ret =
+                          static_cast<Status_310::LongitudedrivingmodeType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Engine speed valid', 'enum':
+// {0: 'ENGSPDVALID_INVALID',1: 'ENGSPDVALID_VALID',2:'ENGSPDVALID_INIT_VALUE',
+// 3: 'ENGSPDVALID_RESERVED'},'precision': 1.0,'len': 2, 'name': 'engspdvalid',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|2]', 'bit': 12,
+// 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Status_310::EngspdvalidType Status310::engspdvalid(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(3, 2);
+
+  Status_310::EngspdvalidType ret =
+                          static_cast<Status_310::EngspdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Detect Acceleration Pedal Override', 'enum':
+// {0: 'ACCEPEDALOVERRIDE_NOT_OVERRIDE', 1: 'ACCEPEDALOVERRIDE_OVERRIDE'},
+// 'precision': 1.0, 'len': 1, 'name': 'accepedaloverride', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 19, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::AccepedaloverrideType Status310::accepedaloverride(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(3, 1);
+
+  Status_310::AccepedaloverrideType ret =
+                          static_cast<Status_310::AccepedaloverrideType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'indicates the brake pedal is pressed or not
+// or incorrect for plausibility check.', 'enum':
+// {0: 'BRAKEPEDALSTATUS_NOT_PRESSED', 1: 'BRAKEPEDALSTATUS_PRESSED',
+// 2: 'BRAKEPEDALSTATUS_RESERVED1', 3: 'BRAKEPEDALSTATUS_ERROR'},
+// 'precision': 1.0, 'len': 2, 'name': 'brakepedalstatus',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]',
+// 'bit': 9, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Status_310::BrakepedalstatusType Status310::brakepedalstatus(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 2);
+
+  Status_310::BrakepedalstatusType ret =
+                            static_cast<Status_310::BrakepedalstatusType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Brake light lamp(on/off),come from ESP',
+// 'enum': {0: 'ESPBRAKELIGHTSTS_OFF', 1: 'ESPBRAKELIGHTSTS_ON'},
+// 'precision': 1.0, 'len': 1, 'name': 'espbrakelightsts', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 29, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::EspbrakelightstsType Status310::espbrakelightsts(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(5, 1);
+
+  Status_310::EspbrakelightstsType ret =
+                            static_cast<Status_310::EspbrakelightstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'EPB switch position signal valid', 'enum':
+// {0: 'EPBSWTPOSITIONVALID_VALID', 1: 'EPBSWTPOSITIONVALID_NOT_VALID'},
+// 'precision': 1.0, 'len': 1, 'name': 'epbswtpositionvalid',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+// 'bit': 20, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Status_310::EpbswtpositionvalidType Status310::epbswtpositionvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(4, 1);
+
+  Status_310::EpbswtpositionvalidType ret =
+                          static_cast<Status_310::EpbswtpositionvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'EPB status', 'enum': {0: 'EPBSTS_RELEASED',
+// 1: 'EPBSTS_CLOSED', 2: 'EPBSTS_IN_PROGRESS', 3: 'EPBSTS_UNKNOWN'},
+// 'precision': 1.0, 'len': 2, 'name': 'epbsts', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 18, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::EpbstsType Status310::epbsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(1, 2);
+
+  Status_310::EpbstsType ret =  static_cast<Status_310::EpbstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Current gear valid', 'enum':
+// {0: 'CURRENTGEARVALID_INVALID', 1: 'CURRENTGEARVALID_VALID'},
+// 'precision': 1.0, 'len': 1, 'name': 'currentgearvalid', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 25, 'type':
+// 'enum', 'order': 'motorola', 'physical_unit': ''}
+Status_310::CurrentgearvalidType Status310::currentgearvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(1, 1);
+
+  Status_310::CurrentgearvalidType ret =
+                            static_cast<Status_310::CurrentgearvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'EPS torque sensor status', 'enum':
+// {0: 'EPSTRQSNSRSTS_NORMAL', 1: 'EPSTRQSNSRSTS_ABNORMAL'}, 'precision': 1.0,
+// 'len': 1, 'name': 'epstrqsnsrsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::EpstrqsnsrstsType Status310::epstrqsnsrsts(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(7, 1);
+
+  Status_310::EpstrqsnsrstsType ret =
+                                static_cast<Status_310::EpstrqsnsrstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Driver Steering Interference Detected
+// Validity', 'enum': {0: 'EPS_INTERFERDETDVALID_INVALID',
+// 1: 'EPS_INTERFERDETDVALID_VALID'}, 'precision': 1.0, 'len': 1,
+// 'name': 'eps_interferdetdvalid', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 38, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::Eps_interferdetdvalidType Status310::eps_interferdetdvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(6, 1);
+
+  Status_310::Eps_interferdetdvalidType ret =
+                         static_cast<Status_310::Eps_interferdetdvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Hands Off Steering Wheel Detection status',
+// 'enum': {0: 'EPSHANDSDETNSTS_HANDSOFF_NOT_DETECTED',
+// 1: 'EPSHANDSDETNSTS_HANDOFFF_DETECTED'}, 'precision': 1.0, 'len': 1,
+// 'name': 'epshandsdetnsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 27, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::EpshandsdetnstsType Status310::epshandsdetnsts(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(3, 1);
+
+  Status_310::EpshandsdetnstsType ret =
+                            static_cast<Status_310::EpshandsdetnstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Hands Off Steering Wheel Detection status
+// Validity', 'enum': {0: 'EPS_HANDSDETNSTSVALID_INVALID',
+// 1: 'EPS_HANDSDETNSTSVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+// 'eps_handsdetnstsvalid', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 34, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::Eps_handsdetnstsvalidType Status310::eps_handsdetnstsvalid(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(2, 1);
+
+  Status_310::Eps_handsdetnstsvalidType ret =
+                         static_cast<Status_310::Eps_handsdetnstsvalidType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'sign of steering wheel angle', 'enum':
+// {0: 'STEERWHEELANGLESIGN_LEFT_POSITIVE',
+// 1: 'STEERWHEELANGLESIGN_RIGHT_NEGATIVE'}, 'precision': 1.0, 'len': 1,
+// 'name': 'steerwheelanglesign', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::SteerwheelanglesignType Status310::steerwheelanglesign(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 1);
+
+  Status_310::SteerwheelanglesignType ret =
+                          static_cast<Status_310::SteerwheelanglesignType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'sign of steering wheel speed ', 'enum':
+// {0: 'STEERWHEELSPDSIGN_LEFT_POSITIVE',1:'STEERWHEELSPDSIGN_RIGHT_NEGATIVE'},
+// 'precision': 1.0, 'len': 1, 'name': 'steerwheelspdsign', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 40, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Status_310::SteerwheelspdsignType Status310::steerwheelspdsign(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 1);
+
+  Status_310::SteerwheelspdsignType ret =
+                          static_cast<Status_310::SteerwheelspdsignType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Driver door status.', 'enum':
+// {0: 'DRIVERDOORSTS_CLOSED', 1: 'DRIVERDOORSTS_OPEN'}, 'precision': 1.0,
+// 'len': 1, 'name': 'driverdoorsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 47, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::DriverdoorstsType Status310::driverdoorsts(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(7, 1);
+
+  Status_310::DriverdoorstsType ret =
+                           static_cast<Status_310::DriverdoorstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Left rear door status', 'enum':
+// {0: 'RLDOORSTS_CLOSED', 1: 'RLDOORSTS_OPEN'}, 'precision': 1.0, 'len': 1,
+// 'name': 'rldoorsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 54, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::RldoorstsType Status310::rldoorsts(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(6, 1);
+
+  Status_310::RldoorstsType ret =  static_cast<Status_310::RldoorstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Passenger door status.', 'enum':
+// {0: 'PASSENGERDOORSTS_CLOSED', 1: 'PASSENGERDOORSTS_OPEN'},'precision': 1.0,
+// 'len': 1, 'name': 'passengerdoorsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 45, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::PassengerdoorstsType Status310::passengerdoorsts(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(5, 1);
+
+  Status_310::PassengerdoorstsType ret =
+                            static_cast<Status_310::PassengerdoorstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Right   rear door status', 'enum':
+// {0: 'RRDOORSTS_CLOSED', 1: 'RRDOORSTS_OPEN'}, 'precision': 1.0, 'len': 1,
+// 'name': 'rrdoorsts', 'is_signed_var': False, 'offset': 0.0,'physical_range':
+// '[0|1]', 'bit': 44, 'type': 'enum', 'order': 'motorola', 'physical_unit':''}
+Status_310::RrdoorstsType Status310::rrdoorsts(
+                            const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(4, 1);
+
+  Status_310::RrdoorstsType ret =  static_cast<Status_310::RrdoorstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Front fog lamp status', 'enum':
+// {0: 'FRONTFOGLMPSTS_OFF', 1:'FRONTFOGLMPSTS_ON',2:'FRONTFOGLMPSTS_RESERVED',
+// 3: 'FRONTFOGLMPSTS_NOT_AVAILABLE'}, 'precision': 1.0, 'len': 2, 'name':
+// 'frontfoglmpsts', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+// '[0|3]', 'bit': 43, 'type': 'enum', 'order': 'motorola', 'physical_unit':''}
+Status_310::FrontfoglmpstsType Status310::frontfoglmpsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(2, 2);
+
+  Status_310::FrontfoglmpstsType ret =
+                          static_cast<Status_310::FrontfoglmpstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Rear fog lamp status', 'enum':
+// {0: 'REARFOGLMPSTS_OFF', 1: 'REARFOGLMPSTS_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'rearfoglmpsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 51, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::RearfoglmpstsType Status310::rearfoglmpsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(3, 1);
+
+  Status_310::RearfoglmpstsType ret =
+                          static_cast<Status_310::RearfoglmpstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Low beam status', 'enum':
+// {0: 'LOWBEAMSTS_OFF', 1: 'LOWBEAMSTS_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'lowbeamsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 49, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::LowbeamstsType Status310::lowbeamsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(1, 1);
+
+  Status_310::LowbeamstsType ret =  static_cast<Status_310::LowbeamstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'High beam status', 'enum':
+// {0: 'HIGHBEAMSTS_OFF', 1: 'HIGHBEAMSTS_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'highbeamsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 63, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::HighbeamstsType Status310::highbeamsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(7, 1);
+
+  Status_310::HighbeamstsType ret = static_cast<Status_310::HighbeamstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Left turn lamp status', 'enum':
+// {0: 'LEFTTURNLAMPSTS_OFF', 1: 'LEFTTURNLAMPSTS_ON'}, 'precision': 1.0,
+// 'len': 1, 'name': 'leftturnlampsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 62, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::LeftturnlampstsType Status310::leftturnlampsts(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(6, 1);
+
+  Status_310::LeftturnlampstsType ret =
+                           static_cast<Status_310::LeftturnlampstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Right turn lamp status', 'enum':
+// {0: 'RIGHTTURNLAMPSTS_OFF', 1: 'RIGHTTURNLAMPSTS_ON'}, 'precision': 1.0,
+// 'len': 1, 'name': 'rightturnlampsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 60, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::RightturnlampstsType Status310::rightturnlampsts(
+                           const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(4, 1);
+
+  Status_310::RightturnlampstsType ret =
+                          static_cast<Status_310::RightturnlampstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'The work status of BCM', 'enum':
+// {0: 'BCM_AVAILSTS_MANUAL_MODE', 1: 'BCM_AVAILSTS_AUTONOMOUS_MODE',
+// 2: 'BCM_AVAILSTS_RESERVED1', 3: 'BCM_AVAILSTS_RESERVED2'}, 'precision': 1.0,
+// 'len': 2, 'name': 'bcm_availsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|3]', 'bit': 58, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::Bcm_availstsType Status310::bcm_availsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(1, 2);
+
+  Status_310::Bcm_availstsType ret =
+                          static_cast<Status_310::Bcm_availstsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Break Lamp status', 'enum':
+// {0: 'BRAKELMPSTS_OFF', 1: 'BRAKELMPSTS_ON'}, 'precision': 1.0, 'len': 1,
+// 'name': 'brakelmpsts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 56, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Status_310::BrakelmpstsType Status310::brakelmpsts(
+                          const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 1);
+
+  Status_310::BrakelmpstsType ret = static_cast<Status_310::BrakelmpstsType>(x);
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/status_310.h
+++ b/modules/canbus/vehicle/wey/protocol/status_310.h
@@ -1,0 +1,324 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Status310 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Status310();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Longitude acceleration valid', 'enum':
+  // {0: 'LONGITUDEACCVALID_INVALID', 1: 'LONGITUDEACCVALID_VALID'},
+  // 'precision': 1.0, 'len': 1, 'name': 'LongitudeAccValid', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::LongitudeaccvalidType longitudeaccvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Indicates Lateral Signal State', 'enum':
+  // {0: 'LATERALACCEVALID_INVALID', 1: 'LATERALACCEVALID_VALID'},
+  // 'precision': 1.0, 'len': 1, 'name': 'LateralAcceValid', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 7, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::LateralaccevalidType lateralaccevalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Vehicle yaw rate valid', 'enum':
+  // {0: 'VEHDYNYAWRATEVALID_INVALID', 1: 'VEHDYNYAWRATEVALID_VALID'},
+  // 'precision': 1.0, 'len': 1, 'name': 'VehDynYawRateValid', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 6, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::VehdynyawratevalidType vehdynyawratevalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front right wheel speed valid', 'enum':
+  // {0: 'FLWHEELSPDVALID_INVALID', 1:'FLWHEELSPDVALID_VALID'},'precision':1.0,
+  // 'len': 1, 'name': 'FLWheelSpdValid', 'is_signed_var': False, 'offset':0.0,
+  // 'physical_range': '[0|1]', 'bit': 5, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::FlwheelspdvalidType flwheelspdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front right wheel speed valid', 'enum':
+  // {0: 'FRWHEELSPDVALID_INVALID', 1:'FRWHEELSPDVALID_VALID'},'precision':1.0,
+  // 'len': 1, 'name': 'FRWheelSpdValid', 'is_signed_var': False, 'offset':0.0,
+  // 'physical_range': '[0|1]', 'bit': 53, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::FrwheelspdvalidType frwheelspdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear left wheel speed valid', 'enum':
+  // {0: 'RLWHEELSPDVALID_INVALID', 1: 'RLWHEELSPDVALID_VALID'}, 'precision':
+  // 1.0, 'len': 1, 'name': 'RLWheelSpdValid', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 3, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::RlwheelspdvalidType rlwheelspdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear right wheel speed valid', 'enum':
+  // {0: 'RRWHEELSPDVALID_INVALID', 1: 'RRWHEELSPDVALID_VALID'}, 'precision':
+  // 1.0, 'len': 1, 'name': 'RRWheelSpdValid', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 2, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::RrwheelspdvalidType rrwheelspdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Quality/fault information to current
+  // Vehicle speed information', 'enum': {0: 'VEHICLESPDVALID_INVALID',
+  // 1: 'VEHICLESPDVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'VehicleSpdValid', 'is_signed_var': False, 'offset': 0.0,'physical_range':
+  // '[0|1]', 'bit': 0, 'type': 'enum', 'order':'motorola','physical_unit': ''}
+  Status_310::VehiclespdvalidType vehiclespdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'This signal indicates if ECM control for
+  // ADS torque request is active or not.', 'enum':
+  // {0: 'LONGITUDEDRIVINGMODE_MANUALMODE',
+  // 1: 'LONGITUDEDRIVINGMODE_AUTOMATICSTANDBY',
+  // 2: 'LONGITUDEDRIVINGMODE_AUTOMATICACCELERATION',
+  // 3: 'LONGITUDEDRIVINGMODE_AUTOMATICDECELERATION'}, 'precision': 1.0,
+  // 'len': 2, 'name': 'LongitudeDrivingMode', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 14, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::LongitudedrivingmodeType longitudedrivingmode(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Engine speed valid', 'enum':
+  // {0: 'ENGSPDVALID_INVALID', 1: 'ENGSPDVALID_VALID',
+  // 2: 'ENGSPDVALID_INIT_VALUE', 3: 'ENGSPDVALID_RESERVED'}, 'precision': 1.0,
+  // 'len': 2, 'name': 'EngSpdValid', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|2]', 'bit': 12, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::EngspdvalidType engspdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail:{'description': 'Detect Acceleration Pedal Override','enum':
+  // {0: 'ACCEPEDALOVERRIDE_NOT_OVERRIDE', 1: 'ACCEPEDALOVERRIDE_OVERRIDE'},
+  // 'precision': 1.0, 'len': 1, 'name': 'AccePedalOverride', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 19, 'type':'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::AccepedaloverrideType accepedaloverride(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'indicates the brake pedal is pressed or
+  // not or incorrect for plausibility check.', 'enum':
+  // {0: 'BRAKEPEDALSTATUS_NOT_PRESSED', 1: 'BRAKEPEDALSTATUS_PRESSED',
+  // 2: 'BRAKEPEDALSTATUS_RESERVED1', 3: 'BRAKEPEDALSTATUS_ERROR'},
+  // 'precision': 1.0, 'len': 2, 'name': 'BrakePedalStatus', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 9, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::BrakepedalstatusType brakepedalstatus(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Brake light lamp(on/off),come from ESP',
+  // 'enum': {0: 'ESPBRAKELIGHTSTS_OFF', 1: 'ESPBRAKELIGHTSTS_ON'},'precision':
+  // 1.0, 'len': 1, 'name': 'ESPBrakeLightSts', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 29, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::EspbrakelightstsType espbrakelightsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'EPB switch position signal valid', 'enum':
+  // {0: 'EPBSWTPOSITIONVALID_VALID', 1: 'EPBSWTPOSITIONVALID_NOT_VALID'},
+  // 'precision': 1.0, 'len': 1, 'name': 'EPBSwtPositionValid', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 20, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::EpbswtpositionvalidType epbswtpositionvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'EPB status', 'enum': {0:'EPBSTS_RELEASED',
+  // 1: 'EPBSTS_CLOSED', 2: 'EPBSTS_IN_PROGRESS', 3: 'EPBSTS_UNKNOWN'},
+  // 'precision': 1.0, 'len': 2, 'name': 'EPBSts', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 18, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::EpbstsType epbsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current gear valid', 'enum':
+  // {0: 'CURRENTGEARVALID_INVALID', 1: 'CURRENTGEARVALID_VALID'},
+  // 'precision': 1.0, 'len': 1, 'name': 'CurrentGearValid', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 25,'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::CurrentgearvalidType currentgearvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'EPS torque sensor status', 'enum':
+  // {0: 'EPSTRQSNSRSTS_NORMAL', 1: 'EPSTRQSNSRSTS_ABNORMAL'}, 'precision':1.0,
+  // 'len': 1, 'name': 'EPSTrqSnsrSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 31, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::EpstrqsnsrstsType epstrqsnsrsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Driver Steering Interference Detected
+  // Validity', 'enum': {0: 'EPS_INTERFERDETDVALID_INVALID',
+  // 1: 'EPS_INTERFERDETDVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'EPS_InterferDetdValid', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 38, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::Eps_interferdetdvalidType eps_interferdetdvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Hands Off Steering Wheel Detection status',
+  // 'enum': {0: 'EPSHANDSDETNSTS_HANDSOFF_NOT_DETECTED',
+  // 1: 'EPSHANDSDETNSTS_HANDOFFF_DETECTED'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'EPSHandsDetnSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 27, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::EpshandsdetnstsType epshandsdetnsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Hands Off Steering Wheel Detection status
+  // Validity', 'enum': {0: 'EPS_HANDSDETNSTSVALID_INVALID',
+  // 1: 'EPS_HANDSDETNSTSVALID_VALID'}, 'precision': 1.0, 'len': 1, 'name':
+  // 'EPS_HandsDetnStsValid', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 34, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::Eps_handsdetnstsvalidType eps_handsdetnstsvalid(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'sign of steering wheel angle', 'enum':
+  // {0: 'STEERWHEELANGLESIGN_LEFT_POSITIVE',
+  // 1: 'STEERWHEELANGLESIGN_RIGHT_NEGATIVE'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'SteerWheelAngleSign', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::SteerwheelanglesignType steerwheelanglesign(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'sign of steering wheel speed ', 'enum':
+  // {0: 'STEERWHEELSPDSIGN_LEFT_POSITIVE',
+  // 1: 'STEERWHEELSPDSIGN_RIGHT_NEGATIVE'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'SteerWheelSpdSign', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 40, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::SteerwheelspdsignType steerwheelspdsign(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Driver door status.', 'enum':
+  // {0: 'DRIVERDOORSTS_CLOSED', 1: 'DRIVERDOORSTS_OPEN'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'DriverDoorSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 47, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::DriverdoorstsType driverdoorsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Left rear door status', 'enum':
+  // {0: 'RLDOORSTS_CLOSED', 1: 'RLDOORSTS_OPEN'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'RLDoorSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 54, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::RldoorstsType rldoorsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Passenger door status.', 'enum':
+  // {0: 'PASSENGERDOORSTS_CLOSED',1:'PASSENGERDOORSTS_OPEN'},'precision': 1.0,
+  // 'len': 1, 'name': 'PassengerDoorSts','is_signed_var': False,'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 45, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::PassengerdoorstsType passengerdoorsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Right   rear door status', 'enum':
+  // {0: 'RRDOORSTS_CLOSED', 1: 'RRDOORSTS_OPEN'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'RRDoorSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 44, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::RrdoorstsType rrdoorsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Front fog lamp status', 'enum':
+  // {0: 'FRONTFOGLMPSTS_OFF', 1: 'FRONTFOGLMPSTS_ON',
+  // 2: 'FRONTFOGLMPSTS_RESERVED', 3: 'FRONTFOGLMPSTS_NOT_AVAILABLE'},
+  // 'precision': 1.0, 'len': 2, 'name':'FrontFogLmpSts','is_signed_var':False,
+  // 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 43, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Status_310::FrontfoglmpstsType frontfoglmpsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Rear fog lamp status', 'enum':
+  // {0: 'REARFOGLMPSTS_OFF', 1: 'REARFOGLMPSTS_ON'}, 'precision':1.0,'len': 1,
+  // 'name': 'RearFogLmpSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 51, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::RearfoglmpstsType rearfoglmpsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Low beam status', 'enum':
+  // {0: 'LOWBEAMSTS_OFF', 1: 'LOWBEAMSTS_ON'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'LowBeamSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 49, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::LowbeamstsType lowbeamsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'High beam status', 'enum':
+  // {0: 'HIGHBEAMSTS_OFF', 1: 'HIGHBEAMSTS_ON'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'HighBeamSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 63, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::HighbeamstsType highbeamsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Left turn lamp status', 'enum':
+  // {0: 'LEFTTURNLAMPSTS_OFF', 1: 'LEFTTURNLAMPSTS_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'LeftTurnLampSts', 'is_signed_var': False, 'offset':0.0,
+  // 'physical_range': '[0|1]', 'bit': 62, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::LeftturnlampstsType leftturnlampsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Right turn lamp status', 'enum':
+  // {0: 'RIGHTTURNLAMPSTS_OFF', 1: 'RIGHTTURNLAMPSTS_ON'}, 'precision': 1.0,
+  // 'len': 1, 'name': 'RightTurnLampSts', 'is_signed_var':False,'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 60, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::RightturnlampstsType rightturnlampsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'The work status of BCM', 'enum':
+  // {0: 'BCM_AVAILSTS_MANUAL_MODE', 1: 'BCM_AVAILSTS_AUTONOMOUS_MODE',
+  // 2: 'BCM_AVAILSTS_RESERVED1', 3: 'BCM_AVAILSTS_RESERVED2'},'precision':1.0,
+  // 'len': 2, 'name': 'BCM_AvailSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|3]', 'bit': 58, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::Bcm_availstsType bcm_availsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Break Lamp status', 'enum':
+  // {0: 'BRAKELMPSTS_OFF', 1: 'BRAKELMPSTS_ON'}, 'precision': 1.0, 'len': 1,
+  // 'name': 'BrakeLmpSts', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 56, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Status_310::BrakelmpstsType brakelmpsts(
+    const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/status_310_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/status_310_test.cc
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/status_310.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Status310Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Status310Test, reset) {
+  Status310 status;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
+
+  status.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().longitudeaccvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().lateralaccevalid(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().vehdynyawratevalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().flwheelspdvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().frwheelspdvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rlwheelspdvalid(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rrwheelspdvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().vehiclespdvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().longitudedrivingmode(),
+                   2);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().engspdvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().accepedaloverride(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().brakepedalstatus(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().espbrakelightsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().epbswtpositionvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().epbsts(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().currentgearvalid(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().epstrqsnsrsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().eps_interferdetdvalid(),
+                   0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().epshandsdetnsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().eps_handsdetnstsvalid(),
+                   0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().steerwheelanglesign(),
+                   1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().steerwheelspdsign(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().driverdoorsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rldoorsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rrdoorsts(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().frontfoglmpsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rearfoglmpsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().lowbeamsts(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().highbeamsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().leftturnlampsts(), 0);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().rightturnlampsts(), 1);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().bcm_availsts(), 2);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().status_310().brakelmpsts(), 0);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp1_391.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp1_391.cc
@@ -1,0 +1,142 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/vin_resp1_391.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Vinresp1391::Vinresp1391() {}
+const int32_t Vinresp1391::ID = 0x391;
+
+void Vinresp1391::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin07(vin07(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin06(vin06(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin05(vin05(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin04(vin04(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin03(vin03(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin02(vin02(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin00(vin00(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp1_391()->
+                              set_vin01(vin01(bytes, length));
+}
+
+// config detail: {'name': 'vin07', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 7, 'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin07(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin06', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 15,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin06(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin05', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 23,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin05(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin04', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 31,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin04(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin03', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 39,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin03(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin02', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 47,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin02(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin00', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin00(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin01', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 55,'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp1391::vin01(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp1_391.h
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp1_391.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Vinresp1391 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Vinresp1391();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'VIN07', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 7, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin07(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN06', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 15, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin06(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN05', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 23, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin05(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN04', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 31, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin04(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN03', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 39, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin03(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN02', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 47, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin02(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN00', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 63, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin00(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN01', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 55, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin01(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp1_391_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp1_391_test.cc
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/vin_resp1_391.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Vinresp1391Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Vinresp1391Test, reset) {
+  Vinresp1391 vin1;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
+
+  vin1.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin07(), 136);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin06(), 68);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin05(), 34);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin04(), 17);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin03(), 17);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin02(), 18);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin01(), 19);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp1_391().vin00(), 20);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp2_392.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp2_392.cc
@@ -1,0 +1,142 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/vin_resp2_392.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Vinresp2392::Vinresp2392() {}
+const int32_t Vinresp2392::ID = 0x392;
+
+void Vinresp2392::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin15(vin15(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin14(vin14(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin13(vin13(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin12(vin12(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin11(vin11(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin10(vin10(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin09(vin09(bytes, length));
+  chassis->mutable_wey()->mutable_vin_resp2_392()->
+                                   set_vin08(vin08(bytes, length));
+}
+
+// config detail: {'name': 'vin15', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 7, 'type':'int',
+// 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin15(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin14', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 15,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin14(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin13', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 23,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin13(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin12', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 31,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin12(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin11', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 39,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin11(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin10', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 47,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin10(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin09', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 55,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin09(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'vin08', 'offset': 0.0, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp2392::vin08(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp2_392.h
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp2_392.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Vinresp2392 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Vinresp2392();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'VIN15', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 7, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin15(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN14', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 15, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin14(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN13', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 23, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin13(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN12', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 31, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin12(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN11', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 39, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin11(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN10', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 47, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin10(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN09', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 55, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin09(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'VIN08', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 63, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin08(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp2_392_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp2_392_test.cc
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/vin_resp2_392.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Vinresp2392Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Vinresp2392Test, reset) {
+  Vinresp2392 vin2;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
+
+  vin2.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin15(), 136);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin14(), 68);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin13(), 34);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin12(), 17);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin11(), 17);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin10(), 18);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin09(), 19);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp2_392().vin08(), 20);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp3_393.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp3_393.cc
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/protocol/vin_resp3_393.h"
+
+#include "glog/logging.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::Byte;
+
+Vinresp3393::Vinresp3393() {}
+const int32_t Vinresp3393::ID = 0x393;
+
+void Vinresp3393::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_wey()->mutable_vin_resp3_393()->
+                                        set_vin16(vin16(bytes, length));
+}
+
+// config detail: {'name': 'vin16', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+// 'bit': 7, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Vinresp3393::vin16(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp3_393.h
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp3_393.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class Vinresp3393 : public ::apollo::drivers::canbus::ProtocolData<
+                    ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Vinresp3393();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+                     ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'VIN16', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]',
+  // 'bit': 7, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  int vin16(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/protocol/vin_resp3_393_test.cc
+++ b/modules/canbus/vehicle/wey/protocol/vin_resp3_393_test.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright 2017 The Apollo Authors. All Rights Reserved.
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,34 +14,28 @@
  * limitations under the License.
  *****************************************************************************/
 
-#pragma once
+#include "modules/canbus/vehicle/wey/protocol/vin_resp3_393.h"
+#include "gtest/gtest.h"
 
-#include "gflags/gflags.h"
+namespace apollo {
+namespace canbus {
+namespace wey {
 
-// System gflags
-DECLARE_string(canbus_node_name);
-DECLARE_string(canbus_module_name);
+class Vinresp3393Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
 
-DECLARE_string(canbus_adapter_config_filename);
+TEST_F(Vinresp3393Test, reset) {
+  Vinresp3393 vin3;
+  int32_t length = 8;
+  ChassisDetail chassis_detail;
+  uint8_t bytes[8] = {0x88, 0x44, 0x22, 0x11, 0x11, 0x12, 0x13, 0x14};
 
-// data file
-DECLARE_string(canbus_conf_file);
+  vin3.Parse(bytes, length, &chassis_detail);
+  EXPECT_DOUBLE_EQ(chassis_detail.wey().vin_resp3_393().vin16(), 136);
+}
 
-// Canbus gflags
-DECLARE_double(chassis_freq);
-DECLARE_int64(min_cmd_interval);
-
-// chassis_detail message publish
-DECLARE_bool(enable_chassis_detail_pub);
-
-// canbus test files
-DECLARE_string(canbus_test_file);
-
-// canbus test files
-DECLARE_bool(receive_guardian);
-
-DECLARE_int32(guardian_cmd_pending_queue_size);
-DECLARE_int32(control_cmd_pending_queue_size);
-
-// use acceleration or pedal
-DECLARE_bool(use_acceleration);
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_controller.cc
+++ b/modules/canbus/vehicle/wey/wey_controller.cc
@@ -1,0 +1,841 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "modules/canbus/vehicle/wey/wey_controller.h"
+#include "modules/common/proto/vehicle_signal.pb.h"
+#include "modules/canbus/vehicle/wey/wey_message_manager.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/common/time/time.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::ProtocolData;
+using ::apollo::common::ErrorCode;
+using ::apollo::control::ControlCommand;
+
+namespace {
+
+const int32_t kMaxFailAttempt = 10;
+const int32_t CHECK_RESPONSE_STEER_UNIT_FLAG = 1;
+const int32_t CHECK_RESPONSE_SPEED_UNIT_FLAG = 2;
+double angle_init = 0;
+}  // namespace
+
+ErrorCode WeyController::Init(
+    const VehicleParameter& params,
+    CanSender<::apollo::canbus::ChassisDetail>* const can_sender,
+    MessageManager<::apollo::canbus::ChassisDetail>* const message_manager) {
+  if (is_initialized_) {
+    AINFO << "WeyController has already been initiated.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+  vehicle_params_.CopyFrom(
+      common::VehicleConfigHelper::Instance()->GetConfig().vehicle_param());
+  params_.CopyFrom(params);
+  if (!params_.has_driving_mode()) {
+    AERROR << "Vehicle conf pb not set driving_mode.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  if (can_sender == nullptr) {
+    return ErrorCode::CANBUS_ERROR;
+  }
+  can_sender_ = can_sender;
+
+  if (message_manager == nullptr) {
+    AERROR << "protocol manager is null.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+  message_manager_ = message_manager;
+
+  // sender part
+  ads1_111_ = dynamic_cast<Ads1111*>
+          (message_manager_->GetMutableProtocolDataById(Ads1111::ID));
+  if (ads1_111_ == nullptr) {
+     AERROR << "Ads1111 does not exist in the WeyMessageManager!";
+     return ErrorCode::CANBUS_ERROR;
+  }
+
+  ads3_38e_ = dynamic_cast<Ads338e*>
+          (message_manager_->GetMutableProtocolDataById(Ads338e::ID));
+  if (ads3_38e_ == nullptr) {
+     AERROR << "Ads338e does not exist in the WeyMessageManager!";
+     return ErrorCode::CANBUS_ERROR;
+  }
+
+  ads_eps_113_ = dynamic_cast<Adseps113*>
+          (message_manager_->GetMutableProtocolDataById(Adseps113::ID));
+  if (ads_eps_113_ == nullptr) {
+     AERROR << "Adseps113 does not exist in the WeyMessageManager!";
+     return ErrorCode::CANBUS_ERROR;
+  }
+
+  ads_req_vin_390_ = dynamic_cast<Adsreqvin390*>
+          (message_manager_->GetMutableProtocolDataById(Adsreqvin390::ID));
+  if (ads_req_vin_390_ == nullptr) {
+     AERROR << "Adsreqvin390 does not exist in the WeyMessageManager!";
+     return ErrorCode::CANBUS_ERROR;
+  }
+
+  ads_shifter_115_ = dynamic_cast<Adsshifter115*>
+          (message_manager_->GetMutableProtocolDataById(Adsshifter115::ID));
+  if (ads_shifter_115_ == nullptr) {
+     AERROR << "Adsshifter115 does not exist in the WeyMessageManager!";
+     return ErrorCode::CANBUS_ERROR;
+  }
+
+  can_sender_->AddMessage(Ads1111::ID, ads1_111_, false);
+  can_sender_->AddMessage(Ads338e::ID, ads3_38e_, false);
+  can_sender_->AddMessage(Adseps113::ID, ads_eps_113_, false);
+  can_sender_->AddMessage(Adsreqvin390::ID, ads_req_vin_390_, false);
+  can_sender_->AddMessage(Adsshifter115::ID, ads_shifter_115_, false);
+
+  // need sleep to ensure all messages received
+  AINFO << "WeyController is initialized.";
+
+  is_initialized_ = true;
+  return ErrorCode::OK;
+}
+
+WeyController::~WeyController() {}
+
+bool WeyController::Start() {
+  if (!is_initialized_) {
+    AERROR << "WeyController has NOT been initiated.";
+    return false;
+  }
+  const auto& update_func = [this] { SecurityDogThreadFunc(); };
+  thread_.reset(new std::thread(update_func));
+
+  return true;
+}
+
+void WeyController::Stop() {
+  if (!is_initialized_) {
+    AERROR << "WeyController stops or starts improperly!";
+    return;
+  }
+
+  if (thread_ != nullptr && thread_->joinable()) {
+    thread_->join();
+    thread_.reset();
+    AINFO << "WeyController stopped.";
+  }
+}
+
+Chassis WeyController::chassis() {
+  chassis_.Clear();
+
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+
+  // 21, 22, previously 1, 2
+  if (driving_mode() == Chassis::EMERGENCY_MODE) {
+    set_chassis_error_code(Chassis::NO_ERROR);
+  }
+
+  chassis_.set_driving_mode(driving_mode());
+  chassis_.set_error_code(chassis_error_code());
+
+  // 3
+  chassis_.set_engine_started(true);
+  // if there is not wey, no chassis detail can be retrieved and return
+  if (!chassis_detail.has_wey()) {
+    AERROR << "NO WEY chassis information!";
+    return chassis_;
+  }
+  Wey wey = chassis_detail.wey();
+
+  // 4 engine_rpm
+  if (wey.has_fbs3_237() && wey.fbs3_237().has_engspd()) {
+    chassis_.set_engine_rpm(static_cast<float>(wey.fbs3_237().engspd()));
+  } else {
+    chassis_.set_engine_rpm(0);
+  }
+
+  // 5 6
+  if (wey.has_fbs2_240() && wey.fbs2_240().has_vehiclespd() &&
+          wey.has_fbs1_243() && wey.has_status_310()) {
+    Fbs2_240 fbs2_240 = wey.fbs2_240();
+    Fbs1_243 fbs1_243 = wey.fbs1_243();
+    Status_310 status_310 = wey.status_310();
+    // speed_mps
+    chassis_.set_speed_mps(static_cast<float>(fbs2_240.vehiclespd()));
+    // rr
+    chassis_.mutable_wheel_speed()->set_is_wheel_spd_rr_valid(
+          static_cast<bool>(status_310.rrwheelspdvalid()));
+    if (fbs2_240.rrwheeldirection() == Fbs2_240::RRWHEELDIRECTION_FORWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rr(WheelSpeed::FORWARD);
+    } else if (fbs2_240.rrwheeldirection() ==
+                  Fbs2_240::RRWHEELDIRECTION_BACKWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rr(WheelSpeed::BACKWARD);
+    } else if (fbs2_240.rrwheeldirection() ==
+                  Fbs2_240::RRWHEELDIRECTION_STOP) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rr(WheelSpeed::STANDSTILL);
+    } else {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rr(WheelSpeed::INVALID);
+    }
+    chassis_.mutable_wheel_speed()->set_wheel_spd_rr(fbs2_240.rrwheelspd());
+    // rl
+    chassis_.mutable_wheel_speed()->set_is_wheel_spd_rl_valid(
+          static_cast<bool>(status_310.rlwheelspdvalid()));
+    if (fbs2_240.rlwheeldrivedirection() ==
+                  Fbs2_240::RLWHEELDRIVEDIRECTION_FORWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rl(WheelSpeed::FORWARD);
+    } else if (fbs2_240.rlwheeldrivedirection() ==
+                  Fbs2_240::RLWHEELDRIVEDIRECTION_BACKWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rl(WheelSpeed::BACKWARD);
+    } else if (fbs2_240.rlwheeldrivedirection() ==
+                  Fbs2_240::RLWHEELDRIVEDIRECTION_STOP) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rl(WheelSpeed::STANDSTILL);
+    } else {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_rl(WheelSpeed::INVALID);
+    }
+    chassis_.mutable_wheel_speed()->set_wheel_spd_rl(fbs2_240.rlwheelspd());
+    // fr
+    chassis_.mutable_wheel_speed()->set_is_wheel_spd_fr_valid(
+          static_cast<bool>(status_310.frwheelspdvalid()));
+    if (fbs1_243.frwheeldirection() ==
+                  Fbs1_243::FRWHEELDIRECTION_FORWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fr(WheelSpeed::FORWARD);
+    } else if (fbs1_243.frwheeldirection() ==
+                  Fbs1_243::FRWHEELDIRECTION_BACKWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fr(WheelSpeed::BACKWARD);
+    } else if (fbs1_243.frwheeldirection() ==
+                  Fbs1_243::FRWHEELDIRECTION_STOP) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fr(WheelSpeed::STANDSTILL);
+    } else {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fr(WheelSpeed::INVALID);
+    }
+    chassis_.mutable_wheel_speed()->set_wheel_spd_fr(fbs2_240.frwheelspd());
+    // fl
+    chassis_.mutable_wheel_speed()->set_is_wheel_spd_fl_valid(
+          static_cast<bool>(status_310.flwheelspdvalid()));
+    if (fbs2_240.flwheeldirection() ==
+                  Fbs2_240::FLWHEELDIRECTION_FORWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fl(WheelSpeed::FORWARD);
+    } else if (fbs2_240.flwheeldirection() ==
+                  Fbs2_240::FLWHEELDIRECTION_BACKWARD) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fl(WheelSpeed::BACKWARD);
+    } else if (fbs2_240.flwheeldirection() ==
+                  Fbs2_240::FLWHEELDIRECTION_STOP) {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fl(WheelSpeed::STANDSTILL);
+    } else {
+      chassis_.mutable_wheel_speed()->
+          set_wheel_direction_fl(WheelSpeed::INVALID);
+    }
+    chassis_.mutable_wheel_speed()->set_wheel_spd_fl(fbs1_243.flwheelspd());
+    } else {
+      chassis_.set_speed_mps(0);
+    }
+  // 7
+    chassis_.set_fuel_range_m(0);
+  // 8
+    if (wey.has_fbs3_237() && wey.fbs3_237().has_accpedalpos()) {
+      chassis_.set_throttle_percentage(
+                  static_cast<float>(wey.fbs3_237().accpedalpos()));
+    } else {
+    chassis_.set_throttle_percentage(0);
+  }
+  // 23, previously 10 gear position
+  if (wey.has_fbs3_237() && wey.fbs3_237().has_currentgear()) {
+    switch (wey.fbs3_237().currentgear()) {
+      case Fbs3_237::CURRENTGEAR_D: {
+        chassis_.set_gear_location(Chassis::GEAR_DRIVE);
+      }
+      break;
+      case Fbs3_237::CURRENTGEAR_N: {
+        chassis_.set_gear_location(Chassis::GEAR_NEUTRAL);
+      }
+      break;
+      case Fbs3_237::CURRENTGEAR_R: {
+        chassis_.set_gear_location(Chassis::GEAR_REVERSE);
+      }
+      break;
+      case Fbs3_237::CURRENTGEAR_P: {
+        chassis_.set_gear_location(Chassis::GEAR_PARKING);
+      }
+      break;
+      default:
+        chassis_.set_gear_location(Chassis::GEAR_INVALID);
+        break;
+    }
+  } else {
+    chassis_.set_gear_location(Chassis::GEAR_NONE);
+  }
+  // 11
+  if (wey.has_fbs4_235() && wey.fbs4_235().has_steerwheelangle() &&
+       wey.has_status_310() && wey.status_310().has_steerwheelanglesign()) {
+    if (wey.status_310().steerwheelanglesign() ==
+            Status_310::STEERWHEELANGLESIGN_LEFT_POSITIVE) {
+      chassis_.set_steering_percentage(
+          static_cast<float>(wey.fbs4_235().steerwheelangle() / 500 / 100));
+      angle_init = wey.fbs4_235().steerwheelangle();
+    } else if (wey.status_310().steerwheelanglesign() ==
+            Status_310::STEERWHEELANGLESIGN_RIGHT_NEGATIVE) {
+      chassis_.set_steering_percentage(
+          static_cast<float>(wey.fbs4_235().steerwheelangle() / (-500) * 100));
+      angle_init = wey.fbs4_235().steerwheelangle()*(-1);
+    } else {
+      chassis_.set_steering_percentage(0);
+    }
+  } else {
+    chassis_.set_steering_percentage(0);
+  }
+
+  // 12
+  if (wey.has_fbs3_237() && wey.fbs3_237().has_epsdrvinputtrqvalue()) {
+    chassis_.set_steering_torque_nm(
+          static_cast<float>(wey.fbs3_237().epsdrvinputtrqvalue()));
+  } else {
+    chassis_.set_steering_torque_nm(0);
+  }
+  // 13
+  if (wey.has_status_310() && wey.status_310().has_epbsts()) {
+        chassis_.set_parking_brake(wey.status_310().epbsts() ==
+          Status_310::EPBSTS_CLOSED);
+  } else {
+    chassis_.set_parking_brake(false);
+  }
+  // 14, 15
+  if (chassis_.has_signal() && wey.has_status_310() &&
+      wey.status_310().has_lowbeamsts() &&
+        wey.status_310().lowbeamsts() == Status_310::LOWBEAMSTS_ON) {
+    chassis_.mutable_signal()->set_low_beam(true);
+  } else {
+    chassis_.mutable_signal()->set_low_beam(false);
+  }
+  // 16, 17
+  if (chassis_.has_signal() && wey.has_status_310()) {
+    if (wey.status_310().has_leftturnlampsts() &&
+        wey.status_310().leftturnlampsts() == Status_310::LEFTTURNLAMPSTS_ON ) {
+      chassis_.mutable_signal()->
+          set_turn_signal(common::VehicleSignal::TURN_LEFT);
+    } else if (wey.status_310().has_rightturnlampsts() &&
+       wey.status_310().rightturnlampsts() == Status_310::RIGHTTURNLAMPSTS_ON) {
+      chassis_.mutable_signal()->
+          set_turn_signal(common::VehicleSignal::TURN_RIGHT);
+    } else {
+      chassis_.mutable_signal()->
+          set_turn_signal(common::VehicleSignal::TURN_NONE);
+    }
+  } else {
+    chassis_.mutable_signal()->
+          set_turn_signal(common::VehicleSignal::TURN_NONE);
+  }
+  // 18
+  if (chassis_.has_license() && wey.has_vin_resp1_391() &&
+        wey.has_vin_resp2_392() && wey.has_vin_resp3_393()) {
+    Vin_resp1_391 vin_resp1_391 = wey.vin_resp1_391();
+    Vin_resp2_392 vin_resp2_392 = wey.vin_resp2_392();
+    Vin_resp3_393 vin_resp3_393 = wey.vin_resp3_393();
+    if (vin_resp1_391.has_vin00() && vin_resp1_391.has_vin01() &&
+       vin_resp1_391.has_vin02() && vin_resp1_391.has_vin03() &&
+       vin_resp1_391.has_vin04() && vin_resp1_391.has_vin05() &&
+       vin_resp1_391.has_vin06() && vin_resp1_391.has_vin07() &&
+       vin_resp2_392.has_vin08() && vin_resp2_392.has_vin09() &&
+       vin_resp2_392.has_vin10() && vin_resp2_392.has_vin11() &&
+       vin_resp2_392.has_vin12() && vin_resp2_392.has_vin13() &&
+       vin_resp2_392.has_vin14() && vin_resp2_392.has_vin15() &&
+       vin_resp3_393.has_vin16()) {
+      int n[17];
+      n[0] = vin_resp1_391.vin07();
+      n[1] = vin_resp1_391.vin06();
+      n[2] = vin_resp1_391.vin05();
+      n[3] = vin_resp1_391.vin04();
+      n[4] = vin_resp1_391.vin03();
+      n[5] = vin_resp1_391.vin02();
+      n[6] = vin_resp1_391.vin01();
+      n[7] = vin_resp1_391.vin00();
+      n[8] = vin_resp2_392.vin15();
+      n[9] = vin_resp2_392.vin14();
+      n[10] = vin_resp2_392.vin13();
+      n[11] = vin_resp2_392.vin12();
+      n[12] = vin_resp2_392.vin11();
+      n[13] = vin_resp2_392.vin10();
+      n[14] = vin_resp2_392.vin09();
+      n[15] = vin_resp2_392.vin08();
+      n[16] = vin_resp3_393.vin16();
+      char ch[18];
+      memset(&ch, 0, sizeof(ch));
+      for (int i = 0; i < 17; i++) {
+        ch[i] = static_cast<char>(n[i]);
+      }
+      ch[17] = '\0';
+      chassis_.mutable_license()->set_vin(ch);
+    }
+  }
+
+  if (chassis_error_mask_) {
+    chassis_.set_chassis_error_mask(chassis_error_mask_);
+  }
+  // give engage_advice based on error_code and canbus feedback
+  if (!chassis_error_mask_ && !chassis_.parking_brake()) {
+    chassis_.mutable_engage_advice()->set_advice(
+        apollo::common::EngageAdvice::READY_TO_ENGAGE);
+  } else {
+    chassis_.mutable_engage_advice()->set_advice(
+        apollo::common::EngageAdvice::DISALLOW_ENGAGE);
+    chassis_.mutable_engage_advice()->set_reason(
+        "CANBUS not ready, firmware error or emergency button pressed!");
+  }
+  return chassis_;
+}
+
+void WeyController::Emergency() {
+  set_driving_mode(Chassis::EMERGENCY_MODE);
+  ResetProtocol();
+}
+
+ErrorCode WeyController::EnableAutoMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE) {
+    AINFO << "already in COMPLETE_AUTO_DRIVE mode";
+    return ErrorCode::OK;
+  }
+  ads1_111_->set_ads_mode(Ads1_111::ADS_MODE_ACTIVE_MODE);
+  ads_eps_113_->set_ads_epsmode(Ads_eps_113::ADS_EPSMODE_ACTIVE);
+  // unlock the limited steering angle for first cmd within [-10,10] deg
+  ads_eps_113_->set_ads_reqepstargetangle(angle_init);
+  ads_shifter_115_->set_ads_shiftmode(Ads_shifter_115::ADS_SHIFTMODE_VALID);
+  ads_req_vin_390_->set_req_vin_signal(Ads_req_vin_390::REQ_VIN_SIGNAL_REQUEST);
+  // BCM enable control for horn/ beam/ turnlight
+  // notice : if BCM enable, the beam manual control is invalid. If you use the
+  // car at night, please watch out or disable this function
+  ads3_38e_->set_ads_bcmworkstsvalid(Ads3_38e::ADS_BCMWORKSTSVALID_VALID);
+  ads3_38e_->set_ads_bcm_worksts(Ads3_38e::ADS_BCM_WORKSTS_ACTIVE);
+  ads3_38e_->set_ads_reqcontrolbcm(Ads3_38e::ADS_REQCONTROLBCM_REQUEST);
+  ads3_38e_->set_dippedbeamon(Ads3_38e::DIPPEDBEAMON_TURN_ON);
+
+  can_sender_->Update();
+  const int32_t flag =
+      CHECK_RESPONSE_STEER_UNIT_FLAG | CHECK_RESPONSE_SPEED_UNIT_FLAG;
+  if (!CheckResponse(flag, true)) {
+    AERROR << "Failed to switch to COMPLETE_AUTO_DRIVE mode.";
+    Emergency();
+    set_chassis_error_code(Chassis::CHASSIS_ERROR);
+    return ErrorCode::CANBUS_ERROR;
+  } else {
+    set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+    AINFO << "Switch to COMPLETE_AUTO_DRIVE mode ok.";
+    return ErrorCode::OK;
+  }
+}
+
+ErrorCode WeyController::DisableAutoMode() {
+  ResetProtocol();
+  can_sender_->Update();
+  set_driving_mode(Chassis::COMPLETE_MANUAL);
+  set_chassis_error_code(Chassis::NO_ERROR);
+  AINFO << "Switch to COMPLETE_MANUAL ok.";
+  return ErrorCode::OK;
+}
+
+ErrorCode WeyController::EnableSteeringOnlyMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_STEER_ONLY) {
+    set_driving_mode(Chassis::AUTO_STEER_ONLY);
+    AINFO << "Already in AUTO_STEER_ONLY mode";
+    return ErrorCode::OK;
+  }
+
+  ads1_111_->set_ads_mode(Ads1_111::ADS_MODE_OFF_MODE);
+  ads_eps_113_->set_ads_epsmode(Ads_eps_113::ADS_EPSMODE_ACTIVE);
+  ads_eps_113_->set_ads_reqepstargetangle(angle_init);
+  ads_shifter_115_->set_ads_shiftmode(Ads_shifter_115::ADS_SHIFTMODE_INVALID);
+  ads3_38e_->set_ads_bcmworkstsvalid(Ads3_38e::ADS_BCMWORKSTSVALID_INVALID);
+  ads3_38e_->set_ads_bcm_worksts(Ads3_38e::ADS_BCM_WORKSTS_DISABLE);
+  ads3_38e_->set_ads_reqcontrolbcm(Ads3_38e::ADS_REQCONTROLBCM_NO_REQUEST);
+
+  can_sender_->Update();
+  if (!CheckResponse(CHECK_RESPONSE_STEER_UNIT_FLAG, true)) {
+    AERROR << "Failed to switch to AUTO_STEER_ONLY mode.";
+    Emergency();
+    set_chassis_error_code(Chassis::CHASSIS_ERROR);
+    return ErrorCode::CANBUS_ERROR;
+  } else {
+    set_driving_mode(Chassis::AUTO_STEER_ONLY);
+    AINFO << "Switch to AUTO_STEER_ONLY mode ok.";
+    return ErrorCode::OK;
+  }
+}
+
+ErrorCode WeyController::EnableSpeedOnlyMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_SPEED_ONLY) {
+    set_driving_mode(Chassis::AUTO_SPEED_ONLY);
+    AINFO << "Already in AUTO_SPEED_ONLY mode";
+    return ErrorCode::OK;
+  }
+  ads1_111_->set_ads_mode(Ads1_111::ADS_MODE_ACTIVE_MODE);
+  ads_eps_113_->set_ads_epsmode(Ads_eps_113::ADS_EPSMODE_DISABLE);
+  ads_shifter_115_->set_ads_shiftmode(Ads_shifter_115::ADS_SHIFTMODE_VALID);
+  ads3_38e_->set_ads_bcmworkstsvalid(Ads3_38e::ADS_BCMWORKSTSVALID_INVALID);
+  ads3_38e_->set_ads_bcm_worksts(Ads3_38e::ADS_BCM_WORKSTS_DISABLE);
+  ads3_38e_->set_ads_reqcontrolbcm(Ads3_38e::ADS_REQCONTROLBCM_NO_REQUEST);
+
+  can_sender_->Update();
+  if (!CheckResponse(CHECK_RESPONSE_SPEED_UNIT_FLAG, true)) {
+    AERROR << "Failed to switch to AUTO_STEER_ONLY mode.";
+    Emergency();
+    set_chassis_error_code(Chassis::CHASSIS_ERROR);
+    return ErrorCode::CANBUS_ERROR;
+  } else {
+    set_driving_mode(Chassis::AUTO_SPEED_ONLY);
+    AINFO << "Switch to AUTO_SPEED_ONLY mode ok.";
+    return ErrorCode::OK;
+  }
+}
+
+// NEUTRAL, REVERSE, DRIVE
+void WeyController::Gear(Chassis::GearPosition gear_position) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "this drive mode no need to set gear.";
+    return;
+  }
+  switch (gear_position) {
+    case Chassis::GEAR_NEUTRAL: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_N);
+      break;
+    }
+    case Chassis::GEAR_REVERSE: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_R);
+      break;
+    }
+    case Chassis::GEAR_DRIVE: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_D);
+      break;
+    }
+    case Chassis::GEAR_PARKING: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_P);
+      break;
+    }
+    case Chassis::GEAR_LOW: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_N);
+      break;
+    }
+    case Chassis::GEAR_NONE: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_N);
+      break;
+    }
+    case Chassis::GEAR_INVALID: {
+      AERROR << "Gear command is invalid!";
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_N);
+      break;
+    }
+    default: {
+      ads_shifter_115_->set_ads_targetgear(Ads_shifter_115::ADS_TARGETGEAR_N);
+      break;
+    }
+  }
+}
+
+// brake with acceleration
+// acceleration:-7.0 ~ 5.0, unit:m/s^2
+void WeyController::Brake(double pedal) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_DEMAND);
+  ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_NO_DEMAND);
+  ads1_111_->set_ads_taracce(pedal);
+}
+
+// drive with acceleration
+// first true the Flags_use_acceleration in canbus.conf and control.conf
+// acceleration:-7.0 ~ 5.0, unit:m/s^2
+void WeyController::Throttle(double pedal) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_NO_DEMAND);
+  ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_DEMAND);
+  ads1_111_->set_ads_taracce(pedal);
+}
+
+// wey default, -500 ~ 500, left:+, right:-
+// angle:-99.99~0.00~99.99, unit:, left:+, right:-
+void WeyController::Steer(double angle) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_STEER_ONLY)) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  const double real_angle = 500 * angle / 100;
+  ads_eps_113_->set_ads_reqepstargetangle(real_angle);
+}
+
+// steering with new angle speed
+// angle:-99.99~0.00~99.99, unit:, left:-, right:+
+// wey has no angle_spd
+void WeyController::Steer(double angle, double angle_spd) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_STEER_ONLY)) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  const double real_angle = 500 * angle / 100;
+  ads_eps_113_->set_ads_reqepstargetangle(real_angle);
+}
+
+void WeyController::SetEpbBreak(const ControlCommand& command) {
+  if (command.parking_brake()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void WeyController::SetBeam(const ControlCommand& command) {
+  if (command.signal().high_beam()) {
+    ads3_38e_->set_highbeamton(Ads3_38e::HIGHBEAMTON_TURN_ON);
+  } else if (command.signal().low_beam()) {
+    ads3_38e_->set_dippedbeamon(Ads3_38e::DIPPEDBEAMON_TURN_ON);
+  } else {
+    ads3_38e_->set_highbeamton(Ads3_38e::HIGHBEAMTON_TURN_OFF);
+    ads3_38e_->set_dippedbeamon(Ads3_38e::DIPPEDBEAMON_TURN_OFF);
+  }
+}
+
+void WeyController::SetHorn(const ControlCommand& command) {
+  if (command.signal().horn()) {
+    ads3_38e_->set_hornon(Ads3_38e::HORNON_TURN_ON);
+  } else {
+    ads3_38e_->set_hornon(Ads3_38e::HORNON_TURN_OFF);
+  }
+}
+
+void WeyController::SetTurningSignal(const ControlCommand& command) {
+  // Set Turn Signal
+  auto signal = command.signal().turn_signal();
+  if (signal == common::VehicleSignal::TURN_LEFT) {
+    ads3_38e_->set_turnllighton(Ads3_38e::TURNLLIGHTON_TURN_LEFT_ON);
+  } else if (signal == common::VehicleSignal::TURN_RIGHT) {
+    ads3_38e_->set_turnllighton(Ads3_38e::TURNLLIGHTON_TURN_RIGHT_ON);
+  } else {
+    ads3_38e_->set_turnllighton(Ads3_38e::TURNLLIGHTON_TURN_OFF);
+  }
+}
+
+void WeyController::ResetProtocol() {
+  message_manager_->ResetSendMessages();
+}
+
+bool WeyController::CheckChassisError() {
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+  if (!chassis_detail.has_wey()) {
+    AERROR_EVERY(100) << "ChassisDetail has NO wey vehicle info."
+                  << chassis_detail.DebugString();
+  return false;
+  }
+  Wey wey = chassis_detail.wey();
+  // check steer error
+  if (wey.has_fail_241()) {
+    if (wey.fail_241().epsfail() == Fail_241::EPSFAIL_FAULT) {
+      return true;
+    }
+  }
+  // check ems error
+  if (wey.has_fail_241()) {
+    if (wey.fail_241().engfail() == Fail_241::ENGFAIL_FAIL) {
+      return true;
+    }
+  }
+  // check braking error
+  if (wey.has_fail_241()) {
+    if (wey.fail_241().espfail() == Fail_241::ESPFAIL_FAILURE) {
+      return true;
+    }
+  }
+  // check gear error question
+  if (wey.has_fail_241()) {
+    if (wey.fail_241().shiftfail() ==
+          Fail_241::SHIFTFAIL_TRANSMISSION_P_ENGAGEMENT_FAULT) {
+      return true;
+    }
+  }
+  // check parking error
+  if (wey.has_fail_241()) {
+    if (wey.fail_241().epbfail() == Fail_241::EPBFAIL_ERROR) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void WeyController::SecurityDogThreadFunc() {
+  int32_t vertical_ctrl_fail = 0;
+  int32_t horizontal_ctrl_fail = 0;
+
+  if (can_sender_ == nullptr) {
+    AERROR << "Fail to run SecurityDogThreadFunc() because can_sender_ is "
+              "nullptr.";
+    return;
+  }
+  while (!can_sender_->IsRunning()) {
+    std::this_thread::yield();
+  }
+
+  std::chrono::duration<double, std::micro> default_period{50000};
+  int64_t start = 0;
+  int64_t end = 0;
+  while (can_sender_->IsRunning()) {
+    start = ::apollo::common::time::AsInt64<::apollo::common::time::micros>(
+        ::apollo::common::time::Clock::Now());
+    const Chassis::DrivingMode mode = driving_mode();
+    bool emergency_mode = false;
+
+    // 1. horizontal control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_STEER_ONLY) &&
+        CheckResponse(CHECK_RESPONSE_STEER_UNIT_FLAG, false) == false) {
+      ++horizontal_ctrl_fail;
+      if (horizontal_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      horizontal_ctrl_fail = 0;
+    }
+
+    // 2. vertical control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_SPEED_ONLY) &&
+        CheckResponse(CHECK_RESPONSE_SPEED_UNIT_FLAG, false) == false) {
+      ++vertical_ctrl_fail;
+      if (vertical_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      vertical_ctrl_fail = 0;
+    }
+    if (CheckChassisError()) {
+      set_chassis_error_code(Chassis::CHASSIS_ERROR);
+      emergency_mode = true;
+    }
+
+    if (emergency_mode && mode != Chassis::EMERGENCY_MODE) {
+      set_driving_mode(Chassis::EMERGENCY_MODE);
+      message_manager_->ResetSendMessages();
+    }
+    end = ::apollo::common::time::AsInt64<::apollo::common::time::micros>(
+        ::apollo::common::time::Clock::Now());
+    std::chrono::duration<double, std::micro> elapsed{end - start};
+    if (elapsed < default_period) {
+      std::this_thread::sleep_for(default_period - elapsed);
+    } else {
+      AERROR
+          << "Too much time consumption in WeyController looping process:"
+          << elapsed.count();
+    }
+  }
+}
+
+bool WeyController::CheckResponse(const int32_t flags, bool need_wait) {
+  int32_t retry_num = 20;
+  ChassisDetail chassis_detail;
+  bool is_eps_online = false;
+  bool is_vcu_online = false;
+  bool is_esp_online = false;
+
+  do {
+    if (message_manager_->GetSensorData(&chassis_detail) != ErrorCode::OK) {
+      AERROR_EVERY(100) << "get chassis detail failed.";
+      return false;
+    }
+    bool check_ok = true;
+    if (flags & CHECK_RESPONSE_STEER_UNIT_FLAG) {
+      is_eps_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_eps_online() &&
+                      chassis_detail.check_response().is_eps_online();
+      check_ok = check_ok && is_eps_online;
+    }
+
+    if (flags & CHECK_RESPONSE_SPEED_UNIT_FLAG) {
+      is_vcu_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_vcu_online() &&
+                      chassis_detail.check_response().is_vcu_online();
+      is_esp_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_esp_online() &&
+                      chassis_detail.check_response().is_esp_online();
+      check_ok = check_ok && is_vcu_online && is_esp_online;
+    }
+    if (need_wait) {
+      --retry_num;
+      std::this_thread::sleep_for(
+          std::chrono::duration<double, std::milli>(20));
+    }
+    if (check_ok) {
+      return true;
+    } else {
+      AINFO << "Need to check response again.";
+    }
+  } while (need_wait && retry_num);
+
+  AINFO << "check_response fail: is_eps_online:" << is_eps_online
+        << ", is_vcu_online:" << is_vcu_online
+        << ", is_esp_online:" << is_esp_online;
+  return false;
+}
+
+void WeyController::set_chassis_error_mask(const int32_t mask) {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  chassis_error_mask_ = mask;
+}
+
+int32_t WeyController::chassis_error_mask() {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  return chassis_error_mask_;
+}
+
+Chassis::ErrorCode WeyController::chassis_error_code() {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  return chassis_error_code_;
+}
+
+void WeyController::set_chassis_error_code(
+    const Chassis::ErrorCode& error_code) {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  chassis_error_code_ = error_code;
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_controller.cc
+++ b/modules/canbus/vehicle/wey/wey_controller.cc
@@ -518,7 +518,7 @@ ErrorCode WeyController::EnableSpeedOnlyMode() {
   }
 }
 
-// NEUTRAL, REVERSE, DRIVE
+// NEUTRAL, REVERSE, DRIVE, PARK
 void WeyController::Gear(Chassis::GearPosition gear_position) {
   if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
         driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
@@ -562,7 +562,7 @@ void WeyController::Gear(Chassis::GearPosition gear_position) {
   }
 }
 
-// brake with acceleration
+// brake with pedal
 // acceleration:-7.0 ~ 5.0, unit:m/s^2
 void WeyController::Brake(double pedal) {
   if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
@@ -570,13 +570,10 @@ void WeyController::Brake(double pedal) {
     AINFO << "The current drive mode does not need to set acceleration.";
     return;
   }
-  ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_DEMAND);
-  ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_NO_DEMAND);
-  ads1_111_->set_ads_taracce(pedal);
+  // None
 }
 
-// drive with acceleration
-// first true the Flags_use_acceleration in canbus.conf and control.conf
+// drive with pedal
 // acceleration:-7.0 ~ 5.0, unit:m/s^2
 void WeyController::Throttle(double pedal) {
   if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
@@ -584,10 +581,28 @@ void WeyController::Throttle(double pedal) {
     AINFO << "The current drive mode does not need to set acceleration.";
     return;
   }
-  ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_NO_DEMAND);
-  ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_DEMAND);
-  ads1_111_->set_ads_taracce(pedal);
+  // None
 }
+
+// wey use the acc to control the car acceleration and deceleration
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void WeyController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  if (acc >= 0) {
+    ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_NO_DEMAND);
+    ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_DEMAND);
+  } else {
+    ads1_111_->set_ads_dectostop(Ads1_111::ADS_DECTOSTOP_DEMAND);
+    ads1_111_->set_ads_driveoff_req(Ads1_111::ADS_DRIVEOFF_REQ_NO_DEMAND);
+  }
+  ads1_111_->set_ads_taracce(acc);
+}
+
 
 // wey default, -500 ~ 500, left:+, right:-
 // angle:-99.99~0.00~99.99, unit:, left:+, right:-

--- a/modules/canbus/vehicle/wey/wey_controller.h
+++ b/modules/canbus/vehicle/wey/wey_controller.h
@@ -1,0 +1,136 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <thread>
+
+#include "modules/canbus/vehicle/vehicle_controller.h"
+
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/common/proto/error_code.pb.h"
+#include "modules/control/proto/control_cmd.pb.h"
+
+#include "modules/canbus/vehicle/wey/protocol/ads1_111.h"
+#include "modules/canbus/vehicle/wey/protocol/ads3_38e.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_eps_113.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_shifter_115.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class WeyController final : public VehicleController {
+ public:
+  WeyController() {}
+
+  virtual ~WeyController();
+
+  ::apollo::common::ErrorCode Init(
+      const VehicleParameter& params,
+      CanSender<::apollo::canbus::ChassisDetail> *const can_sender,
+      MessageManager<::apollo::canbus::ChassisDetail> *const message_manager)
+      override;
+
+  bool Start() override;
+
+  /**
+   * @brief stop the vehicle controller.
+   */
+  void Stop() override;
+
+  /**
+   * @brief calculate and return the chassis.
+   * @returns a copy of chassis. Use copy here to avoid multi-thread issues.
+   */
+  Chassis chassis() override;
+  FRIEND_TEST(WeyControllerTest, SetDrivingMode);
+  FRIEND_TEST(WeyControllerTest, Status);
+  FRIEND_TEST(WeyControllerTest, UpdateDrivingMode);
+
+ private:
+  // main logical function for operation the car enter or exit the auto driving
+  void Emergency() override;
+  ::apollo::common::ErrorCode EnableAutoMode() override;
+  ::apollo::common::ErrorCode DisableAutoMode() override;
+  ::apollo::common::ErrorCode EnableSteeringOnlyMode() override;
+  ::apollo::common::ErrorCode EnableSpeedOnlyMode() override;
+
+  // NEUTRAL, REVERSE, DRIVE
+  void Gear(Chassis::GearPosition state) override;
+
+  // brake with new acceleration
+  // acceleration:0.00~99.99, unit:
+  // acceleration_spd: 60 ~ 100, suggest: 90
+  void Brake(double acceleration) override;
+
+  // drive with old acceleration
+  // gas:0.00~99.99 unit:
+  void Throttle(double throttle) override;
+
+  // steering with old angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  void Steer(double angle) override;
+
+  // steering with new angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  // angle_spd:0.00~99.99, unit:deg/s
+  void Steer(double angle, double angle_spd) override;
+
+  // set Electrical Park Brake
+  void SetEpbBreak(const ::apollo::control::ControlCommand& command) override;
+  void SetBeam(const ::apollo::control::ControlCommand& command) override;
+  void SetHorn(const ::apollo::control::ControlCommand& command) override;
+  void SetTurningSignal(
+      const ::apollo::control::ControlCommand& command) override;
+
+  void ResetProtocol();
+  bool CheckChassisError();
+
+ private:
+  void SecurityDogThreadFunc();
+  virtual bool CheckResponse(const int32_t flags, bool need_wait);
+  void set_chassis_error_mask(const int32_t mask);
+  int32_t chassis_error_mask();
+  Chassis::ErrorCode chassis_error_code();
+  void set_chassis_error_code(const Chassis::ErrorCode& error_code);
+
+ private:
+  // control protocol
+  Ads1111* ads1_111_ = nullptr;
+  Ads338e* ads3_38e_ = nullptr;
+  Adseps113* ads_eps_113_ = nullptr;
+  Adsreqvin390* ads_req_vin_390_ = nullptr;
+  Adsshifter115* ads_shifter_115_ = nullptr;
+
+  Chassis chassis_;
+  std::unique_ptr<std::thread> thread_;
+  bool is_chassis_error_ = false;
+
+  std::mutex chassis_error_code_mutex_;
+  Chassis::ErrorCode chassis_error_code_ = Chassis::NO_ERROR;
+
+  std::mutex chassis_mask_mutex_;
+  int32_t chassis_error_mask_ = 0;
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_controller.h
+++ b/modules/canbus/vehicle/wey/wey_controller.h
@@ -85,6 +85,10 @@ class WeyController final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;

--- a/modules/canbus/vehicle/wey/wey_controller_test.cc
+++ b/modules/canbus/vehicle/wey/wey_controller_test.cc
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/wey_controller.h"
+#include <string>
+#include "gtest/gtest.h"
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/vehicle/wey/wey_message_manager.h"
+#include "modules/common/util/file.h"
+#include "modules/control/proto/control_cmd.pb.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::common::ErrorCode;
+using ::apollo::control::ControlCommand;
+
+class WeyControllerTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    std::string canbus_conf_file =
+        "modules/canbus/testdata/conf/wey_canbus_conf_test.pb.txt";
+    ::apollo::common::util::GetProtoFromFile(canbus_conf_file, &canbus_conf_);
+    params_ = canbus_conf_.vehicle_parameter();
+  }
+
+ protected:
+  WeyController controller_;
+  CanSender<::apollo::canbus::ChassisDetail> sender_;
+  CanbusConf canbus_conf_;
+  VehicleParameter params_;
+  WeyMessageManager msg_manager_;
+  ControlCommand control_cmd_;
+};
+
+TEST_F(WeyControllerTest, Init) {
+  ErrorCode ret = controller_.Init(params_, &sender_, &msg_manager_);
+  EXPECT_EQ(ret, ErrorCode::OK);
+}
+
+TEST_F(WeyControllerTest, SetDrivingMode) {
+  Chassis chassis;
+  chassis.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+
+  controller_.Init(params_, &sender_, &msg_manager_);
+
+  controller_.set_driving_mode(chassis.driving_mode());
+  EXPECT_EQ(controller_.driving_mode(), chassis.driving_mode());
+  EXPECT_EQ(controller_.SetDrivingMode(chassis.driving_mode()), ErrorCode::OK);
+}
+
+TEST_F(WeyControllerTest, Status) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.Update(control_cmd_), ErrorCode::OK);
+
+  controller_.SetHorn(control_cmd_);
+  controller_.SetBeam(control_cmd_);
+  controller_.SetTurningSignal(control_cmd_);
+  EXPECT_FALSE(controller_.CheckChassisError());
+}
+
+TEST_F(WeyControllerTest, UpdateDrivingMode) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.SetDrivingMode(Chassis::COMPLETE_MANUAL),
+            ErrorCode::OK);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_message_manager.cc
+++ b/modules/canbus/vehicle/wey/wey_message_manager.cc
@@ -1,0 +1,62 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "modules/canbus/vehicle/wey/wey_message_manager.h"
+
+#include "modules/canbus/vehicle/wey/protocol/ads1_111.h"
+#include "modules/canbus/vehicle/wey/protocol/ads3_38e.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_eps_113.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_shifter_115.h"
+
+#include "modules/canbus/vehicle/wey/protocol/fail_241.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs1_243.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs2_240.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs3_237.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs4_235.h"
+#include "modules/canbus/vehicle/wey/protocol/status_310.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp1_391.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp2_392.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp3_393.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+WeyMessageManager::WeyMessageManager() {
+  // Control Messages
+  AddSendProtocolData<Ads1111, true>();
+  AddSendProtocolData<Ads338e, true>();
+  AddSendProtocolData<Adseps113, true>();
+  AddSendProtocolData<Adsreqvin390, true>();
+  AddSendProtocolData<Adsshifter115, true>();
+
+  // Report Messages
+  AddRecvProtocolData<Fail241, true>();
+  AddRecvProtocolData<Fbs1243, true>();
+  AddRecvProtocolData<Fbs2240, true>();
+  AddRecvProtocolData<Fbs3237, true>();
+  AddRecvProtocolData<Fbs4235, true>();
+  AddRecvProtocolData<Status310, true>();
+  AddRecvProtocolData<Vinresp1391, true>();
+  AddRecvProtocolData<Vinresp2392, true>();
+  AddRecvProtocolData<Vinresp3393, true>();
+}
+
+WeyMessageManager::~WeyMessageManager() {}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_message_manager.h
+++ b/modules/canbus/vehicle/wey/wey_message_manager.h
@@ -1,0 +1,36 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+using ::apollo::drivers::canbus::MessageManager;
+
+class WeyMessageManager
+    : public MessageManager<::apollo::canbus::ChassisDetail> {
+ public:
+  WeyMessageManager();
+  virtual ~WeyMessageManager();
+};
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_message_manager_test.cc
+++ b/modules/canbus/vehicle/wey/wey_message_manager_test.cc
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/wey_message_manager.h"
+#include "gtest/gtest.h"
+#include "modules/canbus/vehicle/wey/protocol/ads1_111.h"
+#include "modules/canbus/vehicle/wey/protocol/ads3_38e.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_eps_113.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_req_vin_390.h"
+#include "modules/canbus/vehicle/wey/protocol/ads_shifter_115.h"
+
+#include "modules/canbus/vehicle/wey/protocol/fail_241.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs1_243.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs2_240.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs3_237.h"
+#include "modules/canbus/vehicle/wey/protocol/fbs4_235.h"
+#include "modules/canbus/vehicle/wey/protocol/status_310.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp1_391.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp2_392.h"
+#include "modules/canbus/vehicle/wey/protocol/vin_resp3_393.h"
+
+namespace apollo {
+namespace canbus {
+namespace wey {
+
+class WeyMessageManagerTest : public ::testing::Test {
+ public:
+  WeyMessageManagerTest() : manager_() {}
+  virtual void SetUp() {}
+
+ protected:
+  WeyMessageManager manager_;
+};
+
+TEST_F(WeyMessageManagerTest, GetSendProtocols) {
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Ads1111::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Ads338e::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Adseps113::ID) != nullptr);
+  EXPECT_TRUE(
+    manager_.GetMutableProtocolDataById(Adsreqvin390::ID) != nullptr);
+  EXPECT_TRUE(
+    manager_.GetMutableProtocolDataById(Adsshifter115::ID) != nullptr);
+}
+
+TEST_F(WeyMessageManagerTest, GetRecvProtocols) {
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Fail241::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Fbs1243::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Fbs2240::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Fbs3237::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Fbs4235::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Status310::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Vinresp1391::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Vinresp2392::ID) != nullptr);
+  EXPECT_TRUE(manager_.GetMutableProtocolDataById(Vinresp3393::ID) != nullptr);
+}
+
+}  // namespace wey
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_vehicle_factory.cc
+++ b/modules/canbus/vehicle/wey/wey_vehicle_factory.cc
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/wey/wey_vehicle_factory.h"
+#include "modules/canbus/vehicle/wey/wey_controller.h"
+#include "modules/canbus/vehicle/wey/wey_message_manager.h"
+#include "modules/common/util/util.h"
+
+namespace apollo {
+namespace canbus {
+
+std::unique_ptr<VehicleController>
+WeyVehicleFactory::CreateVehicleController() {
+  return std::unique_ptr<VehicleController>(new wey::WeyController());
+}
+
+std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+WeyVehicleFactory::CreateMessageManager() {
+  return std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>(
+       new wey::WeyMessageManager());
+}
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_vehicle_factory.h
+++ b/modules/canbus/vehicle/wey/wey_vehicle_factory.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+/**
+ * @file wey_vehicle_factory.h
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/canbus/vehicle/abstract_vehicle_factory.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+/**
+ * @namespace apollo::canbus
+ * @brief apollo::canbus
+ */
+namespace apollo {
+namespace canbus {
+
+/**
+ * @class WeyVehicleFactory
+ *
+ * @brief this class is inherited from AbstractVehicleFactory. It can be used 
+ * to create controller and message manager for wey vehicle.
+ */
+class WeyVehicleFactory : public AbstractVehicleFactory {
+ public:
+  /**
+  * @brief destructor
+  */
+  virtual ~WeyVehicleFactory() = default;
+
+  /**
+   * @brief create wey vehicle controller
+   * @returns a unique_ptr that points to the created controller
+   */
+  std::unique_ptr<VehicleController> CreateVehicleController() override;
+
+  /**
+   * @brief create wey message manager
+   * @returns a unique_ptr that points to the created message manager
+   */
+  std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+  CreateMessageManager() override;
+};
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/wey/wey_vehicle_factory_test.cc
+++ b/modules/canbus/vehicle/wey/wey_vehicle_factory_test.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright 2018 The Apollo Authors. All Rights Reserved.
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,42 +14,32 @@
  * limitations under the License.
  *****************************************************************************/
 
-#include "modules/canbus/vehicle/vehicle_factory.h"
-
+#include "modules/canbus/vehicle/wey/wey_vehicle_factory.h"
 #include "gtest/gtest.h"
-
 #include "modules/canbus/proto/vehicle_parameter.pb.h"
 
 namespace apollo {
 namespace canbus {
 
-class VehicleFactoryTest : public ::testing::Test {
+class WeyVehicleFactoryTest : public ::testing::Test {
  public:
-  VehicleFactoryTest() : factory_() {}
-
   virtual void SetUp() {
-    factory_.RegisterVehicleFactory();
+    VehicleParameter parameter;
+    parameter.set_brand(VehicleParameter::WEY);
+    wey_factory_.SetVehicleParameter(parameter);
   }
   virtual void TearDown() {}
 
  protected:
-  VehicleFactory factory_;
+  WeyVehicleFactory wey_factory_;
 };
 
-TEST_F(VehicleFactoryTest, CreateVehicle) {
-  VehicleParameter parameter;
+TEST_F(WeyVehicleFactoryTest, InitVehicleController) {
+  EXPECT_TRUE(wey_factory_.CreateVehicleController() != nullptr);
+}
 
-  parameter.set_brand(VehicleParameter::GEM);
-  EXPECT_TRUE(factory_.CreateVehicle(parameter) != nullptr);
-
-  parameter.set_brand(VehicleParameter::LINCOLN_MKZ);
-  EXPECT_TRUE(factory_.CreateVehicle(parameter) != nullptr);
-
-  parameter.set_brand(VehicleParameter::GE3);
-  EXPECT_TRUE(factory_.CreateVehicle(parameter) != nullptr);
-
-  parameter.set_brand(VehicleParameter::WEY);
-  EXPECT_TRUE(factory_.CreateVehicle(parameter) != nullptr);
+TEST_F(WeyVehicleFactoryTest, InitMessageManager) {
+  EXPECT_TRUE(wey_factory_.CreateMessageManager() != nullptr);
 }
 
 }  // namespace canbus

--- a/modules/control/common/control_gflags.cc
+++ b/modules/control/common/control_gflags.cc
@@ -56,8 +56,3 @@ DEFINE_int32(pad_msg_pending_queue_size, 10,
              "Max pad message pending queue size");
 
 DEFINE_bool(reverse_heading_control, false, "test vehicle reverse control");
-
-// switch to use acceleration_cmd or pedal_cmd (brake and throttle) for control
-// TODO(ChaoMa) : default: use pedal_cmd
-DEFINE_bool(use_acceleration, false,
-             "True to use acceleration_cmd instead of pedal_cmd");

--- a/modules/control/common/control_gflags.cc
+++ b/modules/control/common/control_gflags.cc
@@ -56,3 +56,8 @@ DEFINE_int32(pad_msg_pending_queue_size, 10,
              "Max pad message pending queue size");
 
 DEFINE_bool(reverse_heading_control, false, "test vehicle reverse control");
+
+// switch to use acceleration_cmd or pedal_cmd (brake and throttle) for control
+// TODO(ChaoMa) : default: use pedal_cmd
+DEFINE_bool(use_acceleration, false,
+             "True to use acceleration_cmd instead of pedal_cmd");

--- a/modules/control/common/control_gflags.h
+++ b/modules/control/common/control_gflags.h
@@ -50,5 +50,3 @@ DECLARE_int32(localization_pending_queue_size);
 DECLARE_int32(pad_msg_pending_queue_size);
 
 DECLARE_bool(reverse_heading_control);
-
-DECLARE_bool(use_acceleration);

--- a/modules/control/common/control_gflags.h
+++ b/modules/control/common/control_gflags.h
@@ -50,3 +50,5 @@ DECLARE_int32(localization_pending_queue_size);
 DECLARE_int32(pad_msg_pending_queue_size);
 
 DECLARE_bool(reverse_heading_control);
+
+DECLARE_bool(use_acceleration);

--- a/modules/control/conf/control.conf
+++ b/modules/control/conf/control.conf
@@ -7,6 +7,7 @@
 --set_steer_limit=true
 --use_cyber_time=false
 --enable_slope_offset=false
+--use_acceleration=false
 
 # --reverse_heading_vehicle_state=false
 # --reverse_heading_control=false

--- a/modules/control/conf/control.conf
+++ b/modules/control/conf/control.conf
@@ -7,7 +7,6 @@
 --set_steer_limit=true
 --use_cyber_time=false
 --enable_slope_offset=false
---use_acceleration=false
 
 # --reverse_heading_vehicle_state=false
 # --reverse_heading_control=false

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -275,8 +275,10 @@ Status LonController::ComputeControlCommand(
                     ? std::abs(calibration_value)
                     : brake_deadzone;
     }
+      cmd->set_throttle(throttle_cmd);
+      cmd->set_brake(brake_cmd);
   } else {
-    cmd->set_acceleration(acceleration_cmd);
+      cmd->set_acceleration(acceleration_cmd);
     if (acceleration_cmd >= 0) {
       cmd->set_throttle(acceleration_cmd);
     } else {
@@ -308,9 +310,6 @@ Status LonController::ComputeControlCommand(
             debug->speed_lookup(), calibration_value, throttle_cmd, brake_cmd,
             debug->is_full_stop());
   }
-
-  cmd->set_throttle(throttle_cmd);
-  cmd->set_brake(brake_cmd);
 
   if (std::fabs(VehicleStateProvider::Instance()->linear_velocity()) <=
           vehicle_param_.max_abs_speed_when_stopped() ||

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -255,24 +255,33 @@ Status LonController::ComputeControlCommand(
       (chassis->gear_location() == canbus::Chassis::GEAR_REVERSE)
           ? -acceleration_cmd
           : acceleration_cmd;
-  if (FLAGS_use_preview_speed_for_table) {
-    calibration_value = control_interpolation_->Interpolate(
+  if (!FLAGS_use_acceleration) {
+    if (FLAGS_use_preview_speed_for_table) {
+      calibration_value = control_interpolation_->Interpolate(
         std::make_pair(debug->preview_speed_reference(), acceleration_lookup));
-  } else {
-    calibration_value = control_interpolation_->Interpolate(
+    } else {
+      calibration_value = control_interpolation_->Interpolate(
         std::make_pair(chassis_->speed_mps(), acceleration_lookup));
-  }
+    }
 
-  if (calibration_value >= 0) {
-    throttle_cmd = std::abs(calibration_value) > throttle_deadzone
+    if (calibration_value >= 0) {
+      throttle_cmd = std::abs(calibration_value) > throttle_deadzone
                        ? std::abs(calibration_value)
                        : throttle_deadzone;
-    brake_cmd = 0.0;
-  } else {
-    throttle_cmd = 0.0;
-    brake_cmd = std::abs(calibration_value) > brake_deadzone
+      brake_cmd = 0.0;
+    } else {
+      throttle_cmd = 0.0;
+      brake_cmd = std::abs(calibration_value) > brake_deadzone
                     ? std::abs(calibration_value)
                     : brake_deadzone;
+    }
+  } else {
+    cmd->set_acceleration(acceleration_cmd);
+    if (acceleration_cmd >= 0) {
+      cmd->set_throttle(acceleration_cmd);
+    } else {
+      cmd->set_brake(acceleration_cmd);
+    }
   }
 
   debug->set_station_error_limited(station_error_limited);

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -255,35 +255,25 @@ Status LonController::ComputeControlCommand(
       (chassis->gear_location() == canbus::Chassis::GEAR_REVERSE)
           ? -acceleration_cmd
           : acceleration_cmd;
-  if (!FLAGS_use_acceleration) {
-    if (FLAGS_use_preview_speed_for_table) {
-      calibration_value = control_interpolation_->Interpolate(
-        std::make_pair(debug->preview_speed_reference(), acceleration_lookup));
-    } else {
-      calibration_value = control_interpolation_->Interpolate(
-        std::make_pair(chassis_->speed_mps(), acceleration_lookup));
-    }
 
-    if (calibration_value >= 0) {
-      throttle_cmd = std::abs(calibration_value) > throttle_deadzone
+  if (FLAGS_use_preview_speed_for_table) {
+    calibration_value = control_interpolation_->Interpolate(
+        std::make_pair(debug->preview_speed_reference(), acceleration_lookup));
+  } else {
+    calibration_value = control_interpolation_->Interpolate(
+        std::make_pair(chassis_->speed_mps(), acceleration_lookup));
+  }
+
+  if (calibration_value >= 0) {
+    throttle_cmd = std::abs(calibration_value) > throttle_deadzone
                        ? std::abs(calibration_value)
                        : throttle_deadzone;
-      brake_cmd = 0.0;
-    } else {
-      throttle_cmd = 0.0;
-      brake_cmd = std::abs(calibration_value) > brake_deadzone
+    brake_cmd = 0.0;
+  } else {
+    throttle_cmd = 0.0;
+    brake_cmd = std::abs(calibration_value) > brake_deadzone
                     ? std::abs(calibration_value)
                     : brake_deadzone;
-    }
-      cmd->set_throttle(throttle_cmd);
-      cmd->set_brake(brake_cmd);
-  } else {
-      cmd->set_acceleration(acceleration_cmd);
-    if (acceleration_cmd >= 0) {
-      cmd->set_throttle(acceleration_cmd);
-    } else {
-      cmd->set_brake(acceleration_cmd);
-    }
   }
 
   debug->set_station_error_limited(station_error_limited);
@@ -310,6 +300,11 @@ Status LonController::ComputeControlCommand(
             debug->speed_lookup(), calibration_value, throttle_cmd, brake_cmd,
             debug->is_full_stop());
   }
+
+  // if the car is driven by acceleration, disgard the cmd->throttle and brake
+  cmd->set_throttle(throttle_cmd);
+  cmd->set_brake(brake_cmd);
+  cmd->set_acceleration(acceleration_cmd);
 
   if (std::fabs(VehicleStateProvider::Instance()->linear_velocity()) <=
           vehicle_param_.max_abs_speed_when_stopped() ||

--- a/modules/control/controller/mpc_controller.cc
+++ b/modules/control/controller/mpc_controller.cc
@@ -424,8 +424,10 @@ Status MPCController::ComputeControlCommand(
   }
 
   cmd->set_steering_rate(FLAGS_steer_angle_rate);
+  // if the car is driven by acceleration, disgard the cmd->throttle and brake
   cmd->set_throttle(throttle_cmd);
   cmd->set_brake(brake_cmd);
+  cmd->set_acceleration(acceleration_cmd);
 
   debug->set_heading(VehicleStateProvider::Instance()->heading());
   debug->set_steering_position(chassis->steering_percentage());

--- a/modules/tools/gen_vehicle_protocol/template/controller.cc.tpl
+++ b/modules/tools/gen_vehicle_protocol/template/controller.cc.tpl
@@ -275,7 +275,7 @@ void %(car_type_cap)sController::Brake(double pedal) {
   // TODO(All) :  Update brake value based on mode
   if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
         driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
-    AINFO << "The current drive mode does not need to set acceleration.";
+    AINFO << "The current drive mode does not need to set brake pedal.";
     return;
   }
   /* ADD YOUR OWN CAR CHASSIS OPERATION
@@ -288,11 +288,24 @@ void %(car_type_cap)sController::Brake(double pedal) {
 void %(car_type_cap)sController::Throttle(double pedal) {
   if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
         driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
-    AINFO << "The current drive mode does not need to set acceleration.";
+    AINFO << "The current drive mode does not need to set throttle pedal.";
     return;
   }
   /* ADD YOUR OWN CAR CHASSIS OPERATION
   throttle_62_->set_pedal(pedal);
+  */
+}
+
+// confirm the car is driven by acceleration command or throttle/brake pedal
+// drive with acceleration/deceleration
+// acc:-7.0 ~ 5.0, unit:m/s^2
+void %(car_type_cap)sController::Acceleration(double acc) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  /* ADD YOUR OWN CAR CHASSIS OPERATION
   */
 }
 

--- a/modules/tools/gen_vehicle_protocol/template/controller.h.tpl
+++ b/modules/tools/gen_vehicle_protocol/template/controller.h.tpl
@@ -79,6 +79,10 @@ class %(car_type_cap)sController final : public VehicleController {
   // gas:0.00~99.99 unit:
   void Throttle(double throttle) override;
 
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
   // steering with old angle speed
   // angle:-99.99~0.00~99.99, unit:, left:+, right:-
   void Steer(double angle) override;


### PR DESCRIPTION
We add a new car named WEY. The car used acceleration control command instead of throttle/brake pedal, so we do a flag to switch the acceleration cmd or throttle/brake pedal cmd, default is throttle/brake pedal cmd. Also the teleop has been modified. The code has checked, tested, and linted.