### PR TITLE
Prediction: refactored DataForLearning proto.

### DIFF
--- a/modules/prediction/common/feature_output.cc
+++ b/modules/prediction/common/feature_output.cc
@@ -52,21 +52,6 @@ void FeatureOutput::Insert(const Feature& feature) {
 void FeatureOutput::InsertIntoLearningData(const Feature& feature) {
   data_for_learning_.set_id(feature.id());
   data_for_learning_.set_timestamp(feature.timestamp());
-
-  for (int i = 0; i < feature.lane().lane_graph().lane_sequence_size();
-       i ++) {
-    DataForLearning::LaneSequenceData lane_sequence_data;
-    auto curr_lane_sequence = feature.lane().lane_graph().lane_sequence(i);
-
-    lane_sequence_data.set_lane_sequence_id(
-        curr_lane_sequence.lane_sequence_id());
-    for (int j = 0; j < curr_lane_sequence.features().mlp_features_size();
-         j ++) {
-      lane_sequence_data.add_features_lane_learning(
-          curr_lane_sequence.features().mlp_features(j));
-    }
-    data_for_learning_.add_lane_sequence_data()->CopyFrom(lane_sequence_data);
-  }
 }
 
 void FeatureOutput::Write() {

--- a/modules/prediction/proto/offline_features.proto
+++ b/modules/prediction/proto/offline_features.proto
@@ -17,36 +17,14 @@ message CNNFeatures {
   optional int32 label = 5;
 }
 
-// next id = 6;
 message DataForLearning {
   // The info. needed for identifying a unique data point:
   optional int32 id = 1;
   optional double timestamp = 2;
 
-  // The actual input features for learning algorithms:
-  repeated double features_learning = 3;
+  // The features for learning algorithms:
+  repeated double features_for_learning = 3;
 
-  // The labels for each data point:
-  message TrajectoryPoint {
-  	optional double x = 1;
-  	optional double y = 2;
-  	optional double velocity_heading = 3;
-  }
-  repeated TrajectoryPoint trajectory = 4;
-
-
-  // In case if the learning algorithm processes single lane.
-  message LaneSequenceData {
-  	// The info. needed for identifying a unique data point:
-  	optional int32 lane_sequence_id = 1;
-
-  	// The actual input features for learning algorithms:
-  	repeated double features_lane_learning = 2;
-
-  	// The labels for each data point:
-  	optional int32 label = 3;
-	optional double time_to_lane_center = 4;
-	optional double time_to_lane_edge = 5;
-  }
-  repeated LaneSequenceData lane_sequence_data = 5;
+  // The ground-truth labels:
+  repeated double labels = 4;
 }


### PR DESCRIPTION
To avoid adding more protos, DataForLearning can also play the role of the "ModelFeatures" proto.