### PR TITLE
framework: fix implicit conversions

### DIFF
--- a/cyber/tools/cyber_monitor/screen.cc
+++ b/cyber/tools/cyber_monitor/screen.cc
@@ -164,7 +164,7 @@ void Screen::HighlightLine(int lineNo) {
   if (IsInit() && lineNo < Height()) {
     SetCurrentColor(WHITE_BLACK);
     for (int x = 0; x < Width(); ++x) {
-      int ch = mvinch(lineNo + highlight_direction_, x);
+      chtype ch = mvinch(lineNo + highlight_direction_, x);
       ch &= A_CHARTEXT;
       if (ch == ' ') mvaddch(lineNo + highlight_direction_, x, ch);
     }
@@ -172,7 +172,7 @@ void Screen::HighlightLine(int lineNo) {
 
     SetCurrentColor(BLACK_WHITE);
     for (int x = 0; x < Width(); ++x) {
-      int ch = mvinch(lineNo, x);
+      chtype ch = mvinch(lineNo, x);
       mvaddch(lineNo, x, ch & A_CHARTEXT);
     }
     ClearCurrentColor();


### PR DESCRIPTION
error: conversion to 'int' from 'chtype {aka long unsigned int}' may
alter its value [-Werror=conversion]
       int ch = mvinch(lineNo + highlight_direction_, x);
                ^