### PR TITLE
perception: remove unnecessary type value re-assignment

### DIFF
--- a/modules/perception/lidar/tools/offline_lidar_obstacle_perception.cc
+++ b/modules/perception/lidar/tools/offline_lidar_obstacle_perception.cc
@@ -210,7 +210,7 @@ class OfflineLidarObstaclePerception {
                                    const std::string& path) {
     std::ofstream fout(path);
     if (!fout.is_open()) {
-      AERROR << "Fail to open " << path << std::endl;
+      AERROR << "Failed to open: " << path << std::endl;
       return false;
     }
     fout << frame_id << " " << objects.size() << std::endl;
@@ -224,7 +224,7 @@ class OfflineLidarObstaclePerception {
       if (object->type == base::ObjectType::UNKNOWN ||
           object->type == base::ObjectType::UNKNOWN_MOVABLE ||
           object->type == base::ObjectType::UNKNOWN_UNMOVABLE) {
-        type = "unknow";
+        // type is unknow in this case
       } else if (object->type == base::ObjectType::PEDESTRIAN) {
         type = "pedestrian";
       } else if (object->type == base::ObjectType::VEHICLE) {


### PR DESCRIPTION
Maybe we can remove UNKNOWN* check as well, but that might affect the code readable as well as the logic.