### PR TITLE
framework: add new option for cyber_recorder record

### DIFF
--- a/cyber/record/record_writer.cc
+++ b/cyber/record/record_writer.cc
@@ -30,6 +30,8 @@ using proto::SingleMessage;
 
 RecordWriter::RecordWriter() { header_ = HeaderBuilder::GetHeader(); }
 
+RecordWriter::RecordWriter(const proto::Header& header) { header_ = header; }
+
 RecordWriter::~RecordWriter() { Close(); }
 
 bool RecordWriter::Open(const std::string& file) {

--- a/cyber/record/record_writer.h
+++ b/cyber/record/record_writer.h
@@ -43,6 +43,7 @@ class RecordWriter : public RecordBase {
   using FileWriterPtr = std::unique_ptr<RecordFileWriter>;
 
   RecordWriter();
+  explicit RecordWriter(const proto::Header& header);
 
   virtual ~RecordWriter();
 

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -33,6 +33,7 @@
 using apollo::cyber::common::GetFileName;
 using apollo::cyber::common::StringToUnixSeconds;
 using apollo::cyber::common::UnixSecondsToString;
+using apollo::cyber::record::HeaderBuilder;
 using apollo::cyber::record::Info;
 using apollo::cyber::record::Player;
 using apollo::cyber::record::PlayParam;
@@ -41,7 +42,7 @@ using apollo::cyber::record::Recoverer;
 using apollo::cyber::record::Spliter;
 
 const char INFO_OPTIONS[] = "h";
-const char RECORD_OPTIONS[] = "o:ac:h";
+const char RECORD_OPTIONS[] = "o:ac:i:m:h";
 const char PLAY_OPTIONS[] = "f:c:lr:b:e:s:d:p:h";
 const char SPLIT_OPTIONS[] = "f:o:c:k:b:e:h";
 const char RECOVER_OPTIONS[] = "f:o:h";
@@ -136,6 +137,14 @@ void DisplayUsage(const std::string& binary, const std::string& command,
         std::cout << "\t-p, --preload <seconds>\t\t\t" << command
                   << " after trying to preload n second(s)" << std::endl;
         break;
+      case 'i':
+        std::cout << "\t-i, --segment-interval <seconds>\t" << command
+                  << " segmented every n second(s)" << std::endl;
+        break;
+      case 'm':
+        std::cout << "\t-m, --segment-size <MB>\t\t\t" << command
+                  << " segmented every n megabyte(s)" << std::endl;
+        break;
       case 'h':
         std::cout << "\t-h, --help\t\t\t\tshow help message" << std::endl;
         break;
@@ -161,7 +170,7 @@ int main(int argc, char** argv) {
   }
 
   int long_index = 0;
-  const std::string short_opts = "f:c:k:o:alr:b:e:s:d:p:h";
+  const std::string short_opts = "f:c:k:o:alr:b:e:s:d:p:i:m:h";
   static const struct option long_opts[] = {
       {"files", required_argument, nullptr, 'f'},
       {"white-channel", required_argument, nullptr, 'c'},
@@ -175,6 +184,8 @@ int main(int argc, char** argv) {
       {"start", required_argument, nullptr, 's'},
       {"delay", required_argument, nullptr, 'd'},
       {"preload", required_argument, nullptr, 'p'},
+      {"segment-interval", required_argument, nullptr, 'i'},
+      {"segment-size", required_argument, nullptr, 'm'},
       {"help", no_argument, nullptr, 'h'}};
 
   std::vector<std::string> opt_file_vec;
@@ -189,6 +200,7 @@ int main(int argc, char** argv) {
   uint64_t opt_start = 0;
   uint64_t opt_delay = 0;
   uint32_t opt_preload = 3;
+  auto opt_header = HeaderBuilder::GetHeader();
 
   do {
     int opt =
@@ -296,6 +308,44 @@ int main(int argc, char** argv) {
           return -1;
         }
         break;
+      case 'i':
+        try {
+          int interval_s = std::stoi(optarg);
+          if (interval_s < 0) {
+            std::cout << "Argument is less than zero: -i/--segment-interval "
+                      << std::string(optarg) << std::endl;
+            return -1;
+          }
+          opt_header.set_segment_interval(interval_s * 1000000000ULL);
+        } catch (std::invalid_argument& ia) {
+          std::cout << "Invalid argument: -i/--segment-interval "
+                    << std::string(optarg) << std::endl;
+          return -1;
+        } catch (const std::out_of_range& e) {
+          std::cout << "Argument is out of range: -i/--segment-interval "
+                    << std::string(optarg) << std::endl;
+          return -1;
+        }
+        break;
+      case 'm':
+        try {
+          int size_mb = std::stoi(optarg);
+          if (size_mb < 0) {
+            std::cout << "Argument is less than zero: -m/--segment-size "
+                      << std::string(optarg) << std::endl;
+            return -1;
+          }
+          opt_header.set_segment_raw_size(size_mb * 1024 * 1024ULL);
+        } catch (std::invalid_argument& ia) {
+          std::cout << "Invalid argument: -m/--segment-size "
+                    << std::string(optarg) << std::endl;
+          return -1;
+        } catch (const std::out_of_range& e) {
+          std::cout << "Argument is out of range: -m/--segment-size "
+                    << std::string(optarg) << std::endl;
+          return -1;
+        }
+        break;
       case 'h':
         DisplayUsage(binary, command);
         return 0;
@@ -375,7 +425,7 @@ int main(int argc, char** argv) {
     bool record_result = true;
     ::apollo::cyber::Init(argv[0]);
     auto recorder = std::make_shared<Recorder>(opt_output_vec[0], opt_all,
-                                               opt_white_channels);
+                                               opt_white_channels, opt_header);
     record_result = record_result && recorder->Start() ? true : false;
     if (record_result) {
       while (!::apollo::cyber::IsShutdown()) {

--- a/cyber/tools/cyber_recorder/recorder.cc
+++ b/cyber/tools/cyber_recorder/recorder.cc
@@ -16,18 +16,30 @@
 
 #include "cyber/tools/cyber_recorder/recorder.h"
 
+#include "cyber/record/header_builder.h"
+
 namespace apollo {
 namespace cyber {
 namespace record {
 
 Recorder::Recorder(const std::string& output, bool all_channels,
                    const std::vector<std::string>& channel_vec)
-    : output_(output), all_channels_(all_channels), channel_vec_(channel_vec) {}
+    : output_(output), all_channels_(all_channels), channel_vec_(channel_vec) {
+  header_ = HeaderBuilder::GetHeader();
+}
+
+Recorder::Recorder(const std::string& output, bool all_channels,
+                   const std::vector<std::string>& channel_vec,
+                   const proto::Header& header)
+    : output_(output),
+      all_channels_(all_channels),
+      channel_vec_(channel_vec),
+      header_(header) {}
 
 Recorder::~Recorder() { Stop(); }
 
 bool Recorder::Start() {
-  writer_.reset(new RecordWriter());
+  writer_.reset(new RecordWriter(header_));
   if (!writer_->Open(output_)) {
     AERROR << "Datafile open file error.";
     return false;
@@ -150,7 +162,7 @@ bool Recorder::InitReaderImpl(const std::string& channel_name,
     std::weak_ptr<Recorder> weak_this = shared_from_this();
     std::shared_ptr<ReaderBase> reader = nullptr;
     auto callback = [weak_this, channel_name](
-        const std::shared_ptr<RawMessage>& raw_message) {
+                        const std::shared_ptr<RawMessage>& raw_message) {
       auto share_this = weak_this.lock();
       if (!share_this) {
         return;

--- a/cyber/tools/cyber_recorder/recorder.h
+++ b/cyber/tools/cyber_recorder/recorder.h
@@ -26,6 +26,7 @@
 #include "cyber/base/signal.h"
 #include "cyber/cyber.h"
 #include "cyber/message/raw_message.h"
+#include "cyber/proto/record.pb.h"
 #include "cyber/proto/topology_change.pb.h"
 #include "cyber/record/record_writer.h"
 
@@ -47,6 +48,9 @@ class Recorder : public std::enable_shared_from_this<Recorder> {
  public:
   Recorder(const std::string& output, bool all_channels,
            const std::vector<std::string>& channel_vec);
+  Recorder(const std::string& output, bool all_channels,
+           const std::vector<std::string>& channel_vec,
+           const proto::Header& header);
   ~Recorder();
   bool Start();
   bool Stop();
@@ -61,6 +65,7 @@ class Recorder : public std::enable_shared_from_this<Recorder> {
   std::string output_;
   bool all_channels_ = true;
   std::vector<std::string> channel_vec_;
+  proto::Header header_;
   std::unordered_map<std::string, std::shared_ptr<ReaderBase>>
       channel_reader_map_;
   uint64_t message_count_;

--- a/docs/cyber/CyberRT_Developer_Tools.md
+++ b/docs/cyber/CyberRT_Developer_Tools.md
@@ -171,6 +171,8 @@ usage: cyber_recorder record [options]
     -o, --output <file>                output record file
     -a, --all                          all channels
     -c, --channel <name>               channel name
+    -i, --segment-interval <seconds>   record segmented every n second(s)
+    -m, --segment-size <MB>            record segmented every n megabyte(s)
     -h, --help                         show help message
 
 ```


### PR DESCRIPTION
use -i/--segment-interval to specify the interval time (unit: second) used to segment record file;
use -m/--segment-size to specify the raw size(unit: megabyte) used to segment record file;

if you do not want to segment record file, you can set them to zero.
`cyber_recorder record -a -i 0 -m 0`