### PR TITLE
fixing bosfs build error in installer script install_bosfs.sh

### DIFF
--- a/docker/build/installers/install_bosfs.sh
+++ b/docker/build/installers/install_bosfs.sh
@@ -21,9 +21,9 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Prepair.
+# Prepare
 apt-get update -y
-apt-get install -y libfuse-dev
+apt-get install -y libfuse-dev autotools-dev automake uuid-dev
 wget http://sdk.bce.baidu.com/console-sdk/bosfs-1.0.0.8.tar.gz
 tar zxf bosfs-1.0.0.8.tar.gz
 


### PR DESCRIPTION
fixing build error for installer script install_bosfs.sh used building the dev container

1) added 'autotools-dev' and 'automake' to 'apt-get install' to fix the missing 'aclocal' command used in 'autogen.sh' in bosfs gzip
2) added 'uuid-dev' to 'apt-get install'. since fresh containers are missing this package, the build of bosfs fails in:
file: ./model/bce_request.cpp:16:23: fatal error: uuid/uuid.h: no such file

I created issue [6732](https://github.com/ApolloAuto/apollo/issues/6732) to track this.