### PR TITLE
updated the dev container's installer_ipopt.sh

### DIFF
--- a/docker/build/installers/install_ipopt.sh
+++ b/docker/build/installers/install_ipopt.sh
@@ -21,6 +21,7 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+add-apt-repository universe && apt-get -y update
 apt-get install -y libblas-dev liblapack-dev gfortran
 
 wget https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.11.zip -O Ipopt-3.12.11.zip


### PR DESCRIPTION
updated the dev container's `installer_ipopt.sh` script to add the `universe` apt repository which is required to install the `gfortran` package

I opened issue [6735](https://github.com/ApolloAuto/apollo/issues/6735) to track this.