### PR TITLE
Added the leveldb header dependency to install_python_modules.sh

### DIFF
--- a/docker/build/installers/install_python_modules.sh
+++ b/docker/build/installers/install_python_modules.sh
@@ -21,14 +21,16 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-apt-get install -y \
-   libgeos-dev \
-   python-matplotlib \
-   python-pip \
-   python-psutil \
-   python-scipy \
-   python-software-properties \
-   python3-psutil
+apt-get -y update && \
+  apt-get install -y \
+    libgeos-dev \
+    python-matplotlib \
+    python-pip \
+    python-psutil \
+    python-scipy \
+    python-software-properties \
+    python3-psutil \
+    libleveldb-dev
 
 pip install -r py27_requirements.txt
 


### PR DESCRIPTION
updated the dev container's install_python_modules.sh script to install the 
`libleveldb-dev` development headers in addition to what's already being installed

created Issue [6741](https://github.com/ApolloAuto/apollo/issues/6741) to track this.