### PR TITLE
removing plyvel from py27_requirements.txt

### DIFF
--- a/docker/build/installers/install_python_modules.sh
+++ b/docker/build/installers/install_python_modules.sh
@@ -21,14 +21,15 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-apt-get install -y \
-   libgeos-dev \
-   python-matplotlib \
-   python-pip \
-   python-psutil \
-   python-scipy \
-   python-software-properties \
-   python3-psutil
+apt-get -y update && \
+  apt-get install -y \
+    libgeos-dev \
+    python-matplotlib \
+    python-pip \
+    python-psutil \
+    python-scipy \
+    python-software-properties \
+    python3-psutil
 
 pip install -r py27_requirements.txt
 

--- a/docker/build/installers/py27_requirements.txt
+++ b/docker/build/installers/py27_requirements.txt
@@ -18,7 +18,6 @@ requests >= 2.18
 simplejson
 
 # Python tools
-plyvel == 0.9
 pymongo
 pyproj
 shapely


### PR DESCRIPTION
Based on comments in PR [6742](https://github.com/ApolloAuto/apollo/pull/6742), `leveldb` has been replaced with sqlite and I confirmed that removing `plyvel` from the requirements file does fix the [6741](https://github.com/ApolloAuto/apollo/issues/6741) issue.  I will close the PR.

