### PR TITLE
added the grpc v1.14.2 release artifact to install_bazel_packages.sh

### DIFF
--- a/docker/build/installers/install_bazel_packages.sh
+++ b/docker/build/installers/install_bazel_packages.sh
@@ -48,3 +48,5 @@ wget -O tinyxml2-5.0.1.zip \
     https://github.com/leethomason/tinyxml2/archive/5.0.1.zip
 wget -O protobuf-3.3.0.tar.gz \
     https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz
+wget -O v1.14.2.tar.gz \
+    https://github.com/grpc/grpc/archive/v1.14.2.tar.gz


### PR DESCRIPTION
added the grpc v1.14.2 release artifact to `install_bazel_packages.sh`

Fixes issue [6754](https://github.com/ApolloAuto/apollo/issues/6754)