### PR TITLE
changed install directory of osqp headers to /usr/local/include

### DIFF
--- a/docker/build/installers/install_osqp.sh
+++ b/docker/build/installers/install_osqp.sh
@@ -28,7 +28,7 @@ unzip master.zip
 
 pushd osqp-contrib-master
 
-cp -r ./osqp /usr/include/
+cp -r ./osqp /usr/local/include/
 popd
 
 rm -fr master.zip osqp-contrib-master


### PR DESCRIPTION
changed install directory of `osqp` headers to `/usr/local/include`

The bazel BUILD of the math common module is expecing the osqp dependency under `/usr/local/include`.

Fixes issue [6756](https://github.com/ApolloAuto/apollo/issues/6756)