### PR TITLE
Added a headless Qt 5.1.1 install script

### DIFF
--- a/docker/build/dev.x86_64.dockerfile
+++ b/docker/build/dev.x86_64.dockerfile
@@ -61,6 +61,7 @@ RUN bash /tmp/installers/install_pcl.sh
 RUN bash /tmp/installers/install_protobuf.sh
 RUN bash /tmp/installers/install_python_modules.sh
 RUN bash /tmp/installers/install_qp_oases.sh
+RUN bash /tmp/installers/install_qt.sh
 RUN bash /tmp/installers/install_supervisor.sh
 RUN bash /tmp/installers/install_undistort.sh
 RUN bash /tmp/installers/install_user.sh

--- a/docker/build/installers/install_qt.sh
+++ b/docker/build/installers/install_qt.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright 2019 The Apollo Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+# Fail on first error.
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+QT_VERSION_A=5.5
+QT_VERSION_B=5.5.1
+QT_VERSION_SCRIPT=551
+
+wget https://download.qt.io/archive/qt/${QT_VERSION_A}/${QT_VERSION_B}/qt-opensource-linux-x64-${QT_VERSION_B}.run
+
+chmod +x qt-opensource-linux-x64-${QT_VERSION_B}.run 
+
+# The '-platform' flag causes a message to stdout "Unknown option: p, l, a, t, f, o, r, m": message is incorrectly printed (it's a bug). The command still succeeds.
+# https://stackoverflow.com/a/34032216/1158977
+
+# the below error can be ignored since Ubuntu 14 does not have sslv2
+# qt.network.ssl: QSslSocket: cannot resolve SSLv2_client_method
+# qt.network.ssl: QSslSocket: cannot resolve SSLv2_server_method
+./qt-opensource-linux-x64-${QT_VERSION_B}.run --script qt-noninteractive.qs  -platform minimal
+
+# this will install to "/qt" so need to symlink to /usr/local/Qt5.5.1
+# as needed in https://github.com/ApolloAuto/apollo/blob/master/tools/qt.bzl
+ln -s /qt /usr/local/Qt$QT_VERSION_B
+
+# clean up
+rm qt-opensource-linux-x64-${QT_VERSION_B}.run
+rm -rf /usr/local/Qt$QT_VERSION_B/{Docs,Examples,Extras,Tools}
+

--- a/docker/build/installers/qt-noninteractive.qs
+++ b/docker/build/installers/qt-noninteractive.qs
@@ -1,0 +1,58 @@
+//
+// this script enables a headless install of Qt
+//
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function()
+{
+    gui.currentPageWidget().TargetDirectoryLineEdit.setText("/qt");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    // it's easier to select default and
+    // cleanup in the bash script
+    widget.selectDefault();
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm
+if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
+    checkBoxForm.launchQtCreatorCheckBox.checked = false;
+}
+    gui.clickButton(buttons.FinishButton);
+}


### PR DESCRIPTION
Added a headless Qt 5.1.1 install script and corresponding controller script:
```
1) installer download https://download.qt.io/archive/qt/5.8/5.8.0/qt-opensource-linux-x64-5.8.0.run
2) uses qs-noninteractive.qs controller script for headless install
3) installs default selections then removes unecessary directories (Extras, Docs, Tools)
```
Fixes issue [6760](https://github.com/ApolloAuto/apollo/issues/6760)