### PR TITLE
Added an installer script for the pre-built fast-rtps from apollo-platform

### DIFF
--- a/docker/build/dev.x86_64.dockerfile
+++ b/docker/build/dev.x86_64.dockerfile
@@ -51,6 +51,7 @@ RUN bash /tmp/installers/install_conda.sh
 RUN bash /tmp/installers/install_gflags_glog.sh
 RUN bash /tmp/installers/install_glew.sh
 RUN bash /tmp/installers/install_gpu_caffe.sh
+RUN bash /tmp/installers/install_fast_rtps.sh
 RUN bash /tmp/installers/install_ipopt.sh
 RUN bash /tmp/installers/install_osqp.sh
 RUN bash /tmp/installers/install_libjsonrpc-cpp.sh

--- a/docker/build/installers/install_fast_rtps.sh
+++ b/docker/build/installers/install_fast_rtps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright 2019 The Apollo Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+# Fail on first error.
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# download the pre-built fast-rtps
+# from the apollo-platform source code
+wget https://github.com/ApolloAuto/apollo-platform/archive/2.1.2.tar.gz
+
+# install pre-built for x86_64
+tar -xf 2.1.2.tar.gz
+cp -r apollo-platform-2.1.2/ros/third_party/fast-rtps_x86_64 /usr/local/fast-rtps
+
+#clean up
+rm -rf 2.1.2.tar.gz apollo-platform-2.1.2
+


### PR DESCRIPTION
1) installer downloads the source code from apollo-platform 2.1.2 release
2) copies the fast-rtps_x86_64 pre-built package to /usr/local
3) cleans up

Fixes issue [6766](https://github.com/ApolloAuto/apollo/issues/6766)