### PR TITLE
added a container installer script for the poco library

### DIFF
--- a/docker/build/dev.x86_64.dockerfile
+++ b/docker/build/dev.x86_64.dockerfile
@@ -58,6 +58,7 @@ RUN bash /tmp/installers/install_nlopt.sh
 RUN bash /tmp/installers/install_node.sh
 RUN bash /tmp/installers/install_ota.sh
 RUN bash /tmp/installers/install_pcl.sh
+RUN bash /tmp/installers/install_poco.sh
 RUN bash /tmp/installers/install_protobuf.sh
 RUN bash /tmp/installers/install_python_modules.sh
 RUN bash /tmp/installers/install_qp_oases.sh

--- a/docker/build/installers/install_poco.sh
+++ b/docker/build/installers/install_poco.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright 2019 The Apollo Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+# Fail on first error.
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Ubuntu 14.04 has poco package version 1.3.6
+# if a higher version is required, the below
+# will install from source
+apt-get -y update && \
+    apt-get -y install poco
+
+# Install from source
+#VERSION=1.9.0
+
+#wget https://github.com/pocoproject/poco/archive/poco-${VERSION}-release.tar.gz
+#tar -xf poco-${VERSION}-release.tar.gz
+
+# we cant use cmake because poco requires > 3.2
+# and the container is at 2.8
+# but standard ./configure && make works fine
+
+#pushd poco-poco-${VERSION}-release
+  #./configure --omit=Data/ODBC,Data/MySQL && \
+      #    make -s -j`nproc` && \
+      #    make -s -j`nproc` install
+#popd
+
+# clean up
+#rm -rf poco-${VERSION}-release.tar.gz poco-poco-${VERSION}-release


### PR DESCRIPTION
1) the current version of the script installs from apt
2) Ubuntu 14.04 supports Poco 1.3.x which is an old release
3) The script has code that is commented out, which can install from source instead
4) The install from source uses version 1.9.0 but has a variable for changing that version

Fixes issue: [6771](https://github.com/ApolloAuto/apollo/issues/6771)