### PR TITLE
Perception: Fix the crash of HDMap ROI filter with radar

### DIFF
--- a/modules/perception/radar/app/radar_obstacle_perception.cc
+++ b/modules/perception/radar/app/radar_obstacle_perception.cc
@@ -79,8 +79,7 @@ bool RadarObstaclePerception::Perceive(
   ADEBUG << "Detected frame objects number: "
            << detect_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "detector");
-  if (!roi_filter_->RoiFilter(options.roi_filter_options,
-                               detect_frame_ptr)) {
+  if (!roi_filter_->RoiFilter(options.roi_filter_options, detect_frame_ptr)) {
     ADEBUG << "All radar objects were filtered out";
   }
   ADEBUG << "RoiFiltered frame objects number: "

--- a/modules/perception/radar/app/radar_obstacle_perception.cc
+++ b/modules/perception/radar/app/radar_obstacle_perception.cc
@@ -79,8 +79,10 @@ bool RadarObstaclePerception::Perceive(
   ADEBUG << "Detected frame objects number: "
            << detect_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "detector");
-  CHECK(roi_filter_->RoiFilter(options.roi_filter_options,
-                               detect_frame_ptr)) << "radar roi filter error";
+  if (!roi_filter_->RoiFilter(options.roi_filter_options,
+                               detect_frame_ptr)) {
+    ADEBUG << "All radar objects were filtered out";
+  }
   ADEBUG << "RoiFiltered frame objects number: "
            << detect_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "roi_filter");


### PR DESCRIPTION
In the previous code, when all radar objects are out of ROI, ROIfilter() returns false and CHECK will kill the perception. Having 0 radar objects is common. For the solution, I removed CHECK