### PR TITLE
planning: code clean up; removed two locally defined params.

### DIFF
--- a/modules/planning/common/ego_info.cc
+++ b/modules/planning/common/ego_info.cc
@@ -52,9 +52,8 @@ void EgoInfo::CalculateEgoBox(const common::VehicleState& vehicle_state) {
   Vec2d position(vehicle_state.x(), vehicle_state.y());
   Vec2d center(position + vec_to_center.rotate(vehicle_state.heading()));
 
-  const double buffer = 0.1;  // in meters
-  ego_box_ = Box2d(center, vehicle_state.heading(), param.length() + buffer,
-                   param.width() + buffer);
+  ego_box_ = Box2d(center, vehicle_state.heading(), param.length(),
+      param.width());
 }
 
 void EgoInfo::Clear() {

--- a/modules/planning/common/path_decision.cc
+++ b/modules/planning/common/path_decision.cc
@@ -98,8 +98,7 @@ bool PathDecision::MergeWithMainStop(const ObjectStop &obj_stop,
   }
 
   // check stop_line_s vs adc_s, ignore if it is further way than main stop
-  const double kStopBuff = 1.0;
-  stop_line_s = std::fmax(stop_line_s, adc_sl_boundary.end_s() - kStopBuff);
+  stop_line_s = std::fmax(stop_line_s, adc_sl_boundary.end_s());
 
   if (stop_line_s >= stop_reference_line_s_) {
     ADEBUG << "stop point is farther than current main stop point.";

--- a/modules/planning/common/path_decision.cc
+++ b/modules/planning/common/path_decision.cc
@@ -20,6 +20,7 @@
 
 #include "modules/planning/common/path_decision.h"
 
+#include "modules/common/configs/vehicle_config_helper.h"
 #include "modules/common/util/util.h"
 
 namespace apollo {
@@ -98,7 +99,9 @@ bool PathDecision::MergeWithMainStop(const ObjectStop &obj_stop,
   }
 
   // check stop_line_s vs adc_s, ignore if it is further way than main stop
-  stop_line_s = std::fmax(stop_line_s, adc_sl_boundary.end_s());
+  const auto& vehicle_config = common::VehicleConfigHelper::GetConfig();
+  stop_line_s = std::fmax(stop_line_s, adc_sl_boundary.end_s() -
+      vehicle_config.vehicle_param().front_edge_to_center());
 
   if (stop_line_s >= stop_reference_line_s_) {
     ADEBUG << "stop point is farther than current main stop point.";

--- a/modules/planning/scenarios/lane_follow/lane_follow_scenario.cc
+++ b/modules/planning/scenarios/lane_follow/lane_follow_scenario.cc
@@ -21,36 +21,13 @@
 #include "modules/planning/scenarios/lane_follow/lane_follow_scenario.h"
 
 #include "cyber/common/log.h"
-#include "modules/common/math/math_utils.h"
-#include "modules/common/time/time.h"
-#include "modules/common/util/string_tokenizer.h"
-#include "modules/common/util/string_util.h"
-#include "modules/common/vehicle_state/vehicle_state_provider.h"
-#include "modules/map/hdmap/hdmap.h"
-#include "modules/map/hdmap/hdmap_common.h"
-#include "modules/planning/common/ego_info.h"
 #include "modules/planning/common/frame.h"
-#include "modules/planning/common/planning_gflags.h"
-#include "modules/planning/constraint_checker/constraint_checker.h"
 #include "modules/planning/scenarios/lane_follow/lane_follow_stage.h"
-#include "modules/planning/tasks/optimizers/dp_poly_path/dp_poly_path_optimizer.h"
-#include "modules/planning/tasks/optimizers/dp_st_speed/dp_st_speed_optimizer.h"
-#include "modules/planning/tasks/optimizers/path_decider/path_decider.h"
-#include "modules/planning/tasks/optimizers/qp_piecewise_jerk_path/qp_piecewise_jerk_path_optimizer.h"
-#include "modules/planning/tasks/optimizers/qp_spline_path/qp_spline_path_optimizer.h"
-#include "modules/planning/tasks/optimizers/qp_spline_st_speed/qp_spline_st_speed_optimizer.h"
-#include "modules/planning/tasks/optimizers/speed_decider/speed_decider.h"
 
 namespace apollo {
 namespace planning {
 namespace scenario {
 namespace lane_follow {
-
-namespace {
-constexpr double kPathOptimizationFallbackCost = 2e4;
-constexpr double kSpeedOptimizationFallbackCost = 2e4;
-constexpr double kStraightForwardLineCost = 10.0;
-}  // namespace
 
 std::unique_ptr<Stage> LaneFollowScenario::CreateStage(
     const ScenarioConfig::StageConfig& stage_config) {


### PR DESCRIPTION
Verified using dreamland scenarios