### PR TITLE
Planning: fix speed planning visualizing on dreamview

### DIFF
--- a/modules/planning/tasks/deciders/speed_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider.cc
@@ -123,7 +123,6 @@ void SpeedBoundsDecider::RecordSTGraphDebug(
     return;
   }
 
-  st_graph_debug->set_name(Name());
   for (const auto &boundary : st_graph_data.st_boundaries()) {
     auto boundary_debug = st_graph_debug->add_boundary();
     boundary_debug->set_name(boundary->id());

--- a/modules/planning/tasks/optimizers/speed_optimizer.cc
+++ b/modules/planning/tasks/optimizers/speed_optimizer.cc
@@ -61,6 +61,7 @@ void SpeedOptimizer::RecordDebugInfo(const SpeedData& speed_data,
     ADEBUG << "Skip record debug info";
     return;
   }
+  st_graph_debug->set_name(Name());
   st_graph_debug->mutable_speed_profile()->CopyFrom(
       {speed_data.begin(), speed_data.end()});
 }


### PR DESCRIPTION
fix a bug where speed planning results are not ploted on dreamview