### PR TITLE
Cyber: Fix the memory issue of cyber_record

### DIFF
--- a/cyber/record/record_viewer.cc
+++ b/cyber/record/record_viewer.cc
@@ -28,8 +28,11 @@ namespace record {
 RecordViewer::RecordViewer(const RecordReaderPtr& reader, uint64_t begin_time,
                            uint64_t end_time,
                            const std::set<std::string>& channels)
-    : begin_time_(begin_time), end_time_(end_time), channels_(channels) {
-  readers_.emplace_back(reader);
+    : begin_time_(begin_time),
+      end_time_(end_time),
+      channels_(channels),
+      readers_({reader}) {
+  Init();
   UpdateTime();
 }
 
@@ -40,7 +43,7 @@ RecordViewer::RecordViewer(const std::vector<RecordReaderPtr>& readers,
       end_time_(end_time),
       channels_(channels),
       readers_(readers) {
-  Sort();
+  Init();
   UpdateTime();
 }
 
@@ -74,23 +77,24 @@ uint64_t RecordViewer::begin_time() const { return begin_time_; }
 uint64_t RecordViewer::end_time() const { return end_time_; }
 
 std::set<std::string> RecordViewer::GetChannelList() const {
-  std::set<std::string> channel_list;
-
-  for (auto& reader : readers_) {
-    auto all_channel = reader->GetChannelList();
-    std::set_intersection(all_channel.begin(), all_channel.end(),
-                          channels_.begin(), channels_.end(),
-                          std::inserter(channel_list, channel_list.end()));
-  }
-
-  return channel_list;
+  return channel_list_;
 }
 
 RecordViewer::Iterator RecordViewer::begin() { return Iterator(this); }
 
 RecordViewer::Iterator RecordViewer::end() { return Iterator(this, true); }
 
-void RecordViewer::Sort() {
+void RecordViewer::Init() {
+  // Init the channel list
+  for (auto& reader : readers_) {
+    auto all_channel = reader->GetChannelList();
+    std::set_intersection(all_channel.begin(), all_channel.end(),
+                          channels_.begin(), channels_.end(),
+                          std::inserter(channel_list_, channel_list_.end()));
+  }
+  readers_finished_.resize(readers_.size(), false);
+
+  // Sort the readers
   std::sort(readers_.begin(), readers_.end(),
             [](const RecordReaderPtr& lhs, const RecordReaderPtr& rhs) {
               const auto& lhs_header = lhs->header();
@@ -106,6 +110,7 @@ void RecordViewer::Reset() {
   for (auto& reader : readers_) {
     reader->Reset();
   }
+  std::fill(readers_finished_.begin(), readers_finished_.end(), false);
   curr_begin_time_ = begin_time_;
   msg_buffer_.clear();
 }
@@ -146,7 +151,19 @@ bool RecordViewer::FillBuffer() {
       this_end_time = end_time_;
     }
 
-    for (auto& reader : readers_) {
+    for (size_t i = 0; i < readers_.size(); ++i) {
+      if (!readers_finished_[i] &&
+          readers_[i]->header().end_time() < this_begin_time) {
+        readers_finished_[i] = true;
+        readers_[i]->Reset();
+      }
+    }
+
+    for (size_t i = 0; i < readers_.size(); ++i) {
+      if (readers_finished_[i]) {
+        continue;
+      }
+      auto& reader = readers_[i];
       while (true) {
         auto record_msg = std::make_shared<RecordMessage>();
         if (!reader->ReadMessage(record_msg.get(), this_begin_time,

--- a/cyber/record/record_viewer.h
+++ b/cyber/record/record_viewer.h
@@ -81,15 +81,19 @@ class RecordViewer {
  private:
   friend class Iterator;
 
-  void Sort();
+  void Init();
   void Reset();
   void UpdateTime();
   bool FillBuffer();
 
   uint64_t begin_time_ = 0;
   uint64_t end_time_ = UINT64_MAX;
+  // User defined channels
   std::set<std::string> channels_;
+  // All channel in user defined readers
+  std::set<std::string> channel_list_;
   std::vector<RecordReaderPtr> readers_;
+  std::vector<bool> readers_finished_;
 
   uint64_t curr_begin_time_ = 0;
   std::multimap<uint64_t, std::shared_ptr<RecordMessage>> msg_buffer_;


### PR DESCRIPTION
The current `cyber_recorder play`  will hold all the loaded message in the memory.
It cause memory issue while playing many bags.

Example:
`cyber_recorder play -f /path/to/data//20190304154029.record.0000*`

This commit is aims at fixing this issue:
 - Clear the data of the RecordReader if that file is already finish playing

This fix isn't the best solution (will still having memory issue while reading a single super large data), but it is a usable solution for general case. (A lot of sequential small data)

The below is the memory statistic before this change
![screenshot from 2019-03-05 15-31-07](https://user-images.githubusercontent.com/10594560/53797123-7e569000-3f70-11e9-88a1-7d67566ca9d1.png)


The below is the memory statistic after this change
![screenshot from 2019-03-05 17-52-47](https://user-images.githubusercontent.com/10594560/53797112-78f94580-3f70-11e9-8759-0cca69f9b064.png)

The peak memory have been reduced from 7.x GB to 2.x GB
