### PR TITLE
cyber: use int64_t instead of uint64_t in low-level record API to avo…

### DIFF
--- a/cyber/record/file/record_file_base.cc
+++ b/cyber/record/file/record_file_base.cc
@@ -25,7 +25,7 @@ namespace apollo {
 namespace cyber {
 namespace record {
 
-uint64_t RecordFileBase::CurrentPosition() {
+int64_t RecordFileBase::CurrentPosition() {
   off_t pos = lseek(fd_, 0, SEEK_CUR);
   if (pos < 0) {
     AERROR << "lseek failed, file: " << path_ << ", fd: " << fd_
@@ -35,11 +35,7 @@ uint64_t RecordFileBase::CurrentPosition() {
   return pos;
 }
 
-bool RecordFileBase::SetPosition(uint64_t position) {
-  if (position > INT64_MAX) {
-    AERROR << "position > INT64_MAX";
-    return false;
-  }
+bool RecordFileBase::SetPosition(int64_t position) {
   off_t pos = lseek(fd_, position, SEEK_SET);
   if (pos < 0) {
     AERROR << "lseek failed, file: " << path_ << ", fd: " << fd_

--- a/cyber/record/file/record_file_base.h
+++ b/cyber/record/file/record_file_base.h
@@ -50,8 +50,8 @@ class RecordFileBase {
   std::string GetPath() { return path_; }
   Header GetHeader() { return header_; }
   Index GetIndex() { return index_; }
-  uint64_t CurrentPosition();
-  bool SetPosition(uint64_t position);
+  int64_t CurrentPosition();
+  bool SetPosition(int64_t position);
 
  protected:
   std::mutex mutex_;

--- a/cyber/record/file/record_file_reader.cc
+++ b/cyber/record/file/record_file_reader.cc
@@ -130,10 +130,17 @@ bool RecordFileReader::ReadSection(Section* section) {
   return true;
 }
 
-bool RecordFileReader::SkipSection(uint64_t size) {
-  uint64_t c = CurrentPosition();
-  if (!SetPosition(c + size)) {
-    AERROR << "Skip failed, file: " << path_ << ", skip count: " << size;
+bool RecordFileReader::SkipSection(int64_t size) {
+  int64_t pos = CurrentPosition();
+  if (size > INT64_MAX - pos) {
+    AERROR << "Current position plus skip count is larger than INT64_MAX, "
+           << pos << " + " << size << " > " << INT64_MAX;
+    return false;
+  }
+  if (!SetPosition(pos + size)) {
+    AERROR << "Skip failed, file: " << path_
+           << ", current position: " << pos
+           << "skip count: " << size;
     return false;
   }
   return true;

--- a/cyber/record/file/record_file_reader.h
+++ b/cyber/record/file/record_file_reader.h
@@ -48,9 +48,9 @@ class RecordFileReader : public RecordFileBase {
   void Close() override;
   bool Reset();
   bool ReadSection(Section* section);
-  bool SkipSection(uint64_t size);
+  bool SkipSection(int64_t size);
   template <typename T>
-  bool ReadSection(uint64_t size, T* message);
+  bool ReadSection(int64_t size, T* message);
   bool ReadIndex();
   bool EndOfFile() { return end_of_file_; }
 
@@ -60,12 +60,9 @@ class RecordFileReader : public RecordFileBase {
 };
 
 template <typename T>
-bool RecordFileReader::ReadSection(uint64_t size, T* message) {
-  if (size > INT_MAX) {
-    AERROR << "Size is larger than " << INT_MAX;
-    return false;
-  } else if (size == 0) {
-    AERROR << "Size is zero.";
+bool RecordFileReader::ReadSection(int64_t size, T* message) {
+  if (size < INT_MIN || size > INT_MAX) {
+    AERROR << "Size value greater than the range of int value.";
     return false;
   }
   FileInputStream raw_input(fd_, static_cast<int>(size));

--- a/cyber/record/file/record_file_writer.h
+++ b/cyber/record/file/record_file_writer.h
@@ -120,10 +120,10 @@ bool RecordFileWriter::WriteSection(const T& message) {
   } else if (std::is_same<T, Index>::value) {
     type = SectionType::SECTION_INDEX;
   } else {
-    AERROR << "Do not support is template typename.";
+    AERROR << "Do not support this template typename.";
     return false;
   }
-  Section section = {type, (uint64_t)message.ByteSize()};
+  Section section = {type, message.ByteSize()};
   ssize_t count = write(fd_, &section, sizeof(section));
   if (count < 0) {
     AERROR << "Write fd failed, fd: " << fd_ << ", errno: " << errno;

--- a/cyber/record/file/section.h
+++ b/cyber/record/file/section.h
@@ -23,7 +23,7 @@ namespace record {
 
 struct Section {
   SectionType type;
-  uint64_t size;
+  int64_t size;
 };
 
 }  // namespace record


### PR DESCRIPTION
…id type conversion.