### PR TITLE
fix coverage error: can't find .gcno files

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -417,21 +417,18 @@ function gen_coverage() {
 
   COV_DIR=data/cov
   rm -rf $COV_DIR
-  files=$(find bazel-out/local-dbg/bin/modules/ -iname "*.gcda" -o -iname "*.gcno" | grep -v external)
+  files=$(find bazel-out/local-dbg/bin/ -iname "*.gcda" -o -iname "*.gcno" | grep -v external | grep -v third_party)
   for f in $files; do
-    target="$COV_DIR/objs/modules/${f##*modules}"
+    if [ "$f" != "${f##*cyber}" ]; then
+      target="$COV_DIR/objs/cyber${f##*cyber}"
+    else
+      target="$COV_DIR/objs/modules${f##*modules}"
+    fi
     mkdir -p "$(dirname "$target")"
     cp "$f" "$target"
   done
 
-  files=$(find bazel-out/local-opt/bin/modules/ -iname "*.gcda" -o -iname "*.gcno" | grep -v external)
-  for f in $files; do
-    target="$COV_DIR/objs/modules/${f##*modules}"
-    mkdir -p "$(dirname "$target")"
-    cp "$f" "$target"
-  done
-
-  lcov --rc lcov_branch_coverage=1 --capture --directory "$COV_DIR/objs" --output-file "$COV_DIR/conv.info"
+  lcov --rc lcov_branch_coverage=1 --base-directory "/apollo/bazel-apollo" --capture --directory "$COV_DIR/objs" --output-file "$COV_DIR/conv.info"
   if [ $? -ne 0 ]; then
     fail 'lcov failed!'
   fi


### PR DESCRIPTION
Also:
**The reason why the coverage is inaccurate:**
target="$COV_DIR/objs/modules${f##*modules}"
Because the directory of target is cut, many different ".gcda" files are copied to the same one through {cp "$f" "$target"}.
**Solution**
We can merge multiple .gcda files into a single .gcda using gcov-tool which is available Since Ubuntu 16.04. I will try to fix the inaccurate issue after the OS is upgraded.