### PR TITLE
framework: enable black channels for cyber_recorder play mode 

### DIFF
--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -400,7 +400,8 @@ int main(int argc, char** argv) {
     play_param.delay_time_s = opt_delay;
     play_param.preload_time_s = opt_preload;
     play_param.files_to_play.insert(opt_file_vec.begin(), opt_file_vec.end());
-    play_param.black_channels.insert(opt_black_channels.begin(), opt_black_channels.end());
+    play_param.black_channels.insert(opt_black_channels.begin(), 
+                                     opt_black_channels.end());
     play_param.channels_to_play.insert(opt_white_channels.begin(),
                                        opt_white_channels.end());
     Player player(play_param);

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -43,7 +43,7 @@ using apollo::cyber::record::Spliter;
 
 const char INFO_OPTIONS[] = "h";
 const char RECORD_OPTIONS[] = "o:ac:i:m:h";
-const char PLAY_OPTIONS[] = "f:c:lr:b:e:s:d:p:h";
+const char PLAY_OPTIONS[] = "f:ac:k:lr:b:e:s:d:p:h";
 const char SPLIT_OPTIONS[] = "f:o:c:k:b:e:h";
 const char RECOVER_OPTIONS[] = "f:o:h";
 

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -391,7 +391,7 @@ int main(int argc, char** argv) {
     ::apollo::cyber::Init(argv[0]);
     bool play_result = true;
     PlayParam play_param;
-    play_param.is_play_all_channels = opt_all ? 
+    play_param.is_play_all_channels = opt_all ?
                                       opt_all : opt_white_channels.empty();
     play_param.is_loop_playback = opt_loop;
     play_param.play_rate = opt_rate;

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -391,7 +391,8 @@ int main(int argc, char** argv) {
     ::apollo::cyber::Init(argv[0]);
     bool play_result = true;
     PlayParam play_param;
-    play_param.is_play_all_channels = opt_white_channels.empty();
+    play_param.is_play_all_channels = opt_all ? 
+                                      opt_all : opt_white_channels.empty();
     play_param.is_loop_playback = opt_loop;
     play_param.play_rate = opt_rate;
     play_param.begin_time_ns = opt_begin;
@@ -400,7 +401,7 @@ int main(int argc, char** argv) {
     play_param.delay_time_s = opt_delay;
     play_param.preload_time_s = opt_preload;
     play_param.files_to_play.insert(opt_file_vec.begin(), opt_file_vec.end());
-    play_param.black_channels.insert(opt_black_channels.begin(), 
+    play_param.black_channels.insert(opt_black_channels.begin(),
                                      opt_black_channels.end());
     play_param.channels_to_play.insert(opt_white_channels.begin(),
                                        opt_white_channels.end());

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -400,6 +400,7 @@ int main(int argc, char** argv) {
     play_param.delay_time_s = opt_delay;
     play_param.preload_time_s = opt_preload;
     play_param.files_to_play.insert(opt_file_vec.begin(), opt_file_vec.end());
+    play_param.black_channels.insert(opt_black_channels.begin(), opt_black_channels.end());
     play_param.channels_to_play.insert(opt_white_channels.begin(),
                                        opt_white_channels.end());
     Player player(play_param);

--- a/cyber/tools/cyber_recorder/player/play_param.h
+++ b/cyber/tools/cyber_recorder/player/play_param.h
@@ -36,6 +36,7 @@ struct PlayParam {
   uint32_t preload_time_s = 3;
   std::set<std::string> files_to_play;
   std::set<std::string> channels_to_play;
+  std::set<std::string> black_channels;
 };
 
 }  // namespace record

--- a/cyber/tools/cyber_recorder/player/play_task_producer.cc
+++ b/cyber/tools/cyber_recorder/player/play_task_producer.cc
@@ -120,8 +120,10 @@ bool PlayTaskProducer::ReadRecordInfo() {
     for (auto& item : channel_info) {
       auto& channel_name = item.first;
       auto& msg_type = item.second.message_type();
-      if (play_param_.black_channels.find(channel_name) != 
+      if (play_param_.black_channels.find(channel_name) !=
           play_param_.black_channels.end()) {
+        // minus the black message number from record file header
+        total_msg_num_ -= item.second.message_number();
         continue;
       }
       msg_types_[channel_name] = msg_type;
@@ -208,7 +210,7 @@ bool PlayTaskProducer::CreateWriters() {
 
     if (play_param_.is_play_all_channels ||
         play_param_.channels_to_play.count(channel_name) > 0) {
-      if (play_param_.black_channels.find(channel_name) != 
+      if (play_param_.black_channels.find(channel_name) !=
           play_param_.black_channels.end()) {
         continue;
       }

--- a/cyber/tools/cyber_recorder/player/play_task_producer.cc
+++ b/cyber/tools/cyber_recorder/player/play_task_producer.cc
@@ -120,6 +120,9 @@ bool PlayTaskProducer::ReadRecordInfo() {
     for (auto& item : channel_info) {
       auto& channel_name = item.first;
       auto& msg_type = item.second.message_type();
+      if(play_param_.black_channels.find(channel_name) != play_param_.black_channels.end()) {
+        continue;
+      }
       msg_types_[channel_name] = msg_type;
 
       if (!play_param_.is_play_all_channels &&
@@ -204,6 +207,9 @@ bool PlayTaskProducer::CreateWriters() {
 
     if (play_param_.is_play_all_channels ||
         play_param_.channels_to_play.count(channel_name) > 0) {
+      if(play_param_.black_channels.find(channel_name) != play_param_.black_channels.end()) {
+        continue;
+      }
       proto::RoleAttributes attr;
       attr.set_channel_name(channel_name);
       attr.set_message_type(msg_type);

--- a/cyber/tools/cyber_recorder/player/play_task_producer.cc
+++ b/cyber/tools/cyber_recorder/player/play_task_producer.cc
@@ -120,7 +120,8 @@ bool PlayTaskProducer::ReadRecordInfo() {
     for (auto& item : channel_info) {
       auto& channel_name = item.first;
       auto& msg_type = item.second.message_type();
-      if(play_param_.black_channels.find(channel_name) != play_param_.black_channels.end()) {
+      if (play_param_.black_channels.find(channel_name) != 
+          play_param_.black_channels.end()) {
         continue;
       }
       msg_types_[channel_name] = msg_type;
@@ -207,7 +208,8 @@ bool PlayTaskProducer::CreateWriters() {
 
     if (play_param_.is_play_all_channels ||
         play_param_.channels_to_play.count(channel_name) > 0) {
-      if(play_param_.black_channels.find(channel_name) != play_param_.black_channels.end()) {
+      if (play_param_.black_channels.find(channel_name) != 
+          play_param_.black_channels.end()) {
         continue;
       }
       proto::RoleAttributes attr;


### PR DESCRIPTION
black channels: not play specified channel(s) when play record file .

`-k, --black-channel <name>		not play the specified channel`