### PR TITLE
replace max_x, max_y initializers in modules/common/math/box2d.h. Usi…

### DIFF
--- a/modules/common/math/box2d.h
+++ b/modules/common/math/box2d.h
@@ -270,9 +270,9 @@ class Box2d {
 
   std::vector<Vec2d> corners_;
 
-  double max_x_ = std::numeric_limits<double>::min();
+  double max_x_ = std::numeric_limits<double>::lowest();
   double min_x_ = std::numeric_limits<double>::max();
-  double max_y_ = std::numeric_limits<double>::min();
+  double max_y_ = std::numeric_limits<double>::lowest();
   double min_y_ = std::numeric_limits<double>::max();
 };
 


### PR DESCRIPTION
replace max_x, max_y initializers in modules/common/math/box2d.h. 
Using std::numeric_limits<double>::lowest() instead std::numeric_limits<double>::min() which is positive. Fixes #7317