### PR TITLE
Perception: Publish traffic cone using camera only

### DIFF
--- a/modules/perception/fusion/lib/gatekeeper/pbf_gatekeeper/pbf_gatekeeper.cc
+++ b/modules/perception/fusion/lib/gatekeeper/pbf_gatekeeper/pbf_gatekeeper.cc
@@ -182,10 +182,13 @@ bool PbfGatekeeper::CameraAbleToPublish(const TrackPtr &track, bool is_night) {
     SensorObjectConstPtr camera_object = iter->second;
     double range =
         camera_object->GetBaseObject()->camera_supplement.local_center.norm();
-    if (range >= params_.min_camera_publish_distance ||
-        (camera_object->GetBaseObject()->type ==
-             base::ObjectType::UNKNOWN_UNMOVABLE &&
-         range >= 50)) {
+    // If sub_type of object is traffic cone publish it regardless of range
+    if ((camera_object->GetBaseObject()->sub_type ==
+             base::ObjectSubType::TRAFFICCONE) ||
+        (range >= params_.min_camera_publish_distance ||
+          ((camera_object->GetBaseObject()->type ==
+             base::ObjectType::UNKNOWN_UNMOVABLE) &&
+           (range >= params_.min_camera_publish_distance)))) {
       double exist_prob = track->GetExistanceProb();
       if (exist_prob > params_.existance_threshold) {
         static int cnt_cam = 1;


### PR DESCRIPTION
Traffic cone was not published since any camera object within 50 meters was discarded. Since the camera is the best way to detect a traffic cone, I removed 50 meter condition for publishing a traffic cone.