### PR TITLE
DOC: Corrected link for Python License example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ For each new file, please include a license at the top of the file.
 
 * C++ code License example [util.h](modules/common/util/util.h);
 
-* Python code License example [process.py](modules/tools/calibration/process.py);
+* Python code License example [process.py](modules/tools/vehicle_calibration/process.py);
 
 * Bash code License example [apollo_base.sh](scripts/apollo_base.sh);
 


### PR DESCRIPTION
Corrected link for Python License example in CONTRIBUTING.md