### PR TITLE
framework:fixed TypeError: signal_handler()

### DIFF
--- a/cyber/tools/cyber_launch/cyber_launch
+++ b/cyber/tools/cyber_launch/cyber_launch
@@ -470,7 +470,7 @@ def stop_launch(launch_file):
     sys.exit(0)
 
 
-def signal_handler(sig):
+def signal_handler(sig, frame):
     logger.info('Keyboard interrupt received. Stop all processes.')
     stop(sig)
 


### PR DESCRIPTION
fix traceback when run `cyber_launch start some_launch file` signal Keyboard interrupt :


```
Traceback (most recent call last):
  File "/apollo/cyber/tools/cyber_launch/cyber_launch", line 521, in <module>
    main()
  File "/apollo/cyber/tools/cyber_launch/cyber_launch", line 508, in main
    start(params.file)
  File "/apollo/cyber/tools/cyber_launch/cyber_launch", line 438, in start
    all_died = pmon.run()
  File "/apollo/cyber/tools/cyber_launch/cyber_launch", line 280, in run
    time.sleep(0.2)
TypeError: signal_handler() takes exactly 1 argument (2 given)
```