### PR TITLE
use a variable to store result of formula to avoid calculating repeatedly

### DIFF
--- a/modules/control/controller/lat_controller.h
+++ b/modules/control/controller/lat_controller.h
@@ -151,7 +151,7 @@ class LatController : public Controller {
   // the maximum turn of steer
   double steer_single_direction_max_degree_ = 0.0;
 
-  //calculation result for steer_ration & steer direction
+  // calculation result for steer_ration & steer direction
   double steer_ratio_direction_calc = 0.0;
 
   // limit steering to maximum theoretical lateral acceleration

--- a/modules/control/controller/lat_controller.h
+++ b/modules/control/controller/lat_controller.h
@@ -151,6 +151,9 @@ class LatController : public Controller {
   // the maximum turn of steer
   double steer_single_direction_max_degree_ = 0.0;
 
+  //calculation result for steer_ration & steer direction
+  double steer_ratio_direction_calc = 0.0;
+
   // limit steering to maximum theoretical lateral acceleration
   double max_lat_acc_ = 0.0;
 


### PR DESCRIPTION
Control module updates in a very high rate. A formula is calculated in every frame, whose variables are never changed. 
So, use a variable to store the result of this formula.
After testing on TX2, this could reduce the CPU usage of Control by 3%-5%.