### PR TITLE
add cpu binding module for monitoring CPU usage more conveniently

### DIFF
--- a/modules/common/configs/BUILD
+++ b/modules/common/configs/BUILD
@@ -38,6 +38,21 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "cpu_bind_helper",
+    srcs = [
+        "cpu_bind_helper.cc",
+    ],
+    hdrs = [
+        "cpu_bind_helper.h",
+    ],
+    deps = [
+        ":config_gflags",
+        "//modules/common",
+        "@yaml_cpp//:yaml",
+    ],
+)
+
 cc_test(
     name = "vehicle_config_helper_test",
     size = "small",
@@ -46,6 +61,18 @@ cc_test(
     ],
     deps = [
         "vehicle_config_helper",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "cpu_bind_helper_test",
+    size = "small",
+    srcs = [
+        "cpu_bind_helper_test.cc",
+    ],
+    deps = [
+        "cpu_bind_helper",
         "@gtest//:main",
     ],
 )

--- a/modules/common/configs/config_gflags.cc
+++ b/modules/common/configs/config_gflags.cc
@@ -37,6 +37,9 @@ DEFINE_string(speed_control_filename, "speed_control.pb.txt",
 DEFINE_string(vehicle_config_path, "modules/common/data/mkz_config.pb.txt",
               "the file path of vehicle config file");
 
+DEFINE_string(cpubind_config_path, "modules/common/data/cpu_bind.yaml",
+              "the file path of cpu bind config file");
+
 DEFINE_bool(use_ros_time, false,
             "Whether Clock::Now() gets time from system_clock::now() or from "
             "ros::Time::now().");

--- a/modules/common/configs/config_gflags.h
+++ b/modules/common/configs/config_gflags.h
@@ -34,6 +34,7 @@ DECLARE_string(speed_control_filename);
 DECLARE_double(look_forward_time_sec);
 
 DECLARE_string(vehicle_config_path);
+DECLARE_string(cpubind_config_path);
 
 DECLARE_bool(use_ros_time);
 

--- a/modules/common/configs/cpu_bind_helper.cc
+++ b/modules/common/configs/cpu_bind_helper.cc
@@ -14,12 +14,13 @@
  * limitations under the License.
  *****************************************************************************/
 
- 
 #include "modules/common/configs/cpu_bind_helper.h"
 
-#include <unistd.h>
 #include <sched.h>
+#include <unistd.h>
+
 #include <fstream>
+#include <utility>
 
 #include "modules/common/configs/config_gflags.h"
 #include "yaml-cpp/yaml.h"
@@ -53,7 +54,7 @@ void CpuBindHelper::Init(const std::string &config_file) {
 
 void CpuBindHelper::BindCpu(const std::string& module_name) {
   if (!init_) {
-    Init(FLAGS_cpubind_config_path); 
+    Init(FLAGS_cpubind_config_path);
   }
 
   if (bindrule_map_.find(module_name) != bindrule_map_.end()) {
@@ -64,7 +65,7 @@ void CpuBindHelper::BindCpu(const std::string& module_name) {
     for (const auto& elem : core_list) {
       CPU_SET(elem, &mask);
     }
-    
+
     sched_setaffinity(0, sizeof(mask), &mask);
   }
 }

--- a/modules/common/configs/cpu_bind_helper.cc
+++ b/modules/common/configs/cpu_bind_helper.cc
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+ 
+#include "modules/common/configs/cpu_bind_helper.h"
+
+#include <unistd.h>
+#include <sched.h>
+#include <fstream>
+
+#include "modules/common/configs/config_gflags.h"
+#include "yaml-cpp/yaml.h"
+
+namespace apollo {
+namespace common {
+
+CpuBindHelper::CpuBindHelper() {
+}
+
+void CpuBindHelper::Init(const std::string &config_file) {
+  init_ = true;
+  YAML::Node root_node = YAML::LoadFile(config_file);
+  if (root_node["cpubind"]) {
+    const auto& rule_node = root_node["cpubind"];
+    std::size_t rule_size = rule_node.size();
+    for (std::size_t i = 0; i < rule_size; ++i) {
+      const auto& module_node = rule_node[i];
+      const std::string module_name = module_node["module"].as<std::string>();
+      const std::size_t core_size = module_node["cores"].size();
+      std::vector<int> core_list(core_size);
+      core_list.resize(core_size);
+      for (std::size_t j = 0; j < core_size; ++j) {
+        core_list[j] = module_node["cores"][j].as<int>();
+      }
+
+      bindrule_map_.emplace(module_name, std::move(core_list));
+    }
+  }
+}
+
+void CpuBindHelper::BindCpu(const std::string& module_name) {
+  if (!init_) {
+    Init(FLAGS_cpubind_config_path); 
+  }
+
+  if (bindrule_map_.find(module_name) != bindrule_map_.end()) {
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+
+    const std::vector<int>& core_list = bindrule_map_.at(module_name);
+    for (const auto& elem : core_list) {
+      CPU_SET(elem, &mask);
+    }
+    
+    sched_setaffinity(0, sizeof(mask), &mask);
+  }
+}
+
+}  // namespace common
+}  // namespace apollo
+
+

--- a/modules/common/configs/cpu_bind_helper.cc
+++ b/modules/common/configs/cpu_bind_helper.cc
@@ -42,7 +42,6 @@ void CpuBindHelper::Init(const std::string &config_file) {
       const std::string module_name = module_node["module"].as<std::string>();
       const std::size_t core_size = module_node["cores"].size();
       std::vector<int> core_list(core_size);
-      core_list.resize(core_size);
       for (std::size_t j = 0; j < core_size; ++j) {
         core_list[j] = module_node["cores"][j].as<int>();
       }

--- a/modules/common/configs/cpu_bind_helper.h
+++ b/modules/common/configs/cpu_bind_helper.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+/**
+ * @file
+ */
+
+#ifndef MODULES_CONFIGS_CPU_BIND_H_
+#define MODULES_CONFIGS_CPU_BIND_H_
+
+#include <string.h>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest_prod.h"
+
+#include "modules/common/macro.h"
+
+/**
+ * @namespace apollo::common
+ * @brief apollo::common
+ */
+namespace apollo {
+namespace common {
+
+/**
+ * @class CpuBindHelper
+ *
+ * @Brief This is a helper class that helps bind a specified process on a cpu core.
+ * The binding rules are defined in modules/common/data/cpu_set.json
+ */
+class CpuBindHelper {
+public:
+  /**
+   * @brief Load the content of the binding rules file into memory.
+   * Then, process function can call BindCpu function to bind cpu with
+   * the processname as the parameter.
+   */
+  void Init(const std::string &config_file);
+
+  /**
+   * @brief Given the process name, and bind current process on the reserved cpu.
+   * If the given process name can not be found, then nothing will happen,
+   * so changing the process name to another in configuration file is a 
+   * easy way to cancel binding for a process.
+   */
+  void BindCpu(const std::string& module_name);
+
+private:
+  std::unordered_map<std::string, std::vector<int>> bindrule_map_;
+  bool init_ = false;
+
+  FRIEND_TEST(CpuBindHelperTest, Init_BindCpu);
+
+  DECLARE_SINGLETON(CpuBindHelper);
+};
+
+}  // namespace common
+}  // namespace apollo
+
+#endif  // MODULES_CONFIGS_CPU_BIND_H_
+
+

--- a/modules/common/configs/cpu_bind_helper.h
+++ b/modules/common/configs/cpu_bind_helper.h
@@ -21,7 +21,7 @@
 #ifndef MODULES_CONFIGS_CPU_BIND_H_
 #define MODULES_CONFIGS_CPU_BIND_H_
 
-#include <string.h>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -43,7 +43,7 @@ namespace common {
  * The binding rules are defined in modules/common/data/cpu_set.json
  */
 class CpuBindHelper {
-public:
+ public:
   /**
    * @brief Load the content of the binding rules file into memory.
    * Then, process function can call BindCpu function to bind cpu with
@@ -59,7 +59,7 @@ public:
    */
   void BindCpu(const std::string& module_name);
 
-private:
+ private:
   std::unordered_map<std::string, std::vector<int>> bindrule_map_;
   bool init_ = false;
 

--- a/modules/common/configs/cpu_bind_helper_test.cc
+++ b/modules/common/configs/cpu_bind_helper_test.cc
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/common/configs/cpu_bind_helper.h"
+
+#include <cmath>
+#include <string>
+
+#include <unistd.h>
+#include <sched.h>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace common {
+
+class CpuBindHelperTest : public ::testing::Test {
+ public:
+  void SetUp() {
+    //
+  }
+};
+
+TEST_F(CpuBindHelperTest, Init_BindCpu) {
+  CpuBindHelper::instance()->Init("/apollo/modules/common/data/cpu_bind.yaml");
+  CpuBindHelper::instance()->BindCpu("cpu_bind_helper_test");
+
+  const std::unordered_map<std::string, std::vector<int>>::const_iterator it =
+      CpuBindHelper::instance()->bindrule_map_.find("cpu_bind_helper_test");
+  EXPECT_NE(it, CpuBindHelper::instance()->bindrule_map_.end());
+
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  int ret = sched_getaffinity(0, sizeof(cpuset), &cpuset);
+  EXPECT_EQ(0, ret);
+  const int core_array[] = {0, 2, 3};
+  const std::size_t size = sizeof(core_array) / sizeof(int);
+  for (std::size_t i = 0; i < size; ++i) {
+    EXPECT_TRUE(CPU_ISSET(core_array[i], &cpuset));
+  }
+}
+
+}  // namespace common
+}  // namespace apollo

--- a/modules/common/configs/cpu_bind_helper_test.cc
+++ b/modules/common/configs/cpu_bind_helper_test.cc
@@ -16,11 +16,11 @@
 
 #include "modules/common/configs/cpu_bind_helper.h"
 
+#include <sched.h>
+#include <unistd.h>
+
 #include <cmath>
 #include <string>
-
-#include <unistd.h>
-#include <sched.h>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/modules/common/data/cpu_bind.yaml
+++ b/modules/common/data/cpu_bind.yaml
@@ -1,0 +1,7 @@
+cpubind:
+  - module: dreamview
+    cores: [1]
+  - module: perception
+    cores: [2]
+  - module: cpu_bind_helper_test
+    cores: [0, 2, 3]

--- a/modules/dreamview/backend/BUILD
+++ b/modules/dreamview/backend/BUILD
@@ -21,7 +21,12 @@ cc_library(
         "//modules/dreamview/backend/simulation_world:simulation_world_updater",
         "//modules/map/hdmap:hdmap_util",
         "@civetweb//:civetweb++",
-    ],
+    ] + select({
+        "//tools/platforms:aarch64": [
+            "//modules/common/configs:cpu_bind_helper",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cpplint()

--- a/modules/dreamview/backend/dreamview.cc
+++ b/modules/dreamview/backend/dreamview.cc
@@ -27,6 +27,10 @@
 
 #include "modules/dreamview/backend/common/dreamview_gflags.h"
 
+#ifdef __aarch64__
+#include "modules/common/configs/cpu_bind_helper.h"
+#endif
+
 namespace apollo {
 namespace dreamview {
 
@@ -79,6 +83,10 @@ void Dreamview::CheckAdapters() {
 }
 
 Status Dreamview::Init() {
+#ifdef __aarch64__
+  apollo::common::CpuBindHelper::instance()->BindCpu(Name());
+#endif
+
   AdapterManager::Init(FLAGS_dreamview_adapter_config_filename);
   VehicleConfigHelper::Init();
 

--- a/modules/perception/BUILD
+++ b/modules/perception/BUILD
@@ -29,7 +29,12 @@ cc_library(
         "//modules/perception/traffic_light/onboard",
         "@com_google_protobuf//:protobuf",
         "@ros//:ros_common",
-    ],
+    ]  + select({
+        "//tools/platforms:aarch64": [
+            "//modules/common/configs:cpu_bind_helper",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_binary(

--- a/modules/perception/perception.cc
+++ b/modules/perception/perception.cc
@@ -40,6 +40,10 @@
 #include "modules/perception/traffic_light/onboard/tl_preprocessor_subnode.h"
 #include "modules/perception/traffic_light/onboard/tl_proc_subnode.h"
 
+#ifdef __aarch64__
+#include "modules/common/configs/cpu_bind_helper.h"
+#endif
+
 namespace apollo {
 namespace perception {
 
@@ -50,6 +54,10 @@ using apollo::common::ErrorCode;
 std::string Perception::Name() const { return "perception"; }
 
 Status Perception::Init() {
+#ifdef __aarch64__
+  apollo::common::CpuBindHelper::instance()->BindCpu(Name());
+#endif
+
   AdapterManager::Init(FLAGS_perception_adapter_config_filename);
 
   RegistAllOnboardClass();


### PR DESCRIPTION
This feature aims to monitor CPU usage of processes. 
Generally, It brings two benefits:
1. for a certain process and its threads, reduce the possibility of jumping between different cores
2. reduce the consumption of accessing memory and maintaining cache coherence when a process or thread switch cores

Trying to merge to v3.1_dev