### PR TITLE
Add coolhigh canbus code which is cherry-picked from branch v3.1_dev

### DIFF
--- a/modules/canbus/proto/BUILD
+++ b/modules/canbus/proto/BUILD
@@ -13,6 +13,7 @@ proto_library(
         "canbus_conf.proto",
         "chassis.proto",
         "chassis_detail.proto",
+        "ch.proto",
         "vehicle_parameter.proto",
     ],
     deps = [

--- a/modules/canbus/proto/ch.proto
+++ b/modules/canbus/proto/ch.proto
@@ -1,0 +1,199 @@
+syntax = "proto2";
+
+package apollo.canbus;
+
+// Coolhigh vehicle starts from here
+message Control_command_115 {
+// Control Message
+  enum Ctrl_cmdType {
+    CTRL_CMD_OUT_OF_CONTROL = 0;
+    CTRL_CMD_UNDER_CONTROL = 1;
+  }
+  // Take control(Command) [] [0|1]
+  optional Ctrl_cmdType ctrl_cmd = 1;
+}
+
+message Gear_command_114 {
+// Control Message
+  enum Gear_cmdType {
+    GEAR_CMD_PARK = 1;
+    GEAR_CMD_REVERSE = 2;
+    GEAR_CMD_NEUTRAL = 3;
+    GEAR_CMD_DRIVE = 4;
+  }
+  // PRND control(Command) [] [0|3]
+  optional Gear_cmdType gear_cmd = 1;
+}
+
+message Brake_command_111 {
+// Control Message
+  enum Brake_pedal_en_ctrlType {
+    BRAKE_PEDAL_EN_CTRL_DISABLE = 0;
+    BRAKE_PEDAL_EN_CTRL_ENABLE = 1;
+  }
+  // brake pedal enable bit(Command) [] [0|1]
+  optional Brake_pedal_en_ctrlType brake_pedal_en_ctrl = 1;
+  // Percentage of brake pedal(Command) [%] [0|100]
+  optional int32 brake_pedal_cmd = 2;
+}
+
+message Throttle_command_110 {
+// Control Message
+  enum Throttle_pedal_en_ctrlType {
+    THROTTLE_PEDAL_EN_CTRL_DISABLE = 0;
+    THROTTLE_PEDAL_EN_CTRL_ENABLE = 1;
+  }
+  // throttle pedal enable bit(Command) [] [0|1]
+  optional Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl = 1;
+  // Percentage of throttle pedal(Command) [%] [0|100]
+  optional int32 throttle_pedal_cmd = 2;
+}
+
+message Turnsignal_command_113 {
+// Control Message
+  enum Turn_signal_cmdType {
+    TURN_SIGNAL_CMD_NONE = 0;
+    TURN_SIGNAL_CMD_LEFT = 1;
+    TURN_SIGNAL_CMD_RIGHT = 2;
+  }
+  // Lighting control(Command) [] [0|2]
+  optional Turn_signal_cmdType turn_signal_cmd = 1;
+}
+
+message Steer_command_112 {
+// Control Message
+  enum Steer_angle_en_ctrlType {
+    STEER_ANGLE_EN_CTRL_DISABLE = 0;
+    STEER_ANGLE_EN_CTRL_ENABLE = 1;
+  }
+  // steering angle enable bit(Command) [] [0|1]
+  optional Steer_angle_en_ctrlType steer_angle_en_ctrl = 1;
+  // Current steering angle(Command) [radian] [-0.524|0.524]
+  optional double steer_angle_cmd = 2;
+}
+
+message Brake_status__511 {
+// Report Message
+  enum Brake_pedal_en_stsType {
+    BRAKE_PEDAL_EN_STS_DISABLE = 0;
+    BRAKE_PEDAL_EN_STS_ENABLE = 1;
+  }
+  // brake pedal enable bit(Status) [] [0|1]
+  optional Brake_pedal_en_stsType brake_pedal_en_sts = 1;
+  // Percentage of brake pedal(Status) [%] [0|100]
+  optional int32 brake_pedal_sts = 2;
+}
+
+message Throttle_status__510 {
+// Report Message
+  enum Throttle_pedal_en_stsType {
+    THROTTLE_PEDAL_EN_STS_DISABLE = 0;
+    THROTTLE_PEDAL_EN_STS_ENABLE = 1;
+  }
+  // throttle pedal enable bit(Status) [] [0|1]
+  optional Throttle_pedal_en_stsType throttle_pedal_en_sts = 1;
+  // Percentage of throttle pedal(Status) [%] [0|100]
+  optional int32 throttle_pedal_sts = 2;
+}
+
+message Turnsignal_status__513 {
+// Report Message
+  enum Turn_signal_stsType {
+    TURN_SIGNAL_STS_NONE = 0;
+    TURN_SIGNAL_STS_LEFT = 1;
+    TURN_SIGNAL_STS_RIGHT = 2;
+  }
+  // Lighting control(Status) [] [0|2]
+  optional Turn_signal_stsType turn_signal_sts = 1;
+}
+
+message Steer_status__512 {
+// Report Message
+  enum Steer_angle_en_stsType {
+    STEER_ANGLE_EN_STS_DISABLE = 0;
+    STEER_ANGLE_EN_STS_ENABLE = 1;
+  }
+  // steering angle enable bit(Status) [] [0|1]
+  optional Steer_angle_en_stsType steer_angle_en_sts = 1;
+  // Current steering angle(Status) [radian] [-0.524|0.524]
+  optional double steer_angle_sts = 2;
+}
+
+message Ecu_status_1_515 {
+// Report Message
+  enum Ctrl_stsType {
+    CTRL_STS_OUT_OF_CONTROL = 0;
+    CTRL_STS_UNDER_CONTROL = 1;
+  }
+  // Current speed (Steering status) [m/s] [0|0]
+  optional double speed = 1;
+  // Current acceleration (Steering status) [m/s^2] [0|0]
+  optional double acc_speed = 2;
+  // Current Auto-mode state (Chassis status) [] [0|1]
+  optional Ctrl_stsType ctrl_sts = 3;
+  // Current chassis state (Chassis status) [] [0|255]
+  optional int32 chassis_sts = 4;
+  // Chassis error code (Chassis status) [] [0|65535]
+  optional int32 chassis_err = 5;
+}
+
+message Gear_status_514 {
+// Report Message
+  enum Gear_stsType {
+    GEAR_STS_PARK = 1;
+    GEAR_STS_REVERSE = 2;
+    GEAR_STS_NEUTRAL = 3;
+    GEAR_STS_DRIVE = 4;
+  }
+  // PRND control(Status) [] [0|3]
+  optional Gear_stsType gear_sts = 1;
+}
+
+message Ecu_status_3_517 {
+// Report Message
+  // Ultrasonic detection distance 1 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_1 = 1;
+  // Ultrasonic detection distance 2 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_2 = 2;
+  // Ultrasonic detection distance 3 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_3 = 3;
+  // Ultrasonic detection distance 4 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_4 = 4;
+  // Ultrasonic detection distance 5 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_5 = 5;
+  // Ultrasonic detection distance 6 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_6 = 6;
+  // Ultrasonic detection distance 7 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_7 = 7;
+  // Ultrasonic detection distance 8 (Ultrasound status) [cm] [0|0]
+  optional int32 ultrasound_dist_8 = 8;
+}
+
+message Ecu_status_2_516 {
+// Report Message
+  // Percentage of battery remaining (BMS status) [%] [0|0]
+  optional int32 battery_remaining_capacity = 1;
+  // Current battery voltage (BMS status) [V] [0|0]
+  optional double battery_voltage = 2;
+  // Current battery current (BMS status) [A] [0|0]
+  optional double battery_current = 3;
+  // Current battery temperature (BMS status) [?] [0|0]
+  optional int32 battery_temperature = 4;
+}
+
+message Ch {
+  optional Control_command_115 control_command_115 = 1; // control message
+  optional Gear_command_114 gear_command_114 = 2; // control message
+  optional Brake_command_111 brake_command_111 = 3; // control message
+  optional Throttle_command_110 throttle_command_110 = 4; // control message
+  optional Turnsignal_command_113 turnsignal_command_113 = 5; // control message
+  optional Steer_command_112 steer_command_112 = 6; // control message
+  optional Brake_status__511 brake_status__511 = 7; // report message
+  optional Throttle_status__510 throttle_status__510 = 8; // report message
+  optional Turnsignal_status__513 turnsignal_status__513 = 9; // report message
+  optional Steer_status__512 steer_status__512 = 10; // report message
+  optional Ecu_status_1_515 ecu_status_1_515 = 11; // report message
+  optional Gear_status_514 gear_status_514 = 12; // report message
+  optional Ecu_status_3_517 ecu_status_3_517 = 13; // report message
+  optional Ecu_status_2_516 ecu_status_2_516 = 14; // report message
+}

--- a/modules/canbus/proto/chassis_detail.proto
+++ b/modules/canbus/proto/chassis_detail.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 package apollo.canbus;
 
 import "modules/canbus/proto/chassis.proto";
+import "modules/canbus/proto/ch.proto";
 
 message ChassisDetail {
   enum Type {
@@ -27,6 +28,7 @@ message ChassisDetail {
   optional License license = 16;            // License info
   optional Surround surround = 17;          // Surround information
   optional Gem gem = 18;
+  optional Ch ch = 19;       // vehicle
 }
 
 // CheckResponseSignal

--- a/modules/canbus/proto/vehicle_parameter.proto
+++ b/modules/canbus/proto/vehicle_parameter.proto
@@ -8,6 +8,7 @@ message VehicleParameter {
   enum VehicleBrand {
     LINCOLN_MKZ = 0;
     GEM = 1;
+    CH = 2;
   }
 
   optional VehicleBrand brand = 1;

--- a/modules/canbus/testdata/conf/ch_canbus_conf_test.pb.txt
+++ b/modules/canbus/testdata/conf/ch_canbus_conf_test.pb.txt
@@ -1,0 +1,13 @@
+vehicle_parameter {
+  brand: CH
+  max_enable_fail_attempt: 5
+  driving_mode: COMPLETE_AUTO_DRIVE
+}
+
+can_card_parameter {
+  brand:ESD_CAN
+  type: PCI_CARD
+  channel_id: CHANNEL_ID_ZERO
+}
+
+enable_debug_mode: false

--- a/modules/canbus/vehicle/BUILD
+++ b/modules/canbus/vehicle/BUILD
@@ -47,6 +47,7 @@ cc_library(
     deps = [
         "//modules/canbus/vehicle/lincoln:lincoln_vehicle_factory",
         "//modules/canbus/vehicle/gem:gem_vehicle_factory",
+	"//modules/canbus/vehicle/ch:ch_vehicle_factory",
         "//modules/common/util:factory",
     ],
 )

--- a/modules/canbus/vehicle/BUILD
+++ b/modules/canbus/vehicle/BUILD
@@ -47,7 +47,7 @@ cc_library(
     deps = [
         "//modules/canbus/vehicle/lincoln:lincoln_vehicle_factory",
         "//modules/canbus/vehicle/gem:gem_vehicle_factory",
-	"//modules/canbus/vehicle/ch:ch_vehicle_factory",
+        "//modules/canbus/vehicle/ch:ch_vehicle_factory",
         "//modules/common/util:factory",
     ],
 )

--- a/modules/canbus/vehicle/ch/BUILD
+++ b/modules/canbus/vehicle/ch/BUILD
@@ -1,0 +1,90 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "ch_vehicle_factory",
+    srcs = [
+        "ch_vehicle_factory.cc",
+    ],
+    hdrs = [
+        "ch_vehicle_factory.h",
+    ],
+    deps = [
+        ":ch_controller",
+        ":ch_message_manager",
+        "//modules/canbus/vehicle:abstract_vehicle_factory",
+    ],
+)
+
+cc_library(
+    name = "ch_message_manager",
+    srcs = [
+        "ch_message_manager.cc",
+    ],
+    hdrs = [
+        "ch_message_manager.h",
+    ],
+    deps = [
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+    ],
+)
+
+cc_library(
+    name = "ch_controller",
+    srcs = [
+        "ch_controller.cc",
+    ],
+    hdrs = [
+        "ch_controller.h",
+    ],
+    deps = [
+        ":ch_message_manager",
+        "//modules/drivers/canbus/can_comm:can_sender",
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle:vehicle_controller_base",
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+    ],
+)
+
+cc_test(
+    name = "ch_controller_test",
+    size = "small",
+    srcs = [
+        "ch_controller_test.cc",
+    ],
+    data = ["//modules/canbus:canbus_testdata"],
+    deps = [
+        ":ch_controller",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ch_message_manager_test",
+    size = "small",
+    srcs = [
+        "ch_message_manager_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch:ch_message_manager",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
+    name = "ch_vehicle_factory_test",
+    size = "small",
+    srcs = ["ch_vehicle_factory_test.cc"],
+    deps = [
+        ":ch_vehicle_factory",
+        "@gtest//:main",
+    ],
+)
+
+cpplint()

--- a/modules/canbus/vehicle/ch/ch_controller.cc
+++ b/modules/canbus/vehicle/ch/ch_controller.cc
@@ -1,0 +1,582 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "modules/canbus/vehicle/ch/ch_controller.h"
+#include "modules/common/proto/vehicle_signal.pb.h"
+#include "modules/canbus/vehicle/ch/ch_message_manager.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/common/log.h"
+#include "modules/common/time/time.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+using ::apollo::common::ErrorCode;
+using ::apollo::control::ControlCommand;
+using ::apollo::drivers::canbus::ProtocolData;
+
+namespace {
+const int32_t kMaxFailAttempt = 10;
+const int32_t CHECK_RESPONSE_STEER_UNIT_FLAG = 1;
+const int32_t CHECK_RESPONSE_SPEED_UNIT_FLAG = 2;
+}  // namespace
+
+ErrorCode ChController::Init(
+    const VehicleParameter& params,
+    CanSender<::apollo::canbus::ChassisDetail>* const can_sender,
+    MessageManager<::apollo::canbus::ChassisDetail>* const message_manager) {
+  if (is_initialized_) {
+    AINFO << "ChController has already been initiated.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  vehicle_params_.CopyFrom(
+      common::VehicleConfigHelper::instance()->GetConfig().vehicle_param());
+  params_.CopyFrom(params);
+  if (!params_.has_driving_mode()) {
+    AERROR << "Vehicle conf pb not set driving_mode.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  if (can_sender == nullptr) {
+    return ErrorCode::CANBUS_ERROR;
+  }
+  can_sender_ = can_sender;
+
+  if (message_manager == nullptr) {
+    AERROR << "protocol manager is null.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+  message_manager_ = message_manager;
+
+  // sender part
+  brake_command_111_ = dynamic_cast<Brakecommand111*>(
+      message_manager_->GetMutableProtocolDataById(Brakecommand111::ID));
+  if (brake_command_111_ == nullptr) {
+    AERROR << "Brakecommand111 does not exist in the ChMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  gear_command_114_ = dynamic_cast<Gearcommand114*>(
+      message_manager_->GetMutableProtocolDataById(Gearcommand114::ID));
+  if (gear_command_114_ == nullptr) {
+    AERROR << "Gearcommand114 does not exist in the ChMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  steer_command_112_ = dynamic_cast<Steercommand112*>(
+      message_manager_->GetMutableProtocolDataById(Steercommand112::ID));
+  if (steer_command_112_ == nullptr) {
+    AERROR << "Steercommand112 does not exist in the ChMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  throttle_command_110_ = dynamic_cast<Throttlecommand110*>(
+      message_manager_->GetMutableProtocolDataById(Throttlecommand110::ID));
+  if (throttle_command_110_ == nullptr) {
+    AERROR << "Throttlecommand110 does not exist in the ChMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  turnsignal_command_113_ = dynamic_cast<Turnsignalcommand113*>(
+      message_manager_->GetMutableProtocolDataById(Turnsignalcommand113::ID));
+  if (turnsignal_command_113_ == nullptr) {
+    AERROR << "Turnsignalcommand113 does not exist in the ChMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  can_sender_->AddMessage(Brakecommand111::ID, brake_command_111_, false);
+  can_sender_->AddMessage(Gearcommand114::ID, gear_command_114_, false);
+  can_sender_->AddMessage(Steercommand112::ID, steer_command_112_, false);
+  can_sender_->AddMessage(Throttlecommand110::ID, throttle_command_110_, false);
+  can_sender_->AddMessage(Turnsignalcommand113::ID, turnsignal_command_113_,
+                          false);
+
+  // need sleep to ensure all messages received
+  AINFO << "ChController is initialized.";
+
+  is_initialized_ = true;
+  return ErrorCode::OK;
+}
+
+ChController::~ChController() {}
+
+bool ChController::Start() {
+  if (!is_initialized_) {
+    AERROR << "ChController has NOT been initiated.";
+    return false;
+  }
+  const auto& update_func = [this] { SecurityDogThreadFunc(); };
+  thread_.reset(new std::thread(update_func));
+
+  return true;
+}
+
+void ChController::Stop() {
+  if (!is_initialized_) {
+    AERROR << "ChController stops or starts improperly!";
+    return;
+  }
+
+  if (thread_ != nullptr && thread_->joinable()) {
+    thread_->join();
+    thread_.reset();
+    AINFO << "ChController stopped.";
+  }
+}
+
+Chassis ChController::chassis() {
+  chassis_.Clear();
+
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+
+  // 21, 22, previously 1, 2
+  if (driving_mode() == Chassis::EMERGENCY_MODE) {
+    set_chassis_error_code(Chassis::NO_ERROR);
+  }
+
+  chassis_.set_driving_mode(driving_mode());
+  chassis_.set_error_code(chassis_error_code());
+
+  // 3
+  chassis_.set_engine_started(true);
+  // 4 engine rpm ch has no engine rpm
+  // chassis_.set_engine_rpm(0);
+  // 5 ch has no wheel spd.
+  if (chassis_detail.ch().has_ecu_status_1_515() &&
+      chassis_detail.ch().ecu_status_1_515().has_speed()) {
+    chassis_.set_speed_mps(chassis_detail.ch().ecu_status_1_515().speed());
+  } else {
+    chassis_.set_speed_mps(0);
+  }
+
+  // 6 ch has no odometer
+  // chassis_.set_odometer_m(0);
+  // 7 ch has no fuel. do not set;
+  // chassis_.set_fuel_range_m(0);
+  // 8 throttle
+  if (chassis_detail.ch().has_throttle_status__510() &&
+      chassis_detail.ch().throttle_status__510().has_throttle_pedal_sts()) {
+    chassis_.set_throttle_percentage(
+        chassis_detail.ch().throttle_status__510().throttle_pedal_sts());
+  } else {
+    chassis_.set_throttle_percentage(0);
+  }
+  // 9 brake
+  if (chassis_detail.ch().has_brake_status__511() &&
+      chassis_detail.ch().brake_status__511().has_brake_pedal_sts()) {
+    chassis_.set_brake_percentage(
+        chassis_detail.ch().brake_status__511().brake_pedal_sts());
+  } else {
+    chassis_.set_brake_percentage(0);
+  }
+
+  // 23, previously 10   gear
+  if (chassis_detail.ch().has_gear_status_514() &&
+      chassis_detail.ch().gear_status_514().has_gear_sts()) {
+    Chassis::GearPosition gear_pos = Chassis::GEAR_INVALID;
+
+    if (chassis_detail.ch().gear_status_514().gear_sts() ==
+        Gear_status_514::GEAR_STS_NEUTRAL) {
+      gear_pos = Chassis::GEAR_NEUTRAL;
+    }
+    if (chassis_detail.ch().gear_status_514().gear_sts() ==
+        Gear_status_514::GEAR_STS_REVERSE) {
+      gear_pos = Chassis::GEAR_REVERSE;
+    }
+    if (chassis_detail.ch().gear_status_514().gear_sts() ==
+        Gear_status_514::GEAR_STS_DRIVE) {
+      gear_pos = Chassis::GEAR_DRIVE;
+    }
+    if (chassis_detail.ch().gear_status_514().gear_sts() ==
+        Gear_status_514::GEAR_STS_PARK) {
+      gear_pos = Chassis::GEAR_PARKING;
+    }
+
+    chassis_.set_gear_location(gear_pos);
+  } else {
+    chassis_.set_gear_location(Chassis::GEAR_NONE);
+  }
+  // 11 steering
+  if (chassis_detail.ch().has_steer_status__512() &&
+      chassis_detail.ch().steer_status__512().has_steer_angle_sts()) {
+    // * 100.0 /vehicle_params_.max_steer_angle()*M_PI / 180);
+    chassis_.set_steering_percentage(
+        chassis_detail.ch().steer_status__512().steer_angle_sts() * 100.0 /
+        vehicle_params_.max_steer_angle());
+  } else {
+    chassis_.set_steering_percentage(0);
+  }
+
+  // 26
+  if (chassis_error_mask_) {
+    chassis_.set_chassis_error_mask(chassis_error_mask_);
+  }
+  // 6d, 6e, 6f, if gps valid is availiable, assume all gps related field
+  // available
+
+  if (chassis_detail.has_surround()) {
+    chassis_.mutable_surround()->CopyFrom(chassis_detail.surround());
+  }
+  // give engage_advice based on error_code and canbus feedback
+  if (!chassis_error_mask_ && !chassis_.parking_brake() &&
+      (chassis_.throttle_percentage() == 0.0)) {
+    chassis_.mutable_engage_advice()->set_advice(
+        apollo::common::EngageAdvice::READY_TO_ENGAGE);
+  } else {
+    chassis_.mutable_engage_advice()->set_advice(
+        apollo::common::EngageAdvice::DISALLOW_ENGAGE);
+    chassis_.mutable_engage_advice()->set_reason(
+        "CANBUS not ready, firmware error or emergency button pressed!");
+  }
+
+  return chassis_;
+}
+
+void ChController::Emergency() {
+  set_driving_mode(Chassis::EMERGENCY_MODE);
+  ResetProtocol();
+}
+
+ErrorCode ChController::EnableAutoMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE) {
+    AINFO << "already in COMPLETE_AUTO_DRIVE mode";
+    return ErrorCode::OK;
+  }
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  // control_command_115_->set_ctrl_cmd(Control_command_115::CTRL_CMD_UNDER_CONTROL);
+
+  brake_command_111_->set_brake_pedal_en_ctrl(
+      Brake_command_111::BRAKE_PEDAL_EN_CTRL_ENABLE);
+  throttle_command_110_->set_throttle_pedal_en_ctrl(
+      Throttle_command_110::THROTTLE_PEDAL_EN_CTRL_ENABLE);
+  steer_command_112_->set_steer_angle_en_ctrl(
+      Steer_command_112::STEER_ANGLE_EN_CTRL_ENABLE);
+  AINFO << "\n\n\n set enable \n\n\n";
+  can_sender_->Update();
+  const int32_t flag =
+      CHECK_RESPONSE_STEER_UNIT_FLAG | CHECK_RESPONSE_SPEED_UNIT_FLAG;
+  if (!CheckResponse(flag, true)) {
+    AERROR << "Failed to switch to COMPLETE_AUTO_DRIVE mode.";
+    Emergency();
+    set_chassis_error_code(Chassis::CHASSIS_ERROR);
+    return ErrorCode::CANBUS_ERROR;
+  } else {
+    set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+    AINFO << "Switch to COMPLETE_AUTO_DRIVE mode ok.";
+    return ErrorCode::OK;
+  }
+}
+
+ErrorCode ChController::DisableAutoMode() {
+  ResetProtocol();
+  can_sender_->Update();
+  set_driving_mode(Chassis::COMPLETE_MANUAL);
+  set_chassis_error_code(Chassis::NO_ERROR);
+  AINFO << "Switch to COMPLETE_MANUAL OK!";
+  return ErrorCode::OK;
+}
+
+ErrorCode ChController::EnableSteeringOnlyMode() {
+  AFATAL << "SteeringOnlyMode Not supported!";
+  return ErrorCode::OK;
+}
+
+ErrorCode ChController::EnableSpeedOnlyMode() {
+  AFATAL << "SpeedOnlyMode Not supported!";
+  return ErrorCode::OK;
+}
+
+// NEUTRAL, REVERSE, DRIVE
+void ChController::Gear(Chassis::GearPosition gear_position) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "this drive mode no need to set gear.";
+    return;
+  }
+
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  switch (gear_position) {
+    case Chassis::GEAR_NEUTRAL: {
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_NEUTRAL);
+      break;
+    }
+    case Chassis::GEAR_REVERSE: {
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_REVERSE);
+      break;
+    }
+    case Chassis::GEAR_DRIVE: {
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_DRIVE);
+      break;
+    }
+    case Chassis::GEAR_PARKING: {
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_PARK);
+      break;
+    }
+    case Chassis::GEAR_INVALID: {
+      AERROR << "Gear command is invalid!";
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_NEUTRAL);
+      break;
+    }
+    default: {
+      gear_command_114_->set_gear_cmd(Gear_command_114::GEAR_CMD_NEUTRAL);
+      break;
+    }
+  }
+}
+
+// brake with new acceleration
+// acceleration:0.00~99.99, unit:
+// acceleration:0.0 ~ 7.0, unit:m/s^2
+// acceleration_spd:60 ~ 100, suggest: 90
+// -> pedal
+void ChController::Brake(double pedal) {
+  // double real_value = params_.max_acc() * acceleration / 100;
+  // Update brake value based on mode
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  brake_command_111_->set_brake_pedal_cmd(pedal);
+}
+
+// drive with old acceleration
+// gas:0.00~99.99 unit:
+void ChController::Throttle(double pedal) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_SPEED_ONLY)) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  throttle_command_110_->set_throttle_pedal_cmd(pedal);
+}
+
+// ch default, -470 ~ 470, left:+, right:-
+// need to be compatible with control module, so reverse
+// steering with old angle speed
+// angle:-99.99~0.00~99.99, unit:, left:-, right:+
+void ChController::Steer(double angle) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_STEER_ONLY)) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  const double real_angle = vehicle_params_.max_steer_angle() * angle / 100.0;
+  // reverse sign
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  steer_command_112_->set_steer_angle_cmd(real_angle);
+}
+
+// steering with new angle speed
+// angle:-99.99~0.00~99.99, unit:, left:-, right:+
+// angle_spd:0.00~99.99, unit:deg/s
+void ChController::Steer(double angle, double angle_spd) {
+  if (!(driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+        driving_mode() == Chassis::AUTO_STEER_ONLY)) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  // ADD YOUR OWN CAR CHASSIS OPERATION
+  const double real_angle =
+      // vehicle_params_.max_steer_angle() / M_PI * 180 * angle / 100.0;
+      vehicle_params_.max_steer_angle() * angle / 100.0;
+  const double real_angle_spd =
+      ProtocolData<::apollo::canbus::ChassisDetail>::BoundedValue(
+          vehicle_params_.min_steer_angle_rate() / M_PI * 180,
+          vehicle_params_.max_steer_angle_rate() / M_PI * 180,
+          vehicle_params_.max_steer_angle_rate() / M_PI * 180 * angle_spd /
+              100.0);
+  steer_command_112_->set_steer_angle_cmd(real_angle);
+}
+
+void ChController::SetEpbBreak(const ControlCommand& command) {
+  if (command.parking_brake()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void ChController::SetBeam(const ControlCommand& command) {
+  if (command.signal().high_beam()) {
+    // None
+  } else if (command.signal().low_beam()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void ChController::SetHorn(const ControlCommand& command) {
+  if (command.signal().horn()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void ChController::SetTurningSignal(const ControlCommand& command) {}
+
+void ChController::ResetProtocol() { message_manager_->ResetSendMessages(); }
+
+bool ChController::CheckChassisError() {
+  return false;
+}
+
+void ChController::SecurityDogThreadFunc() {
+  int32_t vertical_ctrl_fail = 0;
+  int32_t horizontal_ctrl_fail = 0;
+
+  if (can_sender_ == nullptr) {
+    AERROR << "Fail to run SecurityDogThreadFunc() because can_sender_ is "
+              "nullptr.";
+    return;
+  }
+  while (!can_sender_->IsRunning()) {
+    std::this_thread::yield();
+  }
+
+  std::chrono::duration<double, std::micro> default_period{50000};
+  int64_t start = 0;
+  int64_t end = 0;
+  while (can_sender_->IsRunning()) {
+    start = ::apollo::common::time::AsInt64<::apollo::common::time::micros>(
+        ::apollo::common::time::Clock::Now());
+    const Chassis::DrivingMode mode = driving_mode();
+    bool emergency_mode = false;
+
+    // 1. horizontal control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_STEER_ONLY) &&
+        CheckResponse(CHECK_RESPONSE_STEER_UNIT_FLAG, false) == false) {
+      ++horizontal_ctrl_fail;
+      if (horizontal_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      horizontal_ctrl_fail = 0;
+    }
+
+    // 2. vertical control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_SPEED_ONLY) &&
+        CheckResponse(CHECK_RESPONSE_SPEED_UNIT_FLAG, false) == false) {
+      ++vertical_ctrl_fail;
+      if (vertical_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      vertical_ctrl_fail = 0;
+    }
+    if (CheckChassisError()) {
+      set_chassis_error_code(Chassis::CHASSIS_ERROR);
+      emergency_mode = true;
+    }
+
+    if (emergency_mode && mode != Chassis::EMERGENCY_MODE) {
+      set_driving_mode(Chassis::EMERGENCY_MODE);
+      message_manager_->ResetSendMessages();
+    }
+    end = ::apollo::common::time::AsInt64<::apollo::common::time::micros>(
+        ::apollo::common::time::Clock::Now());
+    std::chrono::duration<double, std::micro> elapsed{end - start};
+    if (elapsed < default_period) {
+      std::this_thread::sleep_for(default_period - elapsed);
+    } else {
+      AERROR << "Too much time consumption in ChController looping process:"
+             << elapsed.count();
+    }
+  }
+}
+bool ChController::CheckResponse(const int32_t flags, bool need_wait) {
+  int32_t retry_num = 20;
+  ChassisDetail chassis_detail;
+  bool is_eps_online = false;
+  bool is_vcu_online = false;
+  bool is_esp_online = false;
+
+  do {
+    if (message_manager_->GetSensorData(&chassis_detail) != ErrorCode::OK) {
+      AERROR_EVERY(100) << "get chassis detail failed.";
+      return false;
+    }
+    bool check_ok = true;
+    if (flags & CHECK_RESPONSE_STEER_UNIT_FLAG) {
+      is_eps_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_eps_online() &&
+                      chassis_detail.check_response().is_eps_online();
+      check_ok = check_ok && is_eps_online;
+    }
+
+    if (flags & CHECK_RESPONSE_SPEED_UNIT_FLAG) {
+      is_vcu_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_vcu_online() &&
+                      chassis_detail.check_response().is_vcu_online();
+      is_esp_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_esp_online() &&
+                      chassis_detail.check_response().is_esp_online();
+      check_ok = check_ok && is_vcu_online && is_esp_online;
+    }
+    if (check_ok) {
+      return true;
+    } else {
+      AINFO << "Need to check response again.";
+    }
+    if (need_wait) {
+      --retry_num;
+      std::this_thread::sleep_for(
+          std::chrono::duration<double, std::milli>(20));
+    }
+  } while (need_wait && retry_num);
+
+  AINFO << "check_response fail: is_eps_online:" << is_eps_online
+        << ", is_vcu_online:" << is_vcu_online
+        << ", is_esp_online:" << is_esp_online;
+
+  return false;
+}
+
+void ChController::set_chassis_error_mask(const int32_t mask) {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  chassis_error_mask_ = mask;
+}
+
+int32_t ChController::chassis_error_mask() {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  return chassis_error_mask_;
+}
+
+Chassis::ErrorCode ChController::chassis_error_code() {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  return chassis_error_code_;
+}
+
+void ChController::set_chassis_error_code(
+    const Chassis::ErrorCode& error_code) {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  chassis_error_code_ = error_code;
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/ch_controller.h
+++ b/modules/canbus/vehicle/ch/ch_controller.h
@@ -1,0 +1,137 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <thread>
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/common/macro.h"
+#include "modules/common/proto/error_code.pb.h"
+#include "modules/control/proto/control_cmd.pb.h"
+#include "modules/canbus/vehicle/ch/protocol/brake_command_111.h"
+#include "modules/canbus/vehicle/ch/protocol/control_command_115.h"
+#include "modules/canbus/vehicle/ch/protocol/gear_command_114.h"
+#include "modules/canbus/vehicle/ch/protocol/steer_command_112.h"
+#include "modules/canbus/vehicle/ch/protocol/throttle_command_110.h"
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class ChController final : public VehicleController {
+ public:
+  ChController() {}
+
+  virtual ~ChController();
+
+  ::apollo::common::ErrorCode Init(
+      const VehicleParameter& params,
+      CanSender<::apollo::canbus::ChassisDetail> *const can_sender,
+      MessageManager<::apollo::canbus::ChassisDetail>
+      *const message_manager) override;
+
+  bool Start() override;
+
+  /**
+   * @brief stop the vehicle controller.
+   */
+  void Stop() override;
+
+  /**
+   * @brief calculate and return the chassis.
+   * @returns a copy of chassis. Use copy here to avoid multi-thread issues.
+   */
+  Chassis chassis() override;
+  FRIEND_TEST(ChControllerTest, SetDrivingMode);
+  FRIEND_TEST(ChControllerTest, Status);
+  FRIEND_TEST(ChControllerTest, UpdateDrivingMode);
+
+ private:
+  // main logical function for operation the car enter or exit the auto driving
+  void Emergency() override;
+  ::apollo::common::ErrorCode EnableAutoMode() override;
+  ::apollo::common::ErrorCode DisableAutoMode() override;
+  ::apollo::common::ErrorCode EnableSteeringOnlyMode() override;
+  ::apollo::common::ErrorCode EnableSpeedOnlyMode() override;
+
+  // NEUTRAL, REVERSE, DRIVE
+  void Gear(Chassis::GearPosition state) override;
+
+  // brake with new acceleration
+  // acceleration:0.00~99.99, unit:
+  // acceleration_spd: 60 ~ 100, suggest: 90
+  void Brake(double acceleration) override;
+
+  // drive with old acceleration
+  // gas:0.00~99.99 unit:
+  void Throttle(double throttle) override;
+
+  // steering with old angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  void Steer(double angle) override;
+
+  // steering with new angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  // angle_spd:0.00~99.99, unit:deg/s
+  void Steer(double angle, double angle_spd) override;
+
+  // set Electrical Park Brake
+  void SetEpbBreak(const ::apollo::control::ControlCommand& command) override;
+  void SetBeam(const ::apollo::control::ControlCommand& command) override;
+  void SetHorn(const ::apollo::control::ControlCommand& command) override;
+  void SetTurningSignal(
+      const ::apollo::control::ControlCommand& command) override;
+
+  void ResetProtocol();
+  bool CheckChassisError();
+
+ private:
+  void SecurityDogThreadFunc();
+  virtual bool CheckResponse(const int32_t flags, bool need_wait);
+  void set_chassis_error_mask(const int32_t mask);
+  int32_t chassis_error_mask();
+  Chassis::ErrorCode chassis_error_code();
+  void set_chassis_error_code(const Chassis::ErrorCode& error_code);
+
+ private:
+  // control protocol
+  Brakecommand111* brake_command_111_ = nullptr;
+  Controlcommand115* control_command_115_ = nullptr;
+  Gearcommand114* gear_command_114_ = nullptr;
+  Steercommand112* steer_command_112_ = nullptr;
+  Throttlecommand110* throttle_command_110_ = nullptr;
+  Turnsignalcommand113* turnsignal_command_113_ = nullptr;
+
+  Chassis chassis_;
+  std::unique_ptr<std::thread> thread_;
+  bool is_chassis_error_ = false;
+
+  std::mutex chassis_error_code_mutex_;
+  Chassis::ErrorCode chassis_error_code_ = Chassis::NO_ERROR;
+
+  std::mutex chassis_mask_mutex_;
+  int32_t chassis_error_mask_ = 0;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/ch/ch_controller_test.cc
+++ b/modules/canbus/vehicle/ch/ch_controller_test.cc
@@ -1,0 +1,94 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/ch_controller.h"
+#include "gtest/gtest.h"
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/canbus/vehicle/ch/ch_message_manager.h"
+#include "modules/common/proto/vehicle_signal.pb.h"
+#include "modules/common/util/file.h"
+#include "modules/control/proto/control_cmd.pb.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+using apollo::common::ErrorCode;
+using apollo::common::VehicleSignal;
+using apollo::control::ControlCommand;
+
+class ChControllerTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    std::string canbus_conf_file =
+        "modules/canbus/testdata/conf/ch_canbus_conf_test.pb.txt";
+    common::util::GetProtoFromFile(canbus_conf_file, &canbus_conf_);
+    params_ = canbus_conf_.vehicle_parameter();
+    control_cmd_.set_throttle(20.0);
+    control_cmd_.set_brake(0.0);
+    control_cmd_.set_steering_rate(80.0);
+    control_cmd_.set_horn(false);
+  }
+
+ protected:
+  ChController controller_;
+  ControlCommand control_cmd_;
+  VehicleSignal vehicle_signal_;
+  CanSender<::apollo::canbus::ChassisDetail> sender_;
+  ChMessageManager msg_manager_;
+  CanbusConf canbus_conf_;
+  VehicleParameter params_;
+};
+
+TEST_F(ChControllerTest, Init) {
+  ErrorCode ret = controller_.Init(params_, &sender_, &msg_manager_);
+  EXPECT_EQ(ret, ErrorCode::OK);
+}
+
+TEST_F(ChControllerTest, SetDrivingMode) {
+  Chassis chassis;
+  chassis.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(chassis.driving_mode());
+  EXPECT_EQ(controller_.driving_mode(), chassis.driving_mode());
+  EXPECT_EQ(controller_.SetDrivingMode(chassis.driving_mode()), ErrorCode::OK);
+}
+
+TEST_F(ChControllerTest, Status) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.Update(control_cmd_), ErrorCode::OK);
+  controller_.SetHorn(control_cmd_);
+  controller_.SetBeam(control_cmd_);
+  controller_.SetTurningSignal(control_cmd_);
+  EXPECT_FALSE(controller_.CheckChassisError());
+}
+
+TEST_F(ChControllerTest, UpdateDrivingMode) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.SetDrivingMode(Chassis::COMPLETE_MANUAL),
+            ErrorCode::OK);
+  EXPECT_EQ(controller_.SetDrivingMode(Chassis::COMPLETE_AUTO_DRIVE),
+            ErrorCode::CANBUS_ERROR);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/ch_message_manager.cc
+++ b/modules/canbus/vehicle/ch/ch_message_manager.cc
@@ -1,0 +1,60 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "modules/canbus/vehicle/ch/ch_message_manager.h"
+#include "modules/canbus/vehicle/ch/protocol/brake_command_111.h"
+#include "modules/canbus/vehicle/ch/protocol/control_command_115.h"
+#include "modules/canbus/vehicle/ch/protocol/gear_command_114.h"
+#include "modules/canbus/vehicle/ch/protocol/steer_command_112.h"
+#include "modules/canbus/vehicle/ch/protocol/throttle_command_110.h"
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h"
+#include "modules/canbus/vehicle/ch/protocol/brake_status__511.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h"
+#include "modules/canbus/vehicle/ch/protocol/gear_status_514.h"
+#include "modules/canbus/vehicle/ch/protocol/steer_status__512.h"
+#include "modules/canbus/vehicle/ch/protocol/throttle_status__510.h"
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+ChMessageManager::ChMessageManager() {
+  // Control Messages
+  AddSendProtocolData<Brakecommand111, true>();
+  AddSendProtocolData<Controlcommand115, true>();
+  AddSendProtocolData<Gearcommand114, true>();
+  AddSendProtocolData<Steercommand112, true>();
+  AddSendProtocolData<Throttlecommand110, true>();
+  AddSendProtocolData<Turnsignalcommand113, true>();
+
+  // Report Messages
+  AddRecvProtocolData<Brakestatus511, true>();
+  AddRecvProtocolData<Ecustatus1515, true>();
+  AddRecvProtocolData<Ecustatus2516, true>();
+  AddRecvProtocolData<Ecustatus3517, true>();
+  AddRecvProtocolData<Gearstatus514, true>();
+  AddRecvProtocolData<Steerstatus512, true>();
+  AddRecvProtocolData<Throttlestatus510, true>();
+  AddRecvProtocolData<Turnsignalstatus513, true>();
+}
+
+ChMessageManager::~ChMessageManager() {}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/ch_message_manager.h
+++ b/modules/canbus/vehicle/ch/ch_message_manager.h
@@ -1,0 +1,37 @@
+/* Copyright 2019 The Apollo Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::MessageManager;
+
+class ChMessageManager :
+public MessageManager<::apollo::canbus::ChassisDetail> {
+ public:
+  ChMessageManager();
+  virtual ~ChMessageManager();
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/ch/ch_message_manager_test.cc
+++ b/modules/canbus/vehicle/ch/ch_message_manager_test.cc
@@ -1,0 +1,161 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/ch_message_manager.h"
+#include "gtest/gtest.h"
+#include "modules/canbus/vehicle/ch/protocol/brake_command_111.h"
+#include "modules/canbus/vehicle/ch/protocol/brake_status__511.h"
+#include "modules/canbus/vehicle/ch/protocol/control_command_115.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h"
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h"
+#include "modules/canbus/vehicle/ch/protocol/gear_command_114.h"
+#include "modules/canbus/vehicle/ch/protocol/gear_status_514.h"
+#include "modules/canbus/vehicle/ch/protocol/steer_command_112.h"
+#include "modules/canbus/vehicle/ch/protocol/steer_status__512.h"
+#include "modules/canbus/vehicle/ch/protocol/throttle_command_110.h"
+#include "modules/canbus/vehicle/ch/protocol/throttle_status__510.h"
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h"
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+using ::apollo::drivers::canbus::ProtocolData;
+using ::apollo::canbus::ChassisDetail;
+
+class ChMessageManagerTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(ChMessageManagerTest, Brakecommand111) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Brakecommand111::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Brakecommand111 *>(pd)->ID, Brakecommand111::ID);
+}
+
+TEST_F(ChMessageManagerTest, Brakestatus511) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Brakestatus511::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Brakestatus511 *>(pd)->ID, Brakestatus511::ID);
+}
+
+TEST_F(ChMessageManagerTest, Controlcommand115) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Controlcommand115::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Controlcommand115 *>(pd)->ID, Controlcommand115::ID);
+}
+
+TEST_F(ChMessageManagerTest, Ecustatus1515) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Ecustatus1515::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Ecustatus1515 *>(pd)->ID, Ecustatus1515::ID);
+}
+
+TEST_F(ChMessageManagerTest, Ecustatus2516) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Ecustatus2516::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Ecustatus2516 *>(pd)->ID, Ecustatus2516::ID);
+}
+
+TEST_F(ChMessageManagerTest, Ecustatus3517) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Ecustatus3517::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Ecustatus3517 *>(pd)->ID, Ecustatus3517::ID);
+}
+
+TEST_F(ChMessageManagerTest, Gearcommand114) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Gearcommand114::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Gearcommand114 *>(pd)->ID, Gearcommand114::ID);
+}
+
+TEST_F(ChMessageManagerTest, Gearstatus514) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Gearstatus514::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Gearstatus514 *>(pd)->ID, Gearstatus514::ID);
+}
+
+TEST_F(ChMessageManagerTest, Steercommand112) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Steercommand112::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Steercommand112 *>(pd)->ID, Steercommand112::ID);
+}
+
+TEST_F(ChMessageManagerTest, Steerstatus512) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Steerstatus512::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Steerstatus512 *>(pd)->ID, Steerstatus512::ID);
+}
+
+TEST_F(ChMessageManagerTest, Throttlecommand110) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Throttlecommand110::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Throttlecommand110 *>(pd)->ID, Throttlecommand110::ID);
+}
+
+TEST_F(ChMessageManagerTest, Throttlestatus510) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Throttlestatus510::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Throttlestatus510 *>(pd)->ID, Throttlestatus510::ID);
+}
+
+TEST_F(ChMessageManagerTest, Turnsignalcommand113) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Turnsignalcommand113::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Turnsignalcommand113 *>
+  (pd)->ID, Turnsignalcommand113::ID);
+}
+
+TEST_F(ChMessageManagerTest, Turnsignalstatus513) {
+  ChMessageManager manager;
+  ProtocolData<ChassisDetail> *pd =
+      manager.GetMutableProtocolDataById(Turnsignalstatus513::ID);
+  EXPECT_TRUE(pd != nullptr);
+  EXPECT_EQ(static_cast<Turnsignalstatus513 *>
+  (pd)->ID, Turnsignalstatus513::ID);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/ch_vehicle_factory.cc
+++ b/modules/canbus/vehicle/ch/ch_vehicle_factory.cc
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/ch_vehicle_factory.h"
+
+#include "modules/canbus/vehicle/ch/ch_controller.h"
+#include "modules/canbus/vehicle/ch/ch_message_manager.h"
+#include "modules/common/log.h"
+#include "modules/common/util/util.h"
+
+namespace apollo {
+namespace canbus {
+
+std::unique_ptr<VehicleController> ChVehicleFactory::CreateVehicleController() {
+  return std::unique_ptr<VehicleController>(new ch::ChController());
+}
+
+std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+ChVehicleFactory::CreateMessageManager() {
+  return std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>(
+      new ch::ChMessageManager());
+}
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/ch_vehicle_factory.h
+++ b/modules/canbus/vehicle/ch/ch_vehicle_factory.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+/**
+ * @file ch_vehicle_factory.h
+ */
+
+#pragma once
+
+#include <memory>
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/canbus/vehicle/abstract_vehicle_factory.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+/**
+ * @namespace apollo::canbus
+ * @brief apollo::canbus
+ */
+namespace apollo {
+namespace canbus {
+
+/**
+ * @class ChVehicleFactory
+ *
+ * @brief this class is inherited from AbstractVehicleFactory. It can be used to
+ * create controller and message manager for ch vehicle.
+ */
+class ChVehicleFactory : public AbstractVehicleFactory {
+ public:
+  /**
+  * @brief destructor
+  */
+  virtual ~ChVehicleFactory() = default;
+
+  /**
+   * @brief create ch vehicle controller
+   * @returns a unique_ptr that points to the created controller
+   */
+  std::unique_ptr<VehicleController> CreateVehicleController() override;
+
+  /**
+   * @brief create ch message manager
+   * @returns a unique_ptr that points to the created message manager
+   */
+  std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+  CreateMessageManager() override;
+};
+
+}  // namespace canbus
+}  // namespace apollo
+

--- a/modules/canbus/vehicle/ch/ch_vehicle_factory_test.cc
+++ b/modules/canbus/vehicle/ch/ch_vehicle_factory_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/ch_vehicle_factory.h"
+#include "gtest/gtest.h"
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+
+namespace apollo {
+namespace canbus {
+
+class ChVehicleFactoryTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    VehicleParameter parameter;
+    parameter.set_brand(VehicleParameter::CH);
+    ch_factory_.SetVehicleParameter(parameter);
+  }
+  virtual void TearDown() {}
+
+ protected:
+  ChVehicleFactory ch_factory_;
+};
+
+TEST_F(ChVehicleFactoryTest, InitVehicleController) {
+  EXPECT_TRUE(ch_factory_.CreateVehicleController() != nullptr);
+}
+
+TEST_F(ChVehicleFactoryTest, InitMessageManager) {
+  EXPECT_TRUE(ch_factory_.CreateMessageManager() != nullptr);
+}
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/BUILD
+++ b/modules/canbus/vehicle/ch/protocol/BUILD
@@ -1,0 +1,417 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "canbus_ch_protocol",
+    deps = [
+        ":brake_command_111",
+        ":brake_status__511",
+        ":control_command_115",
+        ":ecu_status_1_515",
+        ":ecu_status_2_516",
+        ":ecu_status_3_517",
+        ":gear_command_114",
+        ":gear_status_514",
+        ":steer_command_112",
+        ":steer_status__512",
+        ":throttle_command_110",
+        ":throttle_status__510",
+        ":turnsignal_command_113",
+        ":turnsignal_status__513",
+    ],
+)
+
+cc_library(
+    name = "brake_command_111",
+    srcs = [
+        "brake_command_111.cc",
+    ],
+    hdrs = [
+        "brake_command_111.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "brake_command_111_test",
+    size = "small",
+    srcs = [
+        "brake_command_111_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "brake_status__511",
+    srcs = [
+        "brake_status__511.cc",
+    ],
+    hdrs = [
+        "brake_status__511.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "brake_status__511_test",
+    size = "small",
+    srcs = [
+        "brake_status__511_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "control_command_115",
+    srcs = [
+        "control_command_115.cc",
+    ],
+    hdrs = [
+        "control_command_115.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "control_command_115_test",
+    size = "small",
+    srcs = [
+        "control_command_115_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "ecu_status_1_515",
+    srcs = [
+        "ecu_status_1_515.cc",
+    ],
+    hdrs = [
+        "ecu_status_1_515.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ecu_status_1_515_test",
+    size = "small",
+    srcs = [
+        "ecu_status_1_515_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "ecu_status_2_516",
+    srcs = [
+        "ecu_status_2_516.cc",
+    ],
+    hdrs = [
+        "ecu_status_2_516.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ecu_status_2_516_test",
+    size = "small",
+    srcs = [
+        "ecu_status_2_516_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "ecu_status_3_517",
+    srcs = [
+        "ecu_status_3_517.cc",
+    ],
+    hdrs = [
+        "ecu_status_3_517.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ecu_status_3_517_test",
+    size = "small",
+    srcs = [
+        "ecu_status_3_517_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "gear_command_114",
+    srcs = [
+        "gear_command_114.cc",
+    ],
+    hdrs = [
+        "gear_command_114.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "gear_command_114_test",
+    size = "small",
+    srcs = [
+        "gear_command_114_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "gear_status_514",
+    srcs = [
+        "gear_status_514.cc",
+    ],
+    hdrs = [
+        "gear_status_514.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "gear_status_514_test",
+    size = "small",
+    srcs = [
+        "gear_status_514_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "steer_command_112",
+    srcs = [
+        "steer_command_112.cc",
+    ],
+    hdrs = [
+        "steer_command_112.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "steer_command_112_test",
+    size = "small",
+    srcs = [
+        "steer_command_112_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "steer_status__512",
+    srcs = [
+        "steer_status__512.cc",
+    ],
+    hdrs = [
+        "steer_status__512.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "steer_status__512_test",
+    size = "small",
+    srcs = [
+        "steer_status__512_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "throttle_command_110",
+    srcs = [
+        "throttle_command_110.cc",
+    ],
+    hdrs = [
+        "throttle_command_110.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "throttle_command_110_test",
+    size = "small",
+    srcs = [
+        "throttle_command_110_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "throttle_status__510",
+    srcs = [
+        "throttle_status__510.cc",
+    ],
+    hdrs = [
+        "throttle_status__510.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "throttle_status__510_test",
+    size = "small",
+    srcs = [
+        "throttle_status__510_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "turnsignal_command_113",
+    srcs = [
+        "turnsignal_command_113.cc",
+    ],
+    hdrs = [
+        "turnsignal_command_113.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "turnsignal_command_113_test",
+    size = "small",
+    srcs = [
+        "turnsignal_command_113_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cc_library(
+    name = "turnsignal_status__513",
+    srcs = [
+        "turnsignal_status__513.cc",
+    ],
+    hdrs = [
+        "turnsignal_status__513.h",
+    ],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "turnsignal_status__513_test",
+    size = "small",
+    srcs = [
+        "turnsignal_status__513_test.cc",
+    ],
+    deps = [
+        "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
+        "@gtest//:main",
+    ],
+)
+
+cpplint()

--- a/modules/canbus/vehicle/ch/protocol/brake_command_111.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_command_111.cc
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/brake_command_111.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Brakecommand111::ID = 0x111;
+
+// public
+Brakecommand111::Brakecommand111() { Reset(); }
+
+uint32_t Brakecommand111::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Brakecommand111::UpdateData(uint8_t* data) {
+  set_p_brake_pedal_en_ctrl(data, brake_pedal_en_ctrl_);
+  set_p_brake_pedal_cmd(data, brake_pedal_cmd_);
+}
+
+void Brakecommand111::Reset() {
+  // you should check this manually
+  brake_pedal_en_ctrl_ = Brake_command_111::BRAKE_PEDAL_EN_CTRL_DISABLE;
+  brake_pedal_cmd_ = 0;
+}
+
+Brakecommand111* Brakecommand111::set_brake_pedal_en_ctrl(
+    Brake_command_111::Brake_pedal_en_ctrlType brake_pedal_en_ctrl) {
+  brake_pedal_en_ctrl_ = brake_pedal_en_ctrl;
+  return this;
+}
+
+// config detail: {'description': 'brake pedal enable bit(Command)', 'enum': {0:
+// 'BRAKE_PEDAL_EN_CTRL_DISABLE', 1: 'BRAKE_PEDAL_EN_CTRL_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_EN_CTRL', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+void Brakecommand111::set_p_brake_pedal_en_ctrl(
+    uint8_t* data,
+    Brake_command_111::Brake_pedal_en_ctrlType brake_pedal_en_ctrl) {
+  int x = brake_pedal_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+Brakecommand111* Brakecommand111::set_brake_pedal_cmd(int brake_pedal_cmd) {
+  brake_pedal_cmd_ = brake_pedal_cmd;
+  return this;
+}
+
+// config detail: {'description': 'Percentage of brake pedal(Command)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_CMD',
+// 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type': 'int',
+// 'order': 'intel', 'physical_unit': '%'}
+void Brakecommand111::set_p_brake_pedal_cmd(uint8_t* data,
+                                            int brake_pedal_cmd) {
+  brake_pedal_cmd = ProtocolData::BoundedValue(0, 100, brake_pedal_cmd);
+  int x = brake_pedal_cmd;
+
+  Byte to_set(data + 1);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/brake_command_111.h
+++ b/modules/canbus/vehicle/ch/protocol/brake_command_111.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Brakecommand111 : public ::apollo::drivers::canbus::ProtocolData<
+                            ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Brakecommand111();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'brake pedal enable bit(Command)', 'enum':
+  // {0: 'BRAKE_PEDAL_EN_CTRL_DISABLE', 1: 'BRAKE_PEDAL_EN_CTRL_ENABLE'},
+  // 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_EN_CTRL', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Brakecommand111* set_brake_pedal_en_ctrl(
+      Brake_command_111::Brake_pedal_en_ctrlType brake_pedal_en_ctrl);
+
+  // config detail: {'description': 'Percentage of brake pedal(Command)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_CMD',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  Brakecommand111* set_brake_pedal_cmd(int brake_pedal_cmd);
+
+ private:
+  // config detail: {'description': 'brake pedal enable bit(Command)', 'enum':
+  // {0: 'BRAKE_PEDAL_EN_CTRL_DISABLE', 1: 'BRAKE_PEDAL_EN_CTRL_ENABLE'},
+  // 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_EN_CTRL', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  void set_p_brake_pedal_en_ctrl(
+      uint8_t* data,
+      Brake_command_111::Brake_pedal_en_ctrlType brake_pedal_en_ctrl);
+
+  // config detail: {'description': 'Percentage of brake pedal(Command)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_CMD',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  void set_p_brake_pedal_cmd(uint8_t* data, int brake_pedal_cmd);
+
+ private:
+  Brake_command_111::Brake_pedal_en_ctrlType brake_pedal_en_ctrl_;
+  int brake_pedal_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/brake_command_111_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_command_111_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/brake_command_111.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Brakecommand111Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Brakecommand111Test, simple) {
+  Brakecommand111 brake;
+  EXPECT_EQ(brake.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  brake.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/brake_status__511.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Brakestatus511::Brakestatus511() {}
+const int32_t Brakestatus511::ID = 0x511;
+
+void Brakestatus511::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_brake_status__511()->set_brake_pedal_en_sts(
+      brake_pedal_en_sts(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_brake_pedal_sts(
+      brake_pedal_sts(bytes, length));
+}
+
+// config detail: {'description': 'brake pedal enable bit(Status)', 'enum': {0:
+// 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'brake_pedal_en_sts', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Brake_status__511::Brake_pedal_en_stsType Brakestatus511::brake_pedal_en_sts(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+  Brake_status__511::Brake_pedal_en_stsType ret =
+      static_cast<Brake_status__511::Brake_pedal_en_stsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Percentage of brake pedal(Status)', 'offset':
+// 0.0, 'precision': 1.0, 'len': 8, 'name': 'brake_pedal_sts', 'is_signed_var':
+// False, 'physical_range': '[0|100]', 'bit': 8, 'type': 'int', 'order':
+// 'intel', 'physical_unit': '%'}
+int Brakestatus511::brake_pedal_sts(const std::uint8_t* bytes,
+                                    int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.h
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Brakestatus511 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Brakestatus511();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'brake pedal enable bit(Status)', 'enum':
+  // {0: 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE'},
+  // 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_EN_STS', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Brake_status__511::Brake_pedal_en_stsType brake_pedal_en_sts(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Percentage of brake pedal(Status)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_STS',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  int brake_pedal_sts(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511_test.cc
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/brake_status__511.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Brakestatus511Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Brakestatus511Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Brakestatus511 brake;
+  brake.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().brake_status__511().brake_pedal_en_sts(), 1);
+  EXPECT_EQ(cd.ch().brake_status__511().brake_pedal_sts(), 2);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/control_command_115.cc
+++ b/modules/canbus/vehicle/ch/protocol/control_command_115.cc
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/control_command_115.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Controlcommand115::ID = 0x115;
+
+// public
+Controlcommand115::Controlcommand115() { Reset(); }
+
+uint32_t Controlcommand115::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Controlcommand115::UpdateData(uint8_t* data) {
+  set_p_ctrl_cmd(data, ctrl_cmd_);
+}
+
+void Controlcommand115::Reset() {
+  // you should check this manually
+  ctrl_cmd_ = Control_command_115::CTRL_CMD_OUT_OF_CONTROL;
+}
+
+Controlcommand115* Controlcommand115::set_ctrl_cmd(
+    Control_command_115::Ctrl_cmdType ctrl_cmd) {
+  ctrl_cmd_ = ctrl_cmd;
+  return this;
+}
+
+// config detail: {'description': 'Take control(Command)', 'enum': {0:
+// 'CTRL_CMD_OUT_OF_CONTROL', 1: 'CTRL_CMD_UNDER_CONTROL'}, 'precision': 1.0,
+// 'len': 8, 'name': 'CTRL_CMD', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
+void Controlcommand115::set_p_ctrl_cmd(
+    uint8_t* data, Control_command_115::Ctrl_cmdType ctrl_cmd) {
+  int x = ctrl_cmd;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/control_command_115.h
+++ b/modules/canbus/vehicle/ch/protocol/control_command_115.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Controlcommand115 : public ::apollo::drivers::canbus::ProtocolData<
+                              ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Controlcommand115();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'Take control(Command)', 'enum': {0:
+  // 'CTRL_CMD_OUT_OF_CONTROL', 1: 'CTRL_CMD_UNDER_CONTROL'}, 'precision': 1.0,
+  // 'len': 8, 'name': 'CTRL_CMD', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Controlcommand115* set_ctrl_cmd(Control_command_115::Ctrl_cmdType ctrl_cmd);
+
+ private:
+  // config detail: {'description': 'Take control(Command)', 'enum': {0:
+  // 'CTRL_CMD_OUT_OF_CONTROL', 1: 'CTRL_CMD_UNDER_CONTROL'}, 'precision': 1.0,
+  // 'len': 8, 'name': 'CTRL_CMD', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  void set_p_ctrl_cmd(uint8_t* data,
+                      Control_command_115::Ctrl_cmdType ctrl_cmd);
+
+ private:
+  Control_command_115::Ctrl_cmdType ctrl_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/control_command_115_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/control_command_115_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/control_command_115.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Controlcommand115Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Controlcommand115Test, simple) {
+  Controlcommand115 controlcommand;
+  EXPECT_EQ(controlcommand.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  controlcommand.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.cc
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ecustatus1515::Ecustatus1515() {}
+const int32_t Ecustatus1515::ID = 0x515;
+
+void Ecustatus1515::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_ecu_status_1_515()->set_speed(
+      speed(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_1_515()->set_acc_speed(
+      acc_speed(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_1_515()->set_ctrl_sts(
+      ctrl_sts(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_1_515()->set_chassis_sts(
+      chassis_sts(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_1_515()->set_chassis_err(
+      chassis_err(bytes, length));
+
+  chassis->mutable_check_response()->set_is_esp_online(
+      chassis_sts(bytes, length) == 1);
+  chassis->mutable_check_response()->set_is_eps_online(
+      chassis_sts(bytes, length) == 1);
+  chassis->mutable_check_response()->set_is_vcu_online(
+      chassis_sts(bytes, length) == 1);
+}
+
+// config detail: {'description': 'Current speed (Steering status)', 'offset':
+// 0.0, 'precision': 0.01, 'len': 16, 'name': 'speed', 'is_signed_var': True,
+// 'physical_range': '[0|0]', 'bit': 0, 'type': 'double', 'order': 'intel',
+// 'physical_unit': 'm/s'}
+double Ecustatus1515::speed(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 0);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  x <<= 16;
+  x >>= 16;
+
+  double ret = x * 0.010000;
+  return ret;
+}
+
+// config detail: {'description': 'Current acceleration (Steering status)',
+// 'offset': 0.0, 'precision': 0.001, 'len': 16, 'name': 'acc_speed',
+// 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 16, 'type':
+// 'double', 'order': 'intel', 'physical_unit': 'm/s^2'}
+double Ecustatus1515::acc_speed(const std::uint8_t* bytes,
+                                int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 2);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  x <<= 16;
+  x >>= 16;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+
+// config detail: {'description': 'Current Auto-mode state (Chassis status)',
+// 'enum': {0: 'CTRL_STS_OUT_OF_CONTROL', 1: 'CTRL_STS_UNDER_CONTROL'},
+// 'precision': 1.0, 'len': 8, 'name': 'ctrl_sts', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum', 'order':
+// 'intel', 'physical_unit': ''}
+Ecu_status_1_515::Ctrl_stsType Ecustatus1515::ctrl_sts(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Ecu_status_1_515::Ctrl_stsType ret =
+      static_cast<Ecu_status_1_515::Ctrl_stsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Current chassis state (Chassis status)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'chassis_sts',
+// 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 40, 'type':
+// 'int', 'order': 'intel', 'physical_unit': ''}
+int Ecustatus1515::chassis_sts(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Chassis error code (Chassis status)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'chassis_err',
+// 'is_signed_var': False, 'physical_range': '[0|65535]', 'bit': 48, 'type':
+// 'int', 'order': 'intel', 'physical_unit': ''}
+int Ecustatus1515::chassis_err(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 6);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  int ret = x;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Ecustatus1515 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ecustatus1515();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Current speed (Steering status)', 'offset':
+  // 0.0, 'precision': 0.01, 'len': 16, 'name': 'SPEED', 'is_signed_var': True,
+  // 'physical_range': '[0|0]', 'bit': 0, 'type': 'double', 'order': 'intel',
+  // 'physical_unit': 'm/s'}
+  double speed(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current acceleration (Steering status)',
+  // 'offset': 0.0, 'precision': 0.001, 'len': 16, 'name': 'ACC_SPEED',
+  // 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 16, 'type':
+  // 'double', 'order': 'intel', 'physical_unit': 'm/s^2'}
+  double acc_speed(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current Auto-mode state (Chassis status)',
+  // 'enum': {0: 'CTRL_STS_OUT_OF_CONTROL', 1: 'CTRL_STS_UNDER_CONTROL'},
+  // 'precision': 1.0, 'len': 8, 'name': 'CTRL_STS', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Ecu_status_1_515::Ctrl_stsType ctrl_sts(const std::uint8_t* bytes,
+                                          const int32_t length) const;
+
+  // config detail: {'description': 'Current chassis state (Chassis status)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'CHASSIS_STS',
+  // 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 40, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': ''}
+  int chassis_sts(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Chassis error code (Chassis status)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'CHASSIS_ERR',
+  // 'is_signed_var': False, 'physical_range': '[0|65535]', 'bit': 48, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': ''}
+  int chassis_err(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_1_515_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_1_515_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_1_515.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Ecustatus1515Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ecustatus1515Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x01, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ecustatus1515 ecustatus;
+  ecustatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00000001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_DOUBLE_EQ(cd.ch().ecu_status_1_515().speed(), 5.1299999999999999);
+  EXPECT_DOUBLE_EQ(cd.ch().ecu_status_1_515().acc_speed(), 1.0269999999999999);
+  EXPECT_EQ(cd.ch().ecu_status_1_515().ctrl_sts(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_1_515().chassis_sts(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_1_515().chassis_err(), 5139);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
@@ -1,0 +1,124 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ecustatus2516::Ecustatus2516() {}
+const int32_t Ecustatus2516::ID = 0x516;
+
+void Ecustatus2516::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_ch()
+      ->mutable_ecu_status_2_516()
+      ->set_battery_remaining_capacity(
+          battery_remaining_capacity(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_voltage(
+      battery_voltage(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_current(
+      battery_current(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_temperature(
+      battery_temperature(bytes, length));
+}
+
+// config detail: {'description': 'Percentage of battery remaining (BMS
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name':
+// 'battery_remaining_capacity', 'is_signed_var': False, 'physical_range':
+// '[0|0]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
+int Ecustatus2516::battery_remaining_capacity(const std::uint8_t* bytes,
+                                              int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 0);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Current battery voltage (BMS status)',
+// 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'battery_voltage',
+// 'is_signed_var': False, 'physical_range': '[0|0]', 'bit': 16, 'type':
+// 'double', 'order': 'intel', 'physical_unit': 'V'}
+double Ecustatus2516::battery_voltage(const std::uint8_t* bytes,
+                                      int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 2);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+
+// config detail: {'description': 'Current battery current (BMS status)',
+// 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'battery_current',
+// 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 32, 'type':
+// 'double', 'order': 'intel', 'physical_unit': 'A'}
+double Ecustatus2516::battery_current(const std::uint8_t* bytes,
+                                      int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 4);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  x <<= 16;
+  x >>= 16;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+
+// config detail: {'description': 'Current battery temperature (BMS status)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'battery_temperature',
+// 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 48, 'type': 'int',
+// 'order': 'intel', 'physical_unit': '?'}
+int Ecustatus2516::battery_temperature(const std::uint8_t* bytes,
+                                       int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 6);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  x <<= 16;
+  x >>= 16;
+
+  int ret = x;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
@@ -1,0 +1,64 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Ecustatus2516 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ecustatus2516();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Percentage of battery remaining (BMS
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name':
+  // 'BATTERY_REMAINING_CAPACITY', 'is_signed_var': False, 'physical_range':
+  // '[0|0]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
+  int battery_remaining_capacity(const std::uint8_t* bytes,
+                                 const int32_t length) const;
+
+  // config detail: {'description': 'Current battery voltage (BMS status)',
+  // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_VOLTAGE',
+  // 'is_signed_var': False, 'physical_range': '[0|0]', 'bit': 16, 'type':
+  // 'double', 'order': 'intel', 'physical_unit': 'V'}
+  double battery_voltage(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current battery current (BMS status)',
+  // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_CURRENT',
+  // 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 32, 'type':
+  // 'double', 'order': 'intel', 'physical_unit': 'A'}
+  double battery_current(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current battery temperature (BMS status)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'BATTERY_TEMPERATURE',
+  // 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 48, 'type': 'int',
+  // 'order': 'intel', 'physical_unit': '?'}
+  int battery_temperature(const std::uint8_t* bytes,
+                          const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Ecustatus2516Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ecustatus2516Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x01, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ecustatus2516 ecustatus;
+  ecustatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00000001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().ecu_status_2_516().battery_remaining_capacity(), 513);
+  EXPECT_DOUBLE_EQ(cd.ch().ecu_status_2_516().battery_voltage(), 102.7);
+  EXPECT_DOUBLE_EQ(cd.ch().ecu_status_2_516().battery_current(),
+                   460.90000000000003);
+  EXPECT_EQ(cd.ch().ecu_status_2_516().battery_temperature(), 5139);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_3_517.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_3_517.cc
@@ -1,0 +1,156 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ecustatus3517::Ecustatus3517() {}
+const int32_t Ecustatus3517::ID = 0x517;
+
+void Ecustatus3517::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_1(
+      ultrasound_dist_1(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_2(
+      ultrasound_dist_2(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_3(
+      ultrasound_dist_3(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_4(
+      ultrasound_dist_4(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_5(
+      ultrasound_dist_5(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_6(
+      ultrasound_dist_6(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_7(
+      ultrasound_dist_7(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_3_517()->set_ultrasound_dist_8(
+      ultrasound_dist_8(bytes, length));
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 1 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_1', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_1(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 2 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_2', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 8, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_2(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 3 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_3', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 16, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_3(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 4 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_4', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 24, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_4(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 5 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_5', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 32, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_5(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 6 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_6', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 40, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_6(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 7 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_7', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 48, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_7(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Ultrasonic detection distance 8 (Ultrasound
+// status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+// 'ultrasound_dist_8', 'is_signed_var': False, 'physical_range': '[0|0]',
+// 'bit': 56, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+int Ecustatus3517::ultrasound_dist_8(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 7);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Ecustatus3517 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ecustatus3517();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Ultrasonic detection distance 1 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_1', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_1(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 2 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_2', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 8, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_2(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 3 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_3', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 16, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_3(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 4 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_4', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 24, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_4(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 5 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_5', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 32, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_5(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 6 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_6', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 40, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_6(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 7 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_7', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 48, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_7(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Ultrasonic detection distance 8 (Ultrasound
+  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name':
+  // 'ULTRASOUND_DIST_8', 'is_signed_var': False, 'physical_range': '[0|0]',
+  // 'bit': 56, 'type': 'int', 'order': 'intel', 'physical_unit': 'cm'}
+  int ultrasound_dist_8(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_3_517_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_3_517_test.cc
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/ecu_status_3_517.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Ecustatus3517Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ecustatus3517Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x01, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ecustatus3517 ecustatus;
+  ecustatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00000001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_1(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_2(), 2);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_3(), 3);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_4(), 4);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_5(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_6(), 18);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_7(), 19);
+  EXPECT_EQ(cd.ch().ecu_status_3_517().ultrasound_dist_8(), 20);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_command_114.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_command_114.cc
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/gear_command_114.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Gearcommand114::ID = 0x114;
+
+// public
+Gearcommand114::Gearcommand114() { Reset(); }
+
+uint32_t Gearcommand114::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Gearcommand114::UpdateData(uint8_t* data) {
+  set_p_gear_cmd(data, gear_cmd_);
+}
+
+void Gearcommand114::Reset() {
+  // you should check this manually
+  gear_cmd_ = Gear_command_114::GEAR_CMD_NEUTRAL;
+}
+
+Gearcommand114* Gearcommand114::set_gear_cmd(
+    Gear_command_114::Gear_cmdType gear_cmd) {
+  gear_cmd_ = gear_cmd;
+  return this;
+}
+
+// config detail: {'description': 'PRND control(Command)', 'enum': {1:
+// 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
+// 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+// 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+void Gearcommand114::set_p_gear_cmd(uint8_t* data,
+                                    Gear_command_114::Gear_cmdType gear_cmd) {
+  int x = gear_cmd;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_command_114.h
+++ b/modules/canbus/vehicle/ch/protocol/gear_command_114.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Gearcommand114 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Gearcommand114();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'PRND control(Command)', 'enum': {1:
+  // 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
+  // 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Gearcommand114* set_gear_cmd(Gear_command_114::Gear_cmdType gear_cmd);
+
+ private:
+  // config detail: {'description': 'PRND control(Command)', 'enum': {1:
+  // 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
+  // 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  void set_p_gear_cmd(uint8_t* data, Gear_command_114::Gear_cmdType gear_cmd);
+
+ private:
+  Gear_command_114::Gear_cmdType gear_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_command_114_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_command_114_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/gear_command_114.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Gearcommand114Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Gearcommand114Test, simple) {
+  Gearcommand114 gearcommand;
+  EXPECT_EQ(gearcommand.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  gearcommand.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000011);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_status_514.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_status_514.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/gear_status_514.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Gearstatus514::Gearstatus514() {}
+const int32_t Gearstatus514::ID = 0x514;
+
+void Gearstatus514::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_gear_status_514()->set_gear_sts(
+      gear_sts(bytes, length));
+}
+
+// config detail: {'description': 'PRND control(Status)', 'enum': {1:
+// 'GEAR_STS_PARK', 2: 'GEAR_STS_REVERSE', 3: 'GEAR_STS_NEUTRAL', 4:
+// 'GEAR_STS_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'gear_sts',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+// 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+Gear_status_514::Gear_stsType Gearstatus514::gear_sts(const std::uint8_t* bytes,
+                                                      int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Gear_status_514::Gear_stsType ret =
+      static_cast<Gear_status_514::Gear_stsType>(x);
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_status_514.h
+++ b/modules/canbus/vehicle/ch/protocol/gear_status_514.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Gearstatus514 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Gearstatus514();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'PRND control(Status)', 'enum': {1:
+  // 'GEAR_STS_PARK', 2: 'GEAR_STS_REVERSE', 3: 'GEAR_STS_NEUTRAL', 4:
+  // 'GEAR_STS_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_STS',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Gear_status_514::Gear_stsType gear_sts(const std::uint8_t* bytes,
+                                         const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/gear_status_514_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_status_514_test.cc
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/gear_status_514.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Gearstatus514Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Gearstatus514Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Gearstatus514 gearstatus;
+  gearstatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().gear_status_514().gear_sts(), 1);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_command_112.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_command_112.cc
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/steer_command_112.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Steercommand112::ID = 0x112;
+
+// public
+Steercommand112::Steercommand112() { Reset(); }
+
+uint32_t Steercommand112::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Steercommand112::UpdateData(uint8_t* data) {
+  set_p_steer_angle_en_ctrl(data, steer_angle_en_ctrl_);
+  set_p_steer_angle_cmd(data, steer_angle_cmd_);
+}
+
+void Steercommand112::Reset() {
+  // you should check this manually
+  steer_angle_en_ctrl_ = Steer_command_112::STEER_ANGLE_EN_CTRL_DISABLE;
+  steer_angle_cmd_ = 0.0;
+}
+
+Steercommand112* Steercommand112::set_steer_angle_en_ctrl(
+    Steer_command_112::Steer_angle_en_ctrlType steer_angle_en_ctrl) {
+  steer_angle_en_ctrl_ = steer_angle_en_ctrl;
+  return this;
+}
+
+// config detail: {'description': 'steering angle enable bit(Command)', 'enum':
+// {0: 'STEER_ANGLE_EN_CTRL_DISABLE', 1: 'STEER_ANGLE_EN_CTRL_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'STEER_ANGLE_EN_CTRL', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+void Steercommand112::set_p_steer_angle_en_ctrl(
+    uint8_t* data,
+    Steer_command_112::Steer_angle_en_ctrlType steer_angle_en_ctrl) {
+  int x = steer_angle_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+Steercommand112* Steercommand112::set_steer_angle_cmd(double steer_angle_cmd) {
+  steer_angle_cmd_ = steer_angle_cmd;
+  return this;
+}
+
+// config detail: {'description': 'Current steering angle(Command)', 'offset':
+// 0.0, 'precision': 0.001, 'len': 16, 'name': 'STEER_ANGLE_CMD',
+// 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8, 'type':
+// 'double', 'order': 'intel', 'physical_unit': 'radian'}
+void Steercommand112::set_p_steer_angle_cmd(uint8_t* data,
+                                            double steer_angle_cmd) {
+  steer_angle_cmd = ProtocolData::BoundedValue(-0.524, 0.524, steer_angle_cmd);
+  int x = steer_angle_cmd / 0.001000;
+  uint8_t t = 0;
+
+  t = x & 0xFF;
+  Byte to_set0(data + 1);
+  to_set0.set_value(t, 0, 8);
+  x >>= 8;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 2);
+  to_set1.set_value(t, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_command_112.h
+++ b/modules/canbus/vehicle/ch/protocol/steer_command_112.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Steercommand112 : public ::apollo::drivers::canbus::ProtocolData<
+                            ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Steercommand112();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'steering angle enable bit(Command)',
+  // 'enum': {0: 'STEER_ANGLE_EN_CTRL_DISABLE', 1:
+  // 'STEER_ANGLE_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'STEER_ANGLE_EN_CTRL', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Steercommand112* set_steer_angle_en_ctrl(
+      Steer_command_112::Steer_angle_en_ctrlType steer_angle_en_ctrl);
+
+  // config detail: {'description': 'Current steering angle(Command)', 'offset':
+  // 0.0, 'precision': 0.001, 'len': 16, 'name': 'STEER_ANGLE_CMD',
+  // 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8,
+  // 'type': 'double', 'order': 'intel', 'physical_unit': 'radian'}
+  Steercommand112* set_steer_angle_cmd(double steer_angle_cmd);
+
+ private:
+  // config detail: {'description': 'steering angle enable bit(Command)',
+  // 'enum': {0: 'STEER_ANGLE_EN_CTRL_DISABLE', 1:
+  // 'STEER_ANGLE_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'STEER_ANGLE_EN_CTRL', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  void set_p_steer_angle_en_ctrl(
+      uint8_t* data,
+      Steer_command_112::Steer_angle_en_ctrlType steer_angle_en_ctrl);
+
+  // config detail: {'description': 'Current steering angle(Command)', 'offset':
+  // 0.0, 'precision': 0.001, 'len': 16, 'name': 'STEER_ANGLE_CMD',
+  // 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8,
+  // 'type': 'double', 'order': 'intel', 'physical_unit': 'radian'}
+  void set_p_steer_angle_cmd(uint8_t* data, double steer_angle_cmd);
+
+ private:
+  Steer_command_112::Steer_angle_en_ctrlType steer_angle_en_ctrl_;
+  double steer_angle_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_command_112_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_command_112_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/steer_command_112.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Steercommand112Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Steercommand112Test, simple) {
+  Steercommand112 steercommand;
+  EXPECT_EQ(steercommand.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  steercommand.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b00000000);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/steer_status__512.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Steerstatus512::Steerstatus512() {}
+const int32_t Steerstatus512::ID = 0x512;
+
+void Steerstatus512::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_steer_status__512()->set_steer_angle_en_sts(
+      steer_angle_en_sts(bytes, length));
+  chassis->mutable_ch()->mutable_steer_status__512()->set_steer_angle_sts(
+      steer_angle_sts(bytes, length));
+}
+
+// config detail: {'description': 'steering angle enable bit(Status)', 'enum':
+// {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'steer_angle_en_sts', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Steer_status__512::Steer_angle_en_stsType Steerstatus512::steer_angle_en_sts(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Steer_status__512::Steer_angle_en_stsType ret =
+      static_cast<Steer_status__512::Steer_angle_en_stsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Current steering angle(Status)', 'offset':
+// 0.0, 'precision': 0.001, 'len': 16, 'name': 'steer_angle_sts',
+// 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8, 'type':
+// 'double', 'order': 'intel', 'physical_unit': 'radian'}
+double Steerstatus512::steer_angle_sts(const std::uint8_t* bytes,
+                                       int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  x <<= 16;
+  x >>= 16;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.h
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Steerstatus512 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Steerstatus512();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'steering angle enable bit(Status)', 'enum':
+  // {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE'},
+  // 'precision': 1.0, 'len': 8, 'name': 'STEER_ANGLE_EN_STS', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Steer_status__512::Steer_angle_en_stsType steer_angle_en_sts(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Current steering angle(Status)', 'offset':
+  // 0.0, 'precision': 0.001, 'len': 16, 'name': 'STEER_ANGLE_STS',
+  // 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8,
+  // 'type': 'double', 'order': 'intel', 'physical_unit': 'radian'}
+  double steer_angle_sts(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512_test.cc
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/steer_status__512.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Steerstatus512Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Steerstatus512Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Steerstatus512 steerstatus;
+  steerstatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().steer_status__512().steer_angle_en_sts(), 1);
+  EXPECT_DOUBLE_EQ(cd.ch().steer_status__512().steer_angle_sts(),
+                   0.77000000000000002);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_command_110.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_command_110.cc
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/throttle_command_110.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Throttlecommand110::ID = 0x110;
+
+// public
+Throttlecommand110::Throttlecommand110() { Reset(); }
+
+uint32_t Throttlecommand110::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Throttlecommand110::UpdateData(uint8_t* data) {
+  set_p_throttle_pedal_en_ctrl(data, throttle_pedal_en_ctrl_);
+  set_p_throttle_pedal_cmd(data, throttle_pedal_cmd_);
+}
+
+void Throttlecommand110::Reset() {
+  // you should check this manually
+  throttle_pedal_en_ctrl_ =
+      Throttle_command_110::THROTTLE_PEDAL_EN_CTRL_DISABLE;
+  throttle_pedal_cmd_ = 0;
+}
+
+Throttlecommand110* Throttlecommand110::set_throttle_pedal_en_ctrl(
+    Throttle_command_110::Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl) {
+  throttle_pedal_en_ctrl_ = throttle_pedal_en_ctrl;
+  return this;
+}
+
+// config detail: {'description': 'throttle pedal enable bit(Command)', 'enum':
+// {0: 'THROTTLE_PEDAL_EN_CTRL_DISABLE', 1: 'THROTTLE_PEDAL_EN_CTRL_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_EN_CTRL',
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0,
+// 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+void Throttlecommand110::set_p_throttle_pedal_en_ctrl(
+    uint8_t* data,
+    Throttle_command_110::Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl) {
+  int x = throttle_pedal_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+Throttlecommand110* Throttlecommand110::set_throttle_pedal_cmd(
+    int throttle_pedal_cmd) {
+  throttle_pedal_cmd_ = throttle_pedal_cmd;
+  return this;
+}
+
+// config detail: {'description': 'Percentage of throttle pedal(Command)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_CMD',
+// 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type': 'int',
+// 'order': 'intel', 'physical_unit': '%'}
+void Throttlecommand110::set_p_throttle_pedal_cmd(uint8_t* data,
+                                                  int throttle_pedal_cmd) {
+  throttle_pedal_cmd = ProtocolData::BoundedValue(0, 100, throttle_pedal_cmd);
+  int x = throttle_pedal_cmd;
+
+  Byte to_set(data + 1);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_command_110.h
+++ b/modules/canbus/vehicle/ch/protocol/throttle_command_110.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Throttlecommand110 : public ::apollo::drivers::canbus::ProtocolData<
+                               ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Throttlecommand110();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'throttle pedal enable bit(Command)',
+  // 'enum': {0: 'THROTTLE_PEDAL_EN_CTRL_DISABLE', 1:
+  // 'THROTTLE_PEDAL_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'THROTTLE_PEDAL_EN_CTRL', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Throttlecommand110* set_throttle_pedal_en_ctrl(
+      Throttle_command_110::Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl);
+
+  // config detail: {'description': 'Percentage of throttle pedal(Command)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_CMD',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  Throttlecommand110* set_throttle_pedal_cmd(int throttle_pedal_cmd);
+
+ private:
+  // config detail: {'description': 'throttle pedal enable bit(Command)',
+  // 'enum': {0: 'THROTTLE_PEDAL_EN_CTRL_DISABLE', 1:
+  // 'THROTTLE_PEDAL_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'THROTTLE_PEDAL_EN_CTRL', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  void set_p_throttle_pedal_en_ctrl(
+      uint8_t* data,
+      Throttle_command_110::Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl);
+
+  // config detail: {'description': 'Percentage of throttle pedal(Command)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_CMD',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  void set_p_throttle_pedal_cmd(uint8_t* data, int throttle_pedal_cmd);
+
+ private:
+  Throttle_command_110::Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl_;
+  int throttle_pedal_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_command_110_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_command_110_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/throttle_command_110.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Throttlecommand110Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Throttlecommand110Test, simple) {
+  Throttlecommand110 throttlecommand;
+  EXPECT_EQ(throttlecommand.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  throttlecommand.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/throttle_status__510.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Throttlestatus510::Throttlestatus510() {}
+const int32_t Throttlestatus510::ID = 0x510;
+
+void Throttlestatus510::Parse(const std::uint8_t* bytes, int32_t length,
+                              ChassisDetail* chassis) const {
+  chassis->mutable_ch()
+      ->mutable_throttle_status__510()
+      ->set_throttle_pedal_en_sts(throttle_pedal_en_sts(bytes, length));
+  chassis->mutable_ch()->mutable_throttle_status__510()->set_throttle_pedal_sts(
+      throttle_pedal_sts(bytes, length));
+}
+
+// config detail: {'description': 'throttle pedal enable bit(Status)', 'enum':
+// {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE'},
+// 'precision': 1.0, 'len': 8, 'name': 'throttle_pedal_en_sts', 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Throttle_status__510::Throttle_pedal_en_stsType
+Throttlestatus510::throttle_pedal_en_sts(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Throttle_status__510::Throttle_pedal_en_stsType ret =
+      static_cast<Throttle_status__510::Throttle_pedal_en_stsType>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Percentage of throttle pedal(Status)',
+// 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'throttle_pedal_sts',
+// 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type': 'int',
+// 'order': 'intel', 'physical_unit': '%'}
+int Throttlestatus510::throttle_pedal_sts(const std::uint8_t* bytes,
+                                          int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Throttlestatus510 : public ::apollo::drivers::canbus::ProtocolData<
+                              ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Throttlestatus510();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'throttle pedal enable bit(Status)', 'enum':
+  // {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE'},
+  // 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_EN_STS',
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0,
+  // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Throttle_status__510::Throttle_pedal_en_stsType throttle_pedal_en_sts(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Percentage of throttle pedal(Status)',
+  // 'offset': 0.0, 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_STS',
+  // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '%'}
+  int throttle_pedal_sts(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510_test.cc
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/throttle_status__510.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Throttlestatus510Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Throttlestatus510Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Throttlestatus510 throttlestatus;
+  throttlestatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().throttle_status__510().throttle_pedal_en_sts(), 1);
+  EXPECT_EQ(cd.ch().throttle_status__510().throttle_pedal_sts(), 2);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_command_113.cc
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_command_113.cc
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h"
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Turnsignalcommand113::ID = 0x113;
+
+// public
+Turnsignalcommand113::Turnsignalcommand113() { Reset(); }
+
+uint32_t Turnsignalcommand113::GetPeriod() const {
+  // modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Turnsignalcommand113::UpdateData(uint8_t* data) {
+  set_p_turn_signal_cmd(data, turn_signal_cmd_);
+}
+
+void Turnsignalcommand113::Reset() {
+  // you should check this manually
+  turn_signal_cmd_ = Turnsignal_command_113::TURN_SIGNAL_CMD_NONE;
+}
+
+Turnsignalcommand113* Turnsignalcommand113::set_turn_signal_cmd(
+    Turnsignal_command_113::Turn_signal_cmdType turn_signal_cmd) {
+  turn_signal_cmd_ = turn_signal_cmd;
+  return this;
+}
+
+// config detail: {'description': 'Lighting control(Command)', 'enum': {0:
+// 'TURN_SIGNAL_CMD_NONE', 1: 'TURN_SIGNAL_CMD_LEFT', 2:
+// 'TURN_SIGNAL_CMD_RIGHT'}, 'precision': 1.0, 'len': 8, 'name':
+// 'TURN_SIGNAL_CMD', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+// '[0|2]', 'bit': 0, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+void Turnsignalcommand113::set_p_turn_signal_cmd(
+    uint8_t* data,
+    Turnsignal_command_113::Turn_signal_cmdType turn_signal_cmd) {
+  int x = turn_signal_cmd;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h
@@ -1,0 +1,63 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Turnsignalcommand113 : public ::apollo::drivers::canbus::ProtocolData<
+                                 ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Turnsignalcommand113();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'description': 'Lighting control(Command)', 'enum': {0:
+  // 'TURN_SIGNAL_CMD_NONE', 1: 'TURN_SIGNAL_CMD_LEFT', 2:
+  // 'TURN_SIGNAL_CMD_RIGHT'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'TURN_SIGNAL_CMD', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|2]', 'bit': 0, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Turnsignalcommand113* set_turn_signal_cmd(
+      Turnsignal_command_113::Turn_signal_cmdType turn_signal_cmd);
+
+ private:
+  // config detail: {'description': 'Lighting control(Command)', 'enum': {0:
+  // 'TURN_SIGNAL_CMD_NONE', 1: 'TURN_SIGNAL_CMD_LEFT', 2:
+  // 'TURN_SIGNAL_CMD_RIGHT'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'TURN_SIGNAL_CMD', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|2]', 'bit': 0, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  void set_p_turn_signal_cmd(
+      uint8_t* data,
+      Turnsignal_command_113::Turn_signal_cmdType turn_signal_cmd);
+
+ private:
+  Turnsignal_command_113::Turn_signal_cmdType turn_signal_cmd_;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_command_113_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_command_113_test.cc
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_command_113.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Turnsignalcommand113Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Turnsignalcommand113Test, simple) {
+  Turnsignalcommand113 turnsignalcommand;
+  EXPECT_EQ(turnsignalcommand.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68};
+  turnsignalcommand.UpdateData(data);
+  EXPECT_EQ(data[0], 0b00000000);
+  EXPECT_EQ(data[1], 0b01100010);
+  EXPECT_EQ(data[2], 0b01100011);
+  EXPECT_EQ(data[3], 0b01100100);
+  EXPECT_EQ(data[4], 0b01100101);
+  EXPECT_EQ(data[5], 0b01100110);
+  EXPECT_EQ(data[6], 0b01100111);
+  EXPECT_EQ(data[7], 0b01101000);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_status__513.cc
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_status__513.cc
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h"
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+using ::apollo::drivers::canbus::Byte;
+
+Turnsignalstatus513::Turnsignalstatus513() {}
+const int32_t Turnsignalstatus513::ID = 0x513;
+
+void Turnsignalstatus513::Parse(const std::uint8_t* bytes, int32_t length,
+                                ChassisDetail* chassis) const {
+  chassis->mutable_ch()->mutable_turnsignal_status__513()->set_turn_signal_sts(
+      turn_signal_sts(bytes, length));
+}
+
+// config detail: {'description': 'Lighting control(Status)', 'enum': {0:
+// 'TURN_SIGNAL_STS_NONE', 1: 'TURN_SIGNAL_STS_LEFT', 2:
+// 'TURN_SIGNAL_STS_RIGHT'}, 'precision': 1.0, 'len': 8, 'name':
+// 'turn_signal_sts', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+// '[0|2]', 'bit': 0, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+Turnsignal_status__513::Turn_signal_stsType
+Turnsignalstatus513::turn_signal_sts(const std::uint8_t* bytes,
+                                     int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Turnsignal_status__513::Turn_signal_stsType ret =
+      static_cast<Turnsignal_status__513::Turn_signal_stsType>(x);
+  return ret;
+}
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+
+class Turnsignalstatus513 : public ::apollo::drivers::canbus::ProtocolData<
+                                ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Turnsignalstatus513();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'description': 'Lighting control(Status)', 'enum': {0:
+  // 'TURN_SIGNAL_STS_NONE', 1: 'TURN_SIGNAL_STS_LEFT', 2:
+  // 'TURN_SIGNAL_STS_RIGHT'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'TURN_SIGNAL_STS', 'is_signed_var': False, 'offset': 0.0, 'physical_range':
+  // '[0|2]', 'bit': 0, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Turnsignal_status__513::Turn_signal_stsType turn_signal_sts(
+      const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/ch/protocol/turnsignal_status__513_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/turnsignal_status__513_test.cc
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/ch/protocol/turnsignal_status__513.h"
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace ch {
+class Turnsignalstatus513Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Turnsignalstatus513Test, General) {
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Turnsignalstatus513 turnsignalstatus;
+  turnsignalstatus.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000010);
+  EXPECT_EQ(data[2], 0b00000011);
+  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[5], 0b00010010);
+  EXPECT_EQ(data[6], 0b00010011);
+  EXPECT_EQ(data[7], 0b00010100);
+
+  EXPECT_EQ(cd.ch().turnsignal_status__513().turn_signal_sts(), 1);
+}
+
+}  // namespace ch
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/vehicle_factory.cc
+++ b/modules/canbus/vehicle/vehicle_factory.cc
@@ -18,6 +18,7 @@
 #include "modules/canbus/proto/vehicle_parameter.pb.h"
 #include "modules/canbus/vehicle/gem/gem_vehicle_factory.h"
 #include "modules/canbus/vehicle/lincoln/lincoln_vehicle_factory.h"
+#include "modules/canbus/vehicle/ch/ch_vehicle_factory.h"
 
 namespace apollo {
 namespace canbus {
@@ -28,6 +29,9 @@ void VehicleFactory::RegisterVehicleFactory() {
   });
   Register(VehicleParameter::GEM, []() -> AbstractVehicleFactory * {
     return new GemVehicleFactory();
+  });
+  Register(VehicleParameter::CH, []() -> AbstractVehicleFactory * {
+    return new ChVehicleFactory();
   });
 }
 


### PR DESCRIPTION
Add coolhigh canbus code which is cherry-picked from branch v3.1_dev，there are "add coolhigh canbus code","modified proto files","add coolhigh vehicle parameters and configuration files","modified gnss config file","delete the /apollo/modules/calibration/data/ch, it will be push to apollo-internal","modified the /apollo/modules/canbus/vehicle/ch/protocal/BUILD" and "modified the modules/canbus/vehicle/ch/protocol/BUILD , and add the test file".