### PR TITLE
Control: compute the acceleration, jerk variables for Mpc Controller

### DIFF
--- a/modules/control/controller/mpc_controller.cc
+++ b/modules/control/controller/mpc_controller.cc
@@ -524,6 +524,7 @@ void MPCController::UpdateState(SimpleMPCDebug *debug) {
                        VehicleStateProvider::Instance()->heading(),
                        VehicleStateProvider::Instance()->linear_velocity(),
                        VehicleStateProvider::Instance()->angular_velocity(),
+                       VehicleStateProvider::Instance()->linear_acceleration(),
                        trajectory_analyzer_, debug);
 
   // State matrix update;
@@ -562,8 +563,8 @@ void MPCController::FeedforwardUpdate(SimpleMPCDebug *debug) {
 
 void MPCController::ComputeLateralErrors(
     const double x, const double y, const double theta, const double linear_v,
-    const double angular_v, const TrajectoryAnalyzer &trajectory_analyzer,
-    SimpleMPCDebug *debug) {
+    const double angular_v, const double linear_a,
+    const TrajectoryAnalyzer &trajectory_analyzer, SimpleMPCDebug *debug) {
   const auto matched_point =
       trajectory_analyzer.QueryNearestPointByPosition(x, y);
 
@@ -575,23 +576,59 @@ void MPCController::ComputeLateralErrors(
   // d_error = cos_matched_theta * dy - sin_matched_theta * dx;
   debug->set_lateral_error(cos_matched_theta * dy - sin_matched_theta * dx);
 
+  // matched_theta = matched_point.path_point().theta();
+  debug->set_ref_heading(matched_point.path_point().theta());
   const double delta_theta =
-      common::math::NormalizeAngle(theta - matched_point.path_point().theta());
+      common::math::NormalizeAngle(theta - debug->ref_heading());
+  debug->set_heading_error(delta_theta);
+
   const double sin_delta_theta = std::sin(delta_theta);
   // d_error_dot = chassis_v * sin_delta_theta;
-  debug->set_lateral_error_rate(linear_v * sin_delta_theta);
+  double lateral_error_dot = linear_v * sin_delta_theta;
+  double lateral_error_dot_dot = linear_a * sin_delta_theta;
+  if (FLAGS_reverse_heading_control) {
+    if (VehicleStateProvider::Instance()->gear() ==
+        canbus::Chassis::GEAR_REVERSE) {
+      lateral_error_dot = -lateral_error_dot;
+      lateral_error_dot_dot = -lateral_error_dot_dot;
+    }
+  }
 
+  debug->set_lateral_error_rate(lateral_error_dot);
+  debug->set_lateral_acceleration(lateral_error_dot_dot);
+  debug->set_lateral_jerk(
+      (debug->lateral_acceleration() - previous_lateral_acceleration_) / ts_);
+  previous_lateral_acceleration_ = debug->lateral_acceleration();
+
+  // matched_kappa = matched_point.path_point().kappa();
+  debug->set_curvature(matched_point.path_point().kappa());
   // theta_error = delta_theta;
   debug->set_heading_error(delta_theta);
   // theta_error_dot = angular_v - matched_point.path_point().kappa() *
   // matched_point.v();
-  debug->set_heading_error_rate(angular_v - matched_point.path_point().kappa() *
-                                                matched_point.v());
+  debug->set_heading_rate(angular_v);
+  debug->set_ref_heading_rate(debug->curvature() * matched_point.v());
+  debug->set_heading_error_rate(debug->heading_rate() -
+                                debug->ref_heading_rate());
 
-  // matched_theta = matched_point.path_point().theta();
-  debug->set_ref_heading(matched_point.path_point().theta());
-  // matched_kappa = matched_point.path_point().kappa();
-  debug->set_curvature(matched_point.path_point().kappa());
+  debug->set_heading_acceleration(
+      (debug->heading_rate() - previous_heading_rate_) / ts_);
+  debug->set_ref_heading_acceleration(
+      (debug->ref_heading_rate() - previous_ref_heading_rate_) / ts_);
+  debug->set_heading_error_acceleration(debug->heading_acceleration() -
+                                        debug->ref_heading_acceleration());
+  previous_heading_rate_ = debug->heading_rate();
+  previous_ref_heading_rate_ = debug->ref_heading_rate();
+
+  debug->set_heading_jerk(
+      (debug->heading_acceleration() - previous_heading_acceleration_) / ts_);
+  debug->set_ref_heading_jerk(
+      (debug->ref_heading_acceleration() - previous_ref_heading_acceleration_) /
+      ts_);
+  debug->set_heading_error_jerk(debug->heading_jerk() -
+                                debug->ref_heading_jerk());
+  previous_heading_acceleration_ = debug->heading_acceleration();
+  previous_ref_heading_acceleration_ = debug->ref_heading_acceleration();
 }
 
 void MPCController::ComputeLongitudinalErrors(
@@ -625,16 +662,37 @@ void MPCController::ComputeLongitudinalErrors(
 
   ADEBUG << "matched point:" << matched_point.DebugString();
   ADEBUG << "reference point:" << reference_point.DebugString();
-  debug->set_station_error(reference_point.path_point().s() - s_matched);
-  debug->set_speed_error(reference_point.v() - s_dot_matched);
+
+  const double linear_v = VehicleStateProvider::Instance()->linear_velocity();
+  const double linear_a =
+      VehicleStateProvider::Instance()->linear_acceleration();
+  double heading_error = common::math::NormalizeAngle(
+      VehicleStateProvider::Instance()->heading() - matched_point.theta());
+  double lon_speed = linear_v * std::cos(heading_error);
+  double lon_acceleration = linear_a * std::cos(heading_error);
+  double one_minus_kappa_lat_error = 1 - reference_point.path_point().kappa() *
+                                             linear_v * std::sin(heading_error);
 
   debug->set_station_reference(reference_point.path_point().s());
-  debug->set_speed_reference(reference_point.v());
-  debug->set_acceleration_reference(reference_point.a());
-
   debug->set_station_feedback(s_matched);
-  debug->set_speed_feedback(
-      VehicleStateProvider::Instance()->linear_velocity());
+  debug->set_station_error(reference_point.path_point().s() - s_matched);
+  debug->set_speed_reference(reference_point.v());
+  debug->set_speed_feedback(lon_speed);
+  debug->set_speed_error(reference_point.v() - s_dot_matched);
+  debug->set_acceleration_reference(reference_point.a());
+  debug->set_acceleration_feedback(lon_acceleration);
+  debug->set_acceleration_error(reference_point.a() -
+                                lon_acceleration / one_minus_kappa_lat_error);
+  double jerk_reference =
+      (debug->acceleration_reference() - previous_acceleration_reference_) /
+      ts_;
+  double lon_jerk =
+      (debug->acceleration_feedback() - previous_acceleration_) / ts_;
+  debug->set_jerk_reference(jerk_reference);
+  debug->set_jerk_feedback(lon_jerk);
+  debug->set_jerk_error(jerk_reference - lon_jerk / one_minus_kappa_lat_error);
+  previous_acceleration_reference_ = debug->acceleration_reference();
+  previous_acceleration_ = debug->acceleration_feedback();
 }
 
 }  // namespace control

--- a/modules/control/controller/mpc_controller.h
+++ b/modules/control/controller/mpc_controller.h
@@ -108,6 +108,7 @@ class MPCController : public Controller {
 
   void ComputeLateralErrors(const double x, const double y, const double theta,
                             const double linear_v, const double angular_v,
+                            const double linear_a,
                             const TrajectoryAnalyzer &trajectory_analyzer,
                             SimpleMPCDebug *debug);
 
@@ -208,6 +209,21 @@ class MPCController : public Controller {
   double previous_heading_error_ = 0.0;
   // lateral distance to reference trajectory of last control cycle
   double previous_lateral_error_ = 0.0;
+
+  // lateral dynamic variables for computing the differential valute to
+  // estimate acceleration and jerk
+  double previous_lateral_acceleration_ = 0.0;
+
+  double previous_heading_rate_ = 0.0;
+  double previous_ref_heading_rate_ = 0.0;
+
+  double previous_heading_acceleration_ = 0.0;
+  double previous_ref_heading_acceleration_ = 0.0;
+
+  // longitudinal dynamic variables for computing the differential valute to
+  // estimate acceleration and jerk
+  double previous_acceleration_ = 0.0;
+  double previous_acceleration_reference_ = 0.0;
 
   // parameters for mpc solver; number of iterations
   int mpc_max_iteration_ = 0;

--- a/modules/control/controller/mpc_controller_test.cc
+++ b/modules/control/controller/mpc_controller_test.cc
@@ -54,10 +54,11 @@ class MPCControllerTest : public ::testing::Test, MPCController {
 
   void ComputeLateralErrors(const double x, const double y, const double theta,
                             const double linear_v, const double angular_v,
+                            const double linear_a,
                             const TrajectoryAnalyzer &trajectory_analyzer,
                             SimpleMPCDebug *debug) {
     MPCController::ComputeLateralErrors(x, y, theta, linear_v, angular_v,
-                                        trajectory_analyzer, debug);
+                                        linear_a, trajectory_analyzer, debug);
   }
 
  protected:
@@ -111,7 +112,7 @@ TEST_F(MPCControllerTest, ComputeLateralErrors) {
   ComputeLateralErrors(
       vehicle_state->x(), vehicle_state->y(), vehicle_state->heading(),
       vehicle_state->linear_velocity(), vehicle_state->angular_velocity(),
-      trajectory_analyzer, debug);
+      vehicle_state->linear_acceleration(), trajectory_analyzer, debug);
 
   double theta_error_expected = -0.03549;
   double theta_error_dot_expected = 0.0044552856731;

--- a/modules/control/proto/control_cmd.proto
+++ b/modules/control/proto/control_cmd.proto
@@ -179,6 +179,32 @@ message SimpleMPCDebug {
   optional double steer_angle_feedforward_compensation = 32;
   repeated double matrix_q_updated = 33;  // matrix_q_updated_ size = 6
   repeated double matrix_r_updated = 34;  // matrix_r_updated_ size = 2
+
+  // time derivative of lateral error rate, in m/s^2
+  optional double lateral_acceleration = 35;
+  // second time derivative of lateral error rate, in m/s^3
+  optional double lateral_jerk = 36;
+
+  optional double ref_heading_rate = 37;
+  optional double heading_rate = 38;
+
+  // heading_acceleration, as known as yaw acceleration, is the time derivative
+  // of heading rate,  in rad/s^2
+  optional double ref_heading_acceleration = 39;
+  optional double heading_acceleration = 40;
+  optional double heading_error_acceleration = 41;
+
+  // heading_jerk, as known as yaw jerk, is the second time derivative of
+  // heading rate, in rad/s^3
+  optional double ref_heading_jerk = 42;
+  optional double heading_jerk = 43;
+  optional double heading_error_jerk = 44;
+
+  optional double acceleration_feedback = 45;
+  optional double acceleration_error = 46;
+  optional double jerk_reference = 47;
+  optional double jerk_feedback = 48;
+  optional double jerk_error = 49;
 }
 
 message InputDebug {


### PR DESCRIPTION
Similar modifications on MPC controller, as on lon/lat controllers. 
Generated records already verified by Dreamland simulation