### PR TITLE
Cyber: fix cyber_launch bug from #7382

### DIFF
--- a/cyber/tools/cyber_launch/cyber_launch
+++ b/cyber/tools/cyber_launch/cyber_launch
@@ -103,7 +103,7 @@ def module_monitor(mod):
     while True:
         line = mod.popen.stdout.readline()
         if line:
-            logger.debug('%s: %s' % (mod.name, line.strip('\n')))
+            logger.debug('%s# %s' % (mod.name, line.strip('\n')))
             continue
         time.sleep(0.01)
 


### PR DESCRIPTION
* fix a bug on cyber_launch from [#7382](https://github.com/ApolloAuto/apollo/pull/7382/files#diff-f3273e146da2e951b7535a9a181f606dL97), which cause logging info overwhelming.

The ColoredFormatter class is using '#' to split the logging, please don't change the logging info. @freeHackOfJeff 