### PR TITLE
apollo.sh experimental_multi_threaded_digest

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -698,6 +698,7 @@ function main() {
   check_esd_files
 
   DEFINES="--define ARCH=${MACHINE_ARCH} --define CAN_CARD=${CAN_CARD} --cxxopt=-DUSE_ESD_CAN=${USE_ESD_CAN}"
+  # Enable bazel's feature to compute md5 checksums in parallel
   DEFINES="${DEFINES} --experimental_multi_threaded_digest"
 
   if [ ${MACHINE_ARCH} == "x86_64" ]; then

--- a/apollo.sh
+++ b/apollo.sh
@@ -698,6 +698,7 @@ function main() {
   check_esd_files
 
   DEFINES="--define ARCH=${MACHINE_ARCH} --define CAN_CARD=${CAN_CARD} --cxxopt=-DUSE_ESD_CAN=${USE_ESD_CAN}"
+  DEFINES="${DEFINES} --experimental_multi_threaded_digest"
 
   if [ ${MACHINE_ARCH} == "x86_64" ]; then
     DEFINES="${DEFINES} --copt=-mavx2"


### PR DESCRIPTION
enable bazel's feature to compute md5 checksums in parallel.

`docker/scripts/dev_start.sh` brings in over a GB of map data. Then, the maps are globbed and turned into a `file_group` in https://github.com/ApolloAuto/apollo/blob/master/modules/map/BUILD#L3. bazel server will compute the md5 sums and keep it in memory the first time `bazel build` or `bazel test` runs on `modules/map`. Digesting these files takes longer as file sizes grow.

Running in parallel is much faster and doesn't seem to cause any problems.