### PR TITLE
Planning and Relativemap: Updated with followings in order to use nav…

### DIFF
--- a/modules/common/configs/config_gflags.cc
+++ b/modules/common/configs/config_gflags.cc
@@ -58,3 +58,7 @@ DEFINE_string(
 DEFINE_double(look_forward_time_sec, 8.0,
               "look forward time times adc speed to calculate this distance "
               "when creating reference line from routing");
+
+// If you want to use relative map in std model with utm coor , set it true.
+DEFINE_bool(use_navigation_with_utm, false,
+            "Use relative map with utm coor instead of hdmap.");

--- a/modules/common/configs/config_gflags.h
+++ b/modules/common/configs/config_gflags.h
@@ -43,4 +43,6 @@ DECLARE_string(localization_tf2_child_frame_id);
 DECLARE_bool(use_navigation_mode);
 DECLARE_string(navigation_mode_end_way_point_file);
 
+DECLARE_bool(use_navigation_with_utm);
+
 #endif  // MODULES_COMMON_CONFIGS_GFLAGS_H_

--- a/modules/map/hdmap/hdmap_util.cc
+++ b/modules/map/hdmap/hdmap_util.cc
@@ -109,7 +109,7 @@ std::unique_ptr<HDMap> HDMapUtil::sim_map_ = nullptr;
 std::mutex HDMapUtil::sim_map_mutex_;
 
 const HDMap* HDMapUtil::BaseMapPtr() {
-  if (FLAGS_use_navigation_mode) {
+  if (FLAGS_use_navigation_mode || FLAGS_use_navigation_with_utm) {
     std::lock_guard<std::mutex> lock(base_map_mutex_);
     auto* relative_map = AdapterManager::GetRelativeMap();
     if (!relative_map) {
@@ -141,7 +141,7 @@ const HDMap* HDMapUtil::BaseMapPtr() {
 const HDMap& HDMapUtil::BaseMap() { return *CHECK_NOTNULL(BaseMapPtr()); }
 
 const HDMap* HDMapUtil::SimMapPtr() {
-  if (FLAGS_use_navigation_mode) {
+  if (FLAGS_use_navigation_mode || FLAGS_use_navigation_with_utm) {
     return BaseMapPtr();
   } else if (sim_map_ == nullptr) {
     std::lock_guard<std::mutex> lock(sim_map_mutex_);

--- a/modules/map/relative_map/BUILD
+++ b/modules/map/relative_map/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "navigation_lane.h",
     ],
     deps = [
+        "//modules/common/configs:config_gflags",
         "//modules/common:log",
         "//modules/common/proto:pnc_point_proto",
         "//modules/common/vehicle_state:vehicle_state_provider",

--- a/modules/map/relative_map/conf/relative_map.conf
+++ b/modules/map/relative_map/conf/relative_map.conf
@@ -1,5 +1,4 @@
 --flagfile=modules/common/data/global_flagfile.txt
---use_navigation_mode
 --relative_map_config_filename=modules/map/relative_map/conf/relative_map_config.pb.txt
 --enable_cyclic_rerouting=1
 --relative_map_path_frame_ahead=1500

--- a/modules/map/relative_map/navigation_lane.h
+++ b/modules/map/relative_map/navigation_lane.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "modules/common/configs/config_gflags.h"
 #include "modules/common/vehicle_state/proto/vehicle_state.pb.h"
 #include "modules/localization/proto/localization.pb.h"
 #include "modules/map/relative_map/proto/navigation.pb.h"

--- a/modules/map/relative_map/navigation_lane_test.cc
+++ b/modules/map/relative_map/navigation_lane_test.cc
@@ -97,6 +97,8 @@ bool GenerateNavigationInfo(
 class NavigationLaneTest : public testing::Test {
  public:
   virtual void SetUp() {
+    FLAGS_use_navigation_mode = true;
+    FLAGS_use_navigation_with_utm = false;
     common::adapter::AdapterManagerConfig adapter_conf;
     RelativeMapConfig config;
 

--- a/modules/planning/common/frame.cc
+++ b/modules/planning/common/frame.cc
@@ -464,7 +464,7 @@ void Frame::RecordInputDebug(planning_internal::Debug *debug) {
   auto debug_chassis = planning_data->mutable_chassis();
   debug_chassis->CopyFrom(chassis);
 
-  if (!FLAGS_use_navigation_mode) {
+  if (!FLAGS_use_navigation_mode && !FLAGS_use_navigation_with_utm) {
     auto debug_routing = planning_data->mutable_routing();
     debug_routing->CopyFrom(
         AdapterManager::GetRoutingResponse()->GetLatestObserved());

--- a/scripts/relative_map.sh
+++ b/scripts/relative_map.sh
@@ -27,4 +27,4 @@ source "${DIR}/apollo_base.sh"
 # FIXME(all): temporary enable --use_navigation_mode in this script to make
 # it easier to test relative_map node. Need removed in the future.
 
-run_customized_path map/relative_map relative_map "$@" --use_navigation_mode
+run_customized_path map/relative_map relative_map "$@"


### PR DESCRIPTION
…igation with utm coor in std model

1. Configs: Added use_relative_map_with_utm to choose whether use navigation with utm coor or hdmap;
2. Hdmap_util: Modified the condition to get relativemap;
3. Navigation_lane: Modified kWeight;
4. Navigation_lane: Transformated utm to flu only in navigaion model with relativemap;
5. Relativemap: Enabled to use relativemap in std model;
6. Std_planning: Modified the condition to use routing and relativemap;
7. Frame: Modified the condition to use routing.
8. Reference_line_provider: Modified the condition to use routing and relativemap;