### PR TITLE
decider_rss fix ad_rss::extractSituation failed issue 

### DIFF
--- a/WORKSPACE.in
+++ b/WORKSPACE.in
@@ -44,6 +44,15 @@ new_local_repository(
     path = "/home/tmp/google_styleguide",
 )
 
+#ad-rss-lib
+new_git_repository(
+    name = "ad_rss_lib",
+    build_file = "third_party/rss_lib.BUILD",
+    tag = "v1.1.0",
+    remote = "https://github.com/intel/ad-rss-lib",
+)
+
+
 # eigen
 new_http_archive(
     name = "eigen",

--- a/modules/planning/tasks/rss/BUILD
+++ b/modules/planning/tasks/rss/BUILD
@@ -18,7 +18,7 @@ cc_library(
         "//modules/planning/common:reference_line_info",
         "//modules/planning/proto:planning_proto",
         "//modules/planning/tasks:task",
-        "//third_party/rss",
+        "@ad_rss_lib//:ad_rss",
     ],
 )
 
@@ -30,7 +30,7 @@ cc_test(
     ],
     deps = [
         ":decider_rss",
-        "//third_party/rss",
+        "@ad_rss_lib//:ad_rss",
         "@gtest//:main",
     ],
 )

--- a/modules/planning/tasks/rss/decider_rss.cc
+++ b/modules/planning/tasks/rss/decider_rss.cc
@@ -229,7 +229,7 @@ Status RssDecider::Process(Frame *frame,
   rssCheck.calculateAccelerationRestriction(
       worldModel, accelerationRestriction);
 
-  if (double(front_obstacle_distance) > double(dMin_lon)) {
+  if (front_obstacle_distance > static_cast<double> (dMin_lon)) {
     ADEBUG << "Task " << Name() << " Distance is RSS-Safe";
     reference_line_info->mutable_rss_info()->set_is_rss_safe(true);
   } else {
@@ -249,19 +249,19 @@ Status RssDecider::Process(Frame *frame,
   }
 
   reference_line_info->mutable_rss_info()->set_rss_safe_dist_lon(
-      double(dMin_lon));
+      static_cast<double> (dMin_lon));
   reference_line_info->mutable_rss_info()->set_acc_lon_range_minimum(
-      double(accelerationRestriction.longitudinalRange.minimum));
+      static_cast<double> (accelerationRestriction.longitudinalRange.minimum));
   reference_line_info->mutable_rss_info()->set_acc_lon_range_maximum(
-      double(accelerationRestriction.longitudinalRange.maximum));
+      static_cast<double> (accelerationRestriction.longitudinalRange.maximum));
   reference_line_info->mutable_rss_info()->set_acc_lat_left_range_minimum(
-      double(accelerationRestriction.lateralLeftRange.minimum));
+      static_cast<double> (accelerationRestriction.lateralLeftRange.minimum));
   reference_line_info->mutable_rss_info()->set_acc_lat_left_range_maximum(
-      double(accelerationRestriction.lateralLeftRange.maximum));
+      static_cast<double> (accelerationRestriction.lateralLeftRange.maximum));
   reference_line_info->mutable_rss_info()->set_acc_lat_right_range_minimum(
-      double(accelerationRestriction.lateralRightRange.minimum));
+      static_cast<double> (accelerationRestriction.lateralRightRange.minimum));
   reference_line_info->mutable_rss_info()->set_acc_lat_right_range_maximum(
-      double(accelerationRestriction.lateralRightRange.maximum));
+      static_cast<double> (accelerationRestriction.lateralRightRange.maximum));
 
   ADEBUG << " is_rss_safe : " << reference_line_info->rss_info().is_rss_safe();
   ADEBUG << " cur_dist_lon: " << reference_line_info->rss_info().cur_dist_lon();

--- a/modules/planning/tasks/rss/decider_rss.h
+++ b/modules/planning/tasks/rss/decider_rss.h
@@ -41,6 +41,13 @@ class RssDecider : public Task {
  private:
   apollo::common::Status Process(Frame *frame,
                                  ReferenceLineInfo *reference_line_info);
+  ad_rss::core::RssCheck rssCheck;
+
+  void rss_config_default_dynamics(::ad_rss::world::Dynamics *dynamics);
+  void rss_create_ego_object(::ad_rss::world::Object *ego,
+      double vel_lon, double vel_lat);
+  void rss_create_other_object(::ad_rss::world::Object *other,
+      double vel_lon, double vel_lat);
 };
 
 }  // namespace planning

--- a/modules/planning/tasks/rss/decider_rss.h
+++ b/modules/planning/tasks/rss/decider_rss.h
@@ -37,6 +37,37 @@
 namespace apollo {
 namespace planning {
 
+struct rss_world_model_struct {
+  std::string err_code;
+  double front_obs_dist;
+  double obs_s_start;
+  double obs_s_end;
+  double obs_l_start;
+  double obs_l_end;
+  double obs_speed;
+  double ego_v_s_start;
+  double ego_v_s_end;
+  double ego_v_l_start;
+  double ego_v_l_end;
+  double lane_width_ego;
+  double lane_width_obs;
+  double left_width_obs;
+  double lane_length;
+  double OR_front_lon_min;
+  double OR_front_lon_max;
+  double OR_front_lat_min;
+  double OR_front_lat_max;
+  double OR_rear_lon_min;
+  double OR_rear_lon_max;
+  double OR_rear_lat_min;
+  double OR_rear_lat_max;
+  double adc_vel;
+  double laneSeg_len_min;
+  double laneSeg_len_max;
+  double laneSeg_width_min;
+  double laneSeg_width_max;
+};
+
 class RssDecider : public Task {
  public:
   explicit RssDecider(const TaskConfig &config);
@@ -47,12 +78,13 @@ class RssDecider : public Task {
  private:
   apollo::common::Status Process(Frame *frame,
                                  ReferenceLineInfo *reference_line_info);
-
+  struct rss_world_model_struct rss_world_info;
   void rss_config_default_dynamics(::ad_rss::world::Dynamics *dynamics);
   void rss_create_ego_object(::ad_rss::world::Object *ego,
       double vel_lon, double vel_lat);
   void rss_create_other_object(::ad_rss::world::Object *other,
       double vel_lon, double vel_lat);
+  void rss_dump_world_info(const struct rss_world_model_struct &rss_info);
 };
 
 }  // namespace planning

--- a/modules/planning/tasks/rss/decider_rss.h
+++ b/modules/planning/tasks/rss/decider_rss.h
@@ -49,10 +49,10 @@ struct rss_world_model_struct {
   double ego_v_s_end;
   double ego_v_l_start;
   double ego_v_l_end;
-  double lane_width_ego;
-  double lane_width_obs;
-  double left_width_obs;
+  double lane_leftmost;
+  double lane_rightmost;
   double lane_length;
+  double lane_width;
   double OR_front_lon_min;
   double OR_front_lon_max;
   double OR_front_lat_min;

--- a/modules/planning/tasks/rss/decider_rss.h
+++ b/modules/planning/tasks/rss/decider_rss.h
@@ -25,8 +25,14 @@
 #include <string>
 
 #include "modules/planning/tasks/task.h"
-#include "ad_rss/core/RssCheck.hpp"
-#include "TestSupport.hpp"
+#include "ad_rss/situation/SituationVector.hpp"
+#include "ad_rss/core/RssSituationExtraction.hpp"
+#include "ad_rss/state/ResponseStateVector.hpp"
+#include "ad_rss/core/RssSituationChecking.hpp"
+#include "ad_rss/state/ResponseState.hpp"
+#include "ad_rss/core/RssResponseResolving.hpp"
+#include "ad_rss/core/RssResponseTransformation.hpp"
+#include "situation/RSSFormulas.hpp"
 
 namespace apollo {
 namespace planning {
@@ -41,7 +47,6 @@ class RssDecider : public Task {
  private:
   apollo::common::Status Process(Frame *frame,
                                  ReferenceLineInfo *reference_line_info);
-  ad_rss::core::RssCheck rssCheck;
 
   void rss_config_default_dynamics(::ad_rss::world::Dynamics *dynamics);
   void rss_create_ego_object(::ad_rss::world::Object *ego,

--- a/modules/planning/tasks/rss/decider_rss.h
+++ b/modules/planning/tasks/rss/decider_rss.h
@@ -25,8 +25,8 @@
 #include <string>
 
 #include "modules/planning/tasks/task.h"
-#include "rss/core/RssCheck.hpp"
-#include "rss/test_support/TestSupport.hpp"
+#include "ad_rss/core/RssCheck.hpp"
+#include "TestSupport.hpp"
 
 namespace apollo {
 namespace planning {

--- a/modules/planning/tasks/rss/decider_rss_test.cc
+++ b/modules/planning/tasks/rss/decider_rss_test.cc
@@ -18,51 +18,59 @@
  * @file
  **/
 
-#include "rss/core/RssCheck.hpp"
-#include "rss/test_support/TestSupport.hpp"
 
-namespace rss {
+#include "ad_rss/core/RssCheck.hpp"
+#include "TestSupport.hpp"
+
+namespace ad_rss {
 namespace core {
+
+using ad_rss::physics::Distance;
+using ad_rss::physics::ParametricValue;
+using ad_rss::world::OccupiedRegion;
 
 class RssCheckSameDirectionTests : public testing::Test {
  protected:
   virtual void SetUp() {
-    scene.setSituationType(rss::situation::SituationType::SameDirection);
-    leadingObject = createObject(0., 0.);
+    scene.situationType = ad_rss::situation::SituationType::SameDirection;
+    // leadingObject = createObject(0., 0.);  // lateral speed 0
+    leadingObject = createObject(0., 0.5);  // lateral speed toward right
     leadingObject.objectId = 0;
 
     {
-      ::rss::world::OccupiedRegion occupiedRegion;
-      occupiedRegion.lonRange.minimum = 0.94;
-      occupiedRegion.lonRange.maximum = 1.0;
+      OccupiedRegion occupiedRegion;
+      occupiedRegion.lonRange.minimum = ParametricValue(0.94);
+      occupiedRegion.lonRange.maximum = ParametricValue(1.0);
       occupiedRegion.segmentId = 0;
-      occupiedRegion.latRange.minimum = 0.;
-      // occupiedRegion.latRange.maximum = 0.089;  // rss safe
-      occupiedRegion.latRange.maximum = 0.15;  // rss unsafe
+      occupiedRegion.latRange.minimum = ParametricValue(0.);
+      occupiedRegion.latRange.maximum = ParametricValue(0.089);  // rss safe
+      // occupiedRegion.latRange.maximum = ParametricValue(0.15);  // rss unsafe
+      // occupiedRegion.latRange.maximum = ParametricValue(0.3);  // rss unsafe
       leadingObject.occupiedRegions.push_back(occupiedRegion);
     }
 
-    followingObject = createObject(11.0, 0.);
+    // followingObject = createObject(11.0, 0.);  // lateral speed 0
+    followingObject = createObject(11.0, -0.5);  // lateral speed toward left
     followingObject.objectId = 1;
     {
-      ::rss::world::OccupiedRegion occupiedRegion;
-      occupiedRegion.lonRange.minimum = 0.7;
-      occupiedRegion.lonRange.maximum = 0.82;
+      OccupiedRegion occupiedRegion;
+      occupiedRegion.lonRange.minimum = ParametricValue(0.7);
+      occupiedRegion.lonRange.maximum = ParametricValue(0.82);
       occupiedRegion.segmentId = 0;
-      occupiedRegion.latRange.minimum = 0.3;
-      occupiedRegion.latRange.maximum = 0.66;
+      occupiedRegion.latRange.minimum = ParametricValue(0.3);
+      occupiedRegion.latRange.maximum = ParametricValue(0.66);
       followingObject.occupiedRegions.push_back(occupiedRegion);
     }
 
     {
-      ::rss::world::RoadSegment roadSegment;
-      ::rss::world::LaneSegment laneSegment;
+      world::RoadSegment roadSegment;
+      world::LaneSegment laneSegment;
 
       laneSegment.id = 0;
-      laneSegment.length.minimum = 41.4;
-      laneSegment.length.maximum = 41.4;
-      laneSegment.width.minimum = 5.98;
-      laneSegment.width.maximum = 5.98;
+      laneSegment.length.minimum = Distance(41.4);
+      laneSegment.length.maximum = Distance(41.4);
+      laneSegment.width.minimum = Distance(5.98);
+      laneSegment.width.maximum = Distance(5.98);
 
       roadSegment.push_back(laneSegment);
       roadArea.push_back(roadSegment);
@@ -74,41 +82,44 @@ class RssCheckSameDirectionTests : public testing::Test {
     leadingObject.occupiedRegions.clear();
     scene.egoVehicleRoad.clear();
   }
-  ::rss::world::Object followingObject;
-  ::rss::world::Object leadingObject;
-  ::rss::world::RoadArea roadArea;
-  ::rss::world::Scene scene;
+  ::ad_rss::world::Object followingObject;
+  ::ad_rss::world::Object leadingObject;
+  ::ad_rss::world::RoadArea roadArea;
+  ::ad_rss::world::Scene scene;
 };
 
 TEST_F(RssCheckSameDirectionTests, OtherLeading_FixDistance) {
-  ::rss::world::WorldModel worldModel;
+  ::ad_rss::world::WorldModel worldModel;
 
-  worldModel.egoVehicle = followingObject;
+  worldModel.egoVehicle = ad_rss::objectAsEgo(followingObject);
   scene.object = leadingObject;
 
   scene.egoVehicleRoad = roadArea;
   worldModel.scenes.push_back(scene);
   worldModel.timeIndex = 1;
 
-  ::rss::world::AccelerationRestriction accelerationRestriction;
-  ::rss::core::RssCheck rssCheck;
+  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
+  ::ad_rss::core::RssCheck rssCheck;
 
-  double dMin = calculateLongitudinalMinSafeDistance(
-      worldModel.egoVehicle, worldModel.scenes[0].object);
+  ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel,
+      accelerationRestriction));
 
-  ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(
-      worldModel, accelerationRestriction));
-  ASSERT_EQ(accelerationRestriction.longitudinalRange.minimum,
-            -1. * worldModel.egoVehicle.dynamics.alphaLon.brakeMax);
-  ASSERT_EQ(accelerationRestriction.longitudinalRange.maximum,
-            -1. * worldModel.egoVehicle.dynamics.alphaLon.brakeMin);
-
-  printf("dMin = %f\n", dMin);
-  printf("accelerationRestriction.longitudinalRange.minimum=%f\n",
-         accelerationRestriction.longitudinalRange.minimum);
-  printf("accelerationRestriction.longitudinalRange.maximum=%f\n",
-         accelerationRestriction.longitudinalRange.maximum);
+  if (accelerationRestriction.longitudinalRange.maximum ==
+      -1. * worldModel.egoVehicle.dynamics.alphaLon.brakeMin) {
+    printf("[----------] RSS unsafe!!!\n");
+    EXPECT_EQ(accelerationRestriction.longitudinalRange.maximum,
+      -1. * worldModel.egoVehicle.dynamics.alphaLon.brakeMin);
+  } else {
+    printf("[----------] RSS safe!!!\n");
+    EXPECT_EQ(accelerationRestriction.longitudinalRange.maximum,
+      worldModel.egoVehicle.dynamics.alphaLon.accelMax);
+  }
+  // following judgement only true for leading-v v(0,0.5) and ego-v v(11,-0.5)
+  EXPECT_EQ(accelerationRestriction.lateralLeftRange.maximum, -1 *
+      worldModel.egoVehicle.dynamics.alphaLat.brakeMin);
+  EXPECT_EQ(accelerationRestriction.lateralRightRange.maximum,
+      worldModel.egoVehicle.dynamics.alphaLat.accelMax);
 }
 
 }  // namespace core
-}  // namespace rss
+}  // namespace ad_rss

--- a/third_party/rss_lib.BUILD
+++ b/third_party/rss_lib.BUILD
@@ -1,21 +1,3 @@
-# ----------------- BEGIN LICENSE BLOCK ---------------------------------
-#
-# INTEL CONFIDENTIAL
-#
-# Copyright (c) 2018 Intel Corporation
-#
-# This software and the related documents are Intel copyrighted materials, and
-# your use of them is governed by the express license under which they were
-# provided to you (License). Unless the License provides otherwise, you may not
-# use, modify, copy, publish, distribute, disclose or transmit this software or
-# the related documents without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or
-# implied warranties, other than those that are expressly stated in the License.
-#
-# ----------------- END LICENSE BLOCK -----------------------------------
-##
-
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/third_party/rss_lib.BUILD
+++ b/third_party/rss_lib.BUILD
@@ -1,0 +1,70 @@
+# ----------------- BEGIN LICENSE BLOCK ---------------------------------
+#
+# INTEL CONFIDENTIAL
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# This software and the related documents are Intel copyrighted materials, and
+# your use of them is governed by the express license under which they were
+# provided to you (License). Unless the License provides otherwise, you may not
+# use, modify, copy, publish, distribute, disclose or transmit this software or
+# the related documents without Intel's prior written permission.
+#
+# This software and the related documents are provided as is, with no express or
+# implied warranties, other than those that are expressly stated in the License.
+#
+# ----------------- END LICENSE BLOCK -----------------------------------
+##
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+
+cc_library(
+    name = "ad_rss",
+    srcs = [
+        "src/generated/physics/Acceleration.cpp",
+        "src/generated/physics/CoordinateSystemAxis.cpp",
+        "src/generated/physics/Distance.cpp",
+        "src/generated/physics/DistanceSquared.cpp",
+        "src/generated/physics/Duration.cpp",
+        "src/generated/physics/DurationSquared.cpp",
+        "src/generated/physics/ParametricValue.cpp",
+        "src/generated/physics/Speed.cpp",
+        "src/generated/physics/SpeedSquared.cpp",
+        "src/generated/situation/LateralRelativePosition.cpp",
+        "src/generated/situation/LongitudinalRelativePosition.cpp",
+        "src/generated/situation/SituationType.cpp",
+        "src/generated/state/LateralResponse.cpp",
+        "src/generated/state/LongitudinalResponse.cpp",
+        "src/generated/world/LaneDrivingDirection.cpp",
+        "src/generated/world/LaneSegmentType.cpp",
+        "src/generated/world/ObjectType.cpp",
+        "src/core/RssCheck.cpp",
+        "src/core/RssResponseResolving.cpp",
+        "src/core/RssResponseTransformation.cpp",
+        "src/core/RssSituationChecking.cpp",
+        "src/core/RssSituationExtraction.cpp",
+        "src/physics/Math.cpp",
+        "src/situation/RSSFormulas.cpp",
+        "src/situation/RssIntersectionChecker.cpp",
+        "src/situation/RSSSituation.cpp",
+        "src/world/RssSituationCoordinateSystemConversion.cpp",
+        "src/world/RssObjectPositionExtractor.cpp",
+    ] + glob(["src/**/*.hpp"]),
+    hdrs = glob(["include/**/*.hpp"]),
+    copts = ["-fPIC","-std=c++11","-Werror","-Wall","-Wextra","-pedantic","-Wconversion", "-Wsign-conversion", "--coverage"],
+    includes = ["include", "include/generated", "src", "tests/test_support"], 
+    linkopts = ["--coverage"],
+)
+
+################################################################################
+# Install section
+################################################################################
+
+################################################################################
+# Doxygen documentation
+################################################################################

--- a/third_party/rss_lib.BUILD
+++ b/third_party/rss_lib.BUILD
@@ -38,9 +38,8 @@ cc_library(
         "src/world/RssObjectPositionExtractor.cpp",
     ] + glob(["src/**/*.hpp"]),
     hdrs = glob(["include/**/*.hpp"]),
-    copts = ["-fPIC","-std=c++11","-Werror","-Wall","-Wextra","-pedantic","-Wconversion", "-Wsign-conversion", "--coverage"],
+    copts = ["-fPIC","-std=c++11","-Werror","-Wall","-Wextra","-pedantic","-Wconversion", "-Wsign-conversion"],
     includes = ["include", "include/generated", "src", "tests/test_support"], 
-    linkopts = ["--coverage"],
 )
 
 ################################################################################


### PR DESCRIPTION
When running public and stable test scenarios, some corner cases may trigger rss malfunction and print error message "ad_rss::extractSituation failed". 
this issue has been root caused. Former environment conversion in lateral projection may be out of range and introduce this failure. 

This patch contain this fix.  Please Apollo team review and comment on it. 