### PR TITLE
[gnss] Assign the IMU ID 41 to the EPSON G320N as required by Novatel

### DIFF
--- a/modules/drivers/gnss/proto/config.proto
+++ b/modules/drivers/gnss/proto/config.proto
@@ -71,8 +71,8 @@ enum ImuType {
   ISA100 = 34;         // Northrop Grumman Litef ISA-100
   ISA100_400HZ = 38;   // Northrop Grumman Litef ISA-100
   ISA100C_400HZ = 39;  // Northrop Grumman Litef ISA-100
-  G320N = 40;          // EPSON G320N
-  CPT_XW5651 = 41;     // IMU@SPAN-CPT, and XingWangYuda 5651
+  CPT_XW5651 = 40;     // IMU@SPAN-CPT, and XingWangYuda 5651
+  G320N = 41;          // EPSON G320N
   UM442 = 42;          // UM442
   IAM20680 = 57;       // InvenSense-IAM20680
 }


### PR DESCRIPTION
The rationale behind this change is explained in https://github.com/ApolloAuto/apollo/issues/7450
This is justified by https://docs.novatel.com/oem7/Content/SPAN_Commands/CONNECTIMU.htm
It has been tested to solve IMU problems with Apollo running with a PwrPak7-E1