### PR TITLE
[#8053] canbus component does not exit gracefully.

### DIFF
--- a/modules/canbus/canbus_component.cc
+++ b/modules/canbus/canbus_component.cc
@@ -166,6 +166,15 @@ bool CanbusComponent::Init() {
   return true;
 }
 
+void CanbusComponent::Clear() {
+  can_sender_.Stop();
+  can_receiver_.Stop();
+  can_client_->Stop();
+  vehicle_controller_->Stop();
+
+  AINFO << "Cleanup Canbus component";
+}
+
 void CanbusComponent::PublishChassis() {
   Chassis chassis = vehicle_controller_->chassis();
   common::util::FillHeader(node_->Name(), &chassis);

--- a/modules/canbus/canbus_component.h
+++ b/modules/canbus/canbus_component.h
@@ -68,6 +68,7 @@ class CanbusComponent final : public apollo::cyber::TimerComponent {
    */
   std::string Name() const;
 
+ private:
   /**
    * @brief module initialization function
    * @return initialization status
@@ -79,7 +80,11 @@ class CanbusComponent final : public apollo::cyber::TimerComponent {
    */
   bool Proc() override;
 
- private:
+  /**
+   * @brief module cleanup function
+   */ 
+  void Clear() override;
+
   void PublishChassis();
   void PublishChassisDetail();
   void OnControlCommand(const apollo::control::ControlCommand &control_command);


### PR DESCRIPTION
-Override Clear() from ComponentBase so internal handles are cleaned up
 during shutdown.
-Fixes #8053