### PR TITLE
Planning: revert breaking open space debug, and fix for missing open space decider conf

### DIFF
--- a/modules/planning/conf/planning_config.pb.txt
+++ b/modules/planning/conf/planning_config.pb.txt
@@ -199,6 +199,11 @@ default_task_config: {
   }
 }
 default_task_config: {
+  task_type: OPEN_SPACE_PRE_STOP_DECIDER
+  open_space_pre_stop_decider_config: {
+  }
+}
+default_task_config: {
   task_type: OPEN_SPACE_TRAJECTORY_PROVIDER
   open_space_trajectory_provider_config {
     open_space_trajectory_optimizer_config {

--- a/modules/planning/on_lane_planning.cc
+++ b/modules/planning/on_lane_planning.cc
@@ -666,9 +666,9 @@ void OnLanePlanning::AddOpenSpaceOptimizerResult(
   smoothed_line->set_label("Smooth");
   size_t adc_label = 0;
   for (const auto& point : smoothed_trajectory.vehicle_motion_point()) {
-    const auto& x = point.trajectory_point().path_point().x();
-    const auto& y = point.trajectory_point().path_point().y();
-    const auto& heading = point.trajectory_point().path_point().theta();
+    const auto x = point.trajectory_point().path_point().x();
+    const auto y = point.trajectory_point().path_point().y();
+    const auto heading = point.trajectory_point().path_point().theta();
 
     // Draw vehicle shape along the trajectory
     auto* adc_shape = chart->add_car();

--- a/modules/planning/tasks/optimizers/open_space_trajectory_generation/open_space_trajectory_optimizer.h
+++ b/modules/planning/tasks/optimizers/open_space_trajectory_generation/open_space_trajectory_optimizer.h
@@ -62,25 +62,19 @@ class OpenSpaceTrajectoryOptimizer {
     *optimized_trajectory = optimized_trajectory_;
   }
 
-  void RecordWarmStartDebugInfo(
-      const size_t horizon,
+  void RecordDebugInfo(
       const common::TrajectoryPoint& trajectory_stitching_point,
       const Vec2d& translate_origin, const double rotate_angle,
       const std::vector<double>& end_pose, const Eigen::MatrixXd& xWS,
-      const Eigen::MatrixXd& uWs, const std::vector<double>& XYbounds,
+      const Eigen::MatrixXd& uWs, const Eigen::MatrixXd& l_warm_up,
+      const Eigen::MatrixXd& n_warm_up, const Eigen::MatrixXd& dual_l_result_ds,
+      const Eigen::MatrixXd& dual_n_result_ds,
+      const Eigen::MatrixXd& state_result_ds,
+      const Eigen::MatrixXd& control_result_ds,
+      const Eigen::MatrixXd& time_result_ds,
+      const std::vector<double>& XYbounds,
       const std::vector<std::vector<common::math::Vec2d>>&
           obstacles_vertices_vec);
-
-  void RecordDualVariableWarmStartDebugInfo(const size_t horizon,
-                                            const Eigen::MatrixXd& l_warm_up,
-                                            const Eigen::MatrixXd& n_warm_up);
-
-  void RecordSmootherDebugInfo(const size_t horizon,
-                               const Eigen::MatrixXd& dual_l_result_ds,
-                               const Eigen::MatrixXd& dual_n_result_ds,
-                               const Eigen::MatrixXd& state_result_ds,
-                               const Eigen::MatrixXd& control_result_ds,
-                               const Eigen::MatrixXd& time_result_ds);
 
   void UpdateDebugInfo(
       ::apollo::planning_internal::OpenSpaceDebug* open_space_debug);

--- a/modules/planning/tasks/optimizers/open_space_trajectory_generation/open_space_trajectory_provider.cc
+++ b/modules/planning/tasks/optimizers/open_space_trajectory_generation/open_space_trajectory_provider.cc
@@ -152,22 +152,19 @@ Status OpenSpaceTrajectoryProvider::Process() {
       return Status(ErrorCode::OK, "Vehicle is near to destination");
     }
 
-    // Record and update debug information regardless of trajectory update
-    // status
-    if (FLAGS_enable_record_debug) {
-      // call merge debug ptr, open_space_trajectory_optimizer_
-      auto* ptr_debug = frame_->mutable_open_space_info()->mutable_debug();
-      open_space_trajectory_optimizer_->UpdateDebugInfo(
-          ptr_debug->mutable_planning_data()->mutable_open_space());
-
-      // sync debug instance
-      frame_->mutable_open_space_info()->sync_debug_instance();
-    }
-
     // Check if trajectory updated
     if (trajectory_updated_) {
       std::lock_guard<std::mutex> lock(open_space_mutex_);
       LoadResult(trajectory_data);
+      if (FLAGS_enable_record_debug) {
+        // call merge debug ptr, open_space_trajectory_optimizer_
+        auto* ptr_debug = frame_->mutable_open_space_info()->mutable_debug();
+        open_space_trajectory_optimizer_->UpdateDebugInfo(
+            ptr_debug->mutable_planning_data()->mutable_open_space());
+
+        // sync debug instance
+        frame_->mutable_open_space_info()->sync_debug_instance();
+      }
       trajectory_updated_.store(false);
       data_ready_.store(false);
       return Status::OK();


### PR DESCRIPTION
Since we have decided to change designs to use Astar when smoother failed, there is no point of making the recording part more complicated than needed. 