### PR TITLE
enable different clone locations

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -84,8 +84,8 @@ done
 
 APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
-if [ ! -e /apollo ]; then
-    sudo ln -sf ${APOLLO_ROOT_DIR} /apollo
+if [ "$(readlink -f /apollo)" != "${APOLLO_ROOT_DIR}" ]; then
+    sudo ln -snf ${APOLLO_ROOT_DIR} /apollo
 fi
 
 if [ -e /proc/sys/kernel ]; then


### PR DESCRIPTION
```
git clone https://github.com/ApolloAuto/apollo.git repo1
docker/scripts/dev_start.sh
git clone https://github.com/ApolloAuto/apollo.git repo2
docker/scripts/dev_start.sh
ll / | grep apollo
```
The symlink will point to repo2