### PR TITLE
docker: adding more options for docker script to improve CI efficiency

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -18,6 +18,8 @@
 
 INCHINA="no"
 LOCAL_IMAGE="no"
+FAST_BUILD_MODE="no"
+FAST_TEST_MODE="no"
 VERSION=""
 ARCH=$(uname -m)
 VERSION_X86_64="dev-x86_64-20190413_1615"
@@ -56,6 +58,8 @@ cat <<EOF
 Usage: $(basename $0) [options] ...
 OPTIONS:
     -C                     Pull docker image from China mirror.
+    -b, --fast-build       Light mode for building without pulling all the map volumes
+    -f, --fast-test        Light mode for testing without pulling limited set of map volumes
     -h, --help             Display this help and exit.
     -t, --tag <version>    Specify which version of a docker image to pull.
     -l, --local            Use local docker image.
@@ -104,7 +108,12 @@ DEFAULT_MAPS=(
   san_mateo
   san_mateo_hdl64
 )
+DEFAULT_TEST_MAPS=(
+  sunnyvale_big_loop
+  sunnyvale_loop
+)
 MAP_VOLUME_CONF=""
+OTHER_VOLUME_CONF=""
 
 while [ $# -gt 0 ]
 do
@@ -129,6 +138,12 @@ do
         VERSION_OPT=$1
         echo -e "\033[93mWarning\033[0m: You are using an old style command line option which may be removed from"
         echo -e "further versoin, please use -t <version> instead.\n"
+        ;;
+    -b|--fast-build)
+        FAST_BUILD_MODE="yes"
+        ;;
+    -f|--fast-test)
+        FAST_TEST_MODE="yes"
         ;;
     -h|--help)
         show_usage
@@ -221,10 +236,36 @@ function main(){
         docker rm -v -f $APOLLO_DEV 1>/dev/null
     fi
 
-    # Included default maps.
-    for map_name in ${DEFAULT_MAPS[@]}; do
-      source ${APOLLO_ROOT_DIR}/docker/scripts/restart_map_volume.sh ${map_name} "${VOLUME_VERSION}"
-    done
+    if [ "$FAST_BUILD_MODE" == "no" ]; then
+        if [ "$FAST_TEST_MODE" == "no" ]; then
+            # Included default maps.
+            for map_name in ${DEFAULT_MAPS[@]}; do
+              source ${APOLLO_ROOT_DIR}/docker/scripts/restart_map_volume.sh ${map_name} "${VOLUME_VERSION}"
+            done
+            YOLO3D_VOLUME=apollo_yolo3d_volume_$USER
+            docker stop ${YOLO3D_VOLUME} > /dev/null 2>&1
+
+            YOLO3D_VOLUME_IMAGE=${DOCKER_REPO}:yolo3d_volume-${ARCH}-latest
+            docker pull ${YOLO3D_VOLUME_IMAGE}
+            docker run -it -d --rm --name ${YOLO3D_VOLUME} ${YOLO3D_VOLUME_IMAGE}
+
+            OTHER_VOLUME_CONF="${OTHER_VOLUME_CONF} --volumes-from ${YOLO3D_VOLUME}"
+        else
+            # Included default maps.
+            for map_name in ${DEFAULT_TEST_MAPS[@]}; do
+              source ${APOLLO_ROOT_DIR}/docker/scripts/restart_map_volume.sh ${map_name} "${VOLUME_VERSION}"
+            done
+        fi
+    fi
+
+    LOCALIZATION_VOLUME=apollo_localization_volume_$USER
+    docker stop ${LOCALIZATION_VOLUME} > /dev/null 2>&1
+
+    LOCALIZATION_VOLUME_IMAGE=${DOCKER_REPO}:localization_volume-${ARCH}-latest
+    docker pull ${LOCALIZATION_VOLUME_IMAGE}
+    docker run -it -d --rm --name ${LOCALIZATION_VOLUME} ${LOCALIZATION_VOLUME_IMAGE}
+
+    OTHER_VOLUME_CONF="${OTHER_VOLUME_CONF} --volumes-from ${LOCALIZATION_VOLUME}"
 
     local display=""
     if [[ -z ${DISPLAY} ]];then
@@ -247,20 +288,6 @@ function main(){
         mkdir "$HOME/.cache"
     fi
 
-    LOCALIZATION_VOLUME=apollo_localization_volume_$USER
-    docker stop ${LOCALIZATION_VOLUME} > /dev/null 2>&1
-
-    LOCALIZATION_VOLUME_IMAGE=${DOCKER_REPO}:localization_volume-${ARCH}-latest
-    docker pull ${LOCALIZATION_VOLUME_IMAGE}
-    docker run -it -d --rm --name ${LOCALIZATION_VOLUME} ${LOCALIZATION_VOLUME_IMAGE}
-
-    YOLO3D_VOLUME=apollo_yolo3d_volume_$USER
-    docker stop ${YOLO3D_VOLUME} > /dev/null 2>&1
-
-    YOLO3D_VOLUME_IMAGE=${DOCKER_REPO}:yolo3d_volume-${ARCH}-latest
-    docker pull ${YOLO3D_VOLUME_IMAGE}
-    docker run -it -d --rm --name ${YOLO3D_VOLUME} ${YOLO3D_VOLUME_IMAGE}
-
     info "Starting docker container \"${APOLLO_DEV}\" ..."
 
     DOCKER_CMD="nvidia-docker"
@@ -275,8 +302,7 @@ function main(){
         --privileged \
         --name $APOLLO_DEV \
         ${MAP_VOLUME_CONF} \
-        --volumes-from ${LOCALIZATION_VOLUME} \
-        --volumes-from ${YOLO3D_VOLUME} \
+        ${OTHER_VOLUME_CONF} \
         -e DISPLAY=$display \
         -e DOCKER_USER=$USER \
         -e USER=$USER \


### PR DESCRIPTION
To improve CI efficiency, add two new options in docker script as dev_start.sh
* -b for build only, not pulling any map information
* -f for unit tests, pull only limited set of map information

Due the growing number of maps, it's pain to pulling all the map at each CI steps.
We have 5 steps in total in CI right now. First three steps can run well without
any map, and the rest will need some limited map support.

Total time of all steps in a CI reduces from about 2 hours to 90mins, which save
both time and resources.

Previous tested CI with -b and -f options to prove its correctness:

https://travis-ci.com/ApolloAuto/apollo/builds/112120858

https://travis-ci.com/ApolloAuto/apollo/builds/112129192