### PR TITLE
dont depend on all maps

### DIFF
--- a/modules/map/BUILD
+++ b/modules/map/BUILD
@@ -1,8 +1,1 @@
 package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "map_data",
-    srcs = glob([
-        "data/**",
-    ]),
-)

--- a/modules/map/data/BUILD
+++ b/modules/map/data/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "map_sunnyvale_big_loop",
+    testonly = True,
+    srcs = glob([
+        "sunnyvale_big_loop/**",
+    ]),
+)
+
+filegroup(
+    name = "map_sunnyvale_loop",
+    testonly = True,
+    srcs = glob([
+        "sunnyvale_loop/**",
+    ]),
+)
+

--- a/modules/map/hdmap/BUILD
+++ b/modules/map/hdmap/BUILD
@@ -59,7 +59,6 @@ cc_test(
     data = [
         ":testdata",
         "//modules/common/util",
-        "//modules/map:map_data",
     ],
     deps = [
         ":hdmap",
@@ -77,7 +76,6 @@ cc_test(
     ],
     data = [
         ":testdata",
-        "//modules/map:map_data",
     ],
     deps = [
         ":hdmap_util",

--- a/modules/map/pnc_map/BUILD
+++ b/modules/map/pnc_map/BUILD
@@ -112,7 +112,7 @@ cc_test(
     ],
     data = [
         ":testdata",
-        "//modules/map:map_data",
+        "//modules/map/data:map_sunnyvale_loop",
     ],
     deps = [
         ":pnc_map",
@@ -130,7 +130,7 @@ cc_test(
     ],
     data = [
         ":testdata",
-        "//modules/map:map_data",
+        "//modules/map/data:map_sunnyvale_loop",
     ],
     deps = [
         ":route_segments",

--- a/modules/map/tools/BUILD
+++ b/modules/map/tools/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 cc_binary(
     name = "map_tool",
     srcs = ["map_tool.cc"],
-    data = ["//modules/map:map_data"],
     deps = [
         "//external:gflags",
         "//modules/common",
@@ -19,7 +18,6 @@ cc_binary(
 cc_binary(
     name = "map_xysl",
     srcs = ["map_xysl.cc"],
-    data = ["//modules/map:map_data"],
     deps = [
         "//external:gflags",
         "//modules/common",
@@ -43,7 +41,6 @@ cc_binary(
 cc_binary(
     name = "sim_map_generator",
     srcs = ["sim_map_generator.cc"],
-    data = ["//modules/map:map_data"],
     deps = [
         "//external:gflags",
         "//modules/common",
@@ -59,7 +56,6 @@ cc_binary(
 cc_binary(
     name = "proto_map_generator",
     srcs = ["proto_map_generator.cc"],
-    data = ["//modules/map:map_data"],
     deps = [
         "//external:gflags",
         "//modules/common",
@@ -73,7 +69,6 @@ cc_binary(
 cc_binary(
     name = "bin_map_generator",
     srcs = ["bin_map_generator.cc"],
-    data = ["//modules/map:map_data"],
     deps = [
         "//external:gflags",
         "//modules/common",

--- a/modules/planning/integration_tests/BUILD
+++ b/modules/planning/integration_tests/BUILD
@@ -11,7 +11,6 @@ cc_library(
         "planning_test_base.h",
     ],
     data = [
-        "//modules/map:map_data",
         "//modules/planning:planning_conf",
         "//modules/planning:planning_testdata",
     ],
@@ -51,7 +50,7 @@ cc_test(
     ],
     data = [
         "//modules/common/configs:config_gflags",
-        "//modules/map:map_data",
+        "//modules/map/data:map_sunnyvale_loop",
         "//modules/planning:planning_testdata",
     ],
     deps = [
@@ -67,7 +66,7 @@ cc_test(
     ],
     data = [
         "//modules/common/configs:config_gflags",
-        "//modules/map:map_data",
+        "//modules/map/data:map_sunnyvale_big_loop",
         "//modules/planning:planning_testdata",
     ],
     deps = [

--- a/modules/planning/tasks/deciders/speed_bounds_decider/BUILD
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/BUILD
@@ -66,7 +66,6 @@ cc_test(
         "speed_limit_decider_test.cc",
     ],
     data = [
-        "//modules/map:map_data",
         "//modules/planning:planning_testdata",
     ],
     deps = [
@@ -85,7 +84,6 @@ cc_test(
         "st_boundary_mapper_test.cc",
     ],
     data = [
-        "//modules/map:map_data",
         "//modules/planning:planning_testdata",
     ],
     deps = [

--- a/modules/tools/manual_traffic_light/BUILD
+++ b/modules/tools/manual_traffic_light/BUILD
@@ -6,7 +6,6 @@ cc_library(
     name = "manual_traffic_light",
     srcs = ["manual_traffic_light.cc"],
     copts = ["-DMODULE_NAME=\\\"manual_traffic_light\\\""],
-    data = ["//modules/map:map_data"],
     deps = [
         "//modules/common/adapters:adapter_gflags",
         "//modules/map/hdmap:hdmap_util",


### PR DESCRIPTION
## Description
bazel is still hashing a lot of maps, it doesn't need to. Two tests only need sunnyvale_big_loop and sunnyvale_loop. Bazel's hashing is useful for reproducing test results, but a lot of libraries didn't actually need all the maps exactly as they are.

## Tests
### 1. citest_extended
```
docker/scripts/dev_start.sh && ./apollo_docker.sh citest_extended && docker/scripts/dev_start.sh && time ./apollo_docker.sh citest_extended
```
is about 25 seconds regardless of this change.

### 2. sunnyvale_big_loop_test
```
docker/scripts/dev_start.sh && docker/scripts/dev_into.sh
bazel test //modules/planning/integration_tests:sunnyvale_big_loop_test
```
Goes from 230 seconds to 18 seconds.