### PR TITLE
Revert "Common: change default log level for mpi_dev banch"

### DIFF
--- a/modules/common/data/global_flagfile.txt
+++ b/modules/common/data/global_flagfile.txt
@@ -11,6 +11,4 @@
 
 --use_navigation_mode=false
 
---stderrthreshold=ERROR
-
 --map_dir=/apollo/modules/map/data/sunnyvale_big_loop


### PR DESCRIPTION
This reverts commit 870a12dc55a2c575429f1baa26e910985235f779.

It breaks at runtime.