### PR TITLE
Bugfix: count of objects in pool

### DIFF
--- a/cyber/base/concurrent_object_pool.h
+++ b/cyber/base/concurrent_object_pool.h
@@ -45,8 +45,11 @@ class CCObjectPool : public std::enable_shared_from_this<CCObjectPool<T>> {
   std::shared_ptr<T> ConstructObject(Args &&... args);
 
   std::shared_ptr<T> GetObject();
-  void ReleaseObject(T *);
-  uint32_t size() const;
+
+  uint32_t size() const {
+    Head head = free_head_.load(std::memory_order_acquire);
+    return head.count;
+  }
 
  private:
   struct Node {
@@ -63,7 +66,8 @@ class CCObjectPool : public std::enable_shared_from_this<CCObjectPool<T>> {
   CCObjectPool(CCObjectPool &) = delete;
   CCObjectPool &operator=(CCObjectPool &) = delete;
   bool FindFreeHead(Head *head);
-
+  void ReleaseObject(T *);
+ 
   std::atomic<Head> free_head_;
   Node *node_arena_ = nullptr;
   uint32_t capacity_ = 0;
@@ -141,7 +145,7 @@ void CCObjectPool<T>::ReleaseObject(T *object) {
   do {
     node->next = old_head.node;
     new_head.node = node;
-    new_head.count = old_head.count + 1;
+    new_head.count = old_head.count - 1;
   } while (!free_head_.compare_exchange_weak(old_head, new_head,
                                              std::memory_order_acq_rel,
                                              std::memory_order_acquire));

--- a/cyber/base/concurrent_object_pool.h
+++ b/cyber/base/concurrent_object_pool.h
@@ -67,7 +67,7 @@ class CCObjectPool : public std::enable_shared_from_this<CCObjectPool<T>> {
   CCObjectPool &operator=(CCObjectPool &) = delete;
   bool FindFreeHead(Head *head);
   void ReleaseObject(T *);
- 
+
   std::atomic<Head> free_head_;
   Node *node_arena_ = nullptr;
   uint32_t capacity_ = 0;


### PR DESCRIPTION
If I understand it right, count in Head stands for the count of objects currently "alive" in pool. 
When object get released,  head.count should be minus 1 rather than plus 1.
And,  ReleaseObject(T* ) should be private.
