### PR TITLE
prediction: udpate feature history size condition

### DIFF
--- a/modules/prediction/scenario/prioritization/obstacles_prioritizer.cc
+++ b/modules/prediction/scenario/prioritization/obstacles_prioritizer.cc
@@ -196,7 +196,7 @@ void ObstaclesPrioritizer::AssignCautionLevelCruiseKeepLane() {
     AERROR << "Ego vehicle not found";
     return;
   }
-  if (ego_vehicle->history_size() < 2) {
+  if (ego_vehicle->history_size() == 0) {
     AERROR << "Ego vehicle has no history";
     return;
   }


### PR DESCRIPTION
Actually we can get the `lane_graph` after inserted the ego vehicle position information for the first time.

Fixed at least the ERROR report every loop.
```
E0611 10:19:06.131490   190 obstacles_prioritizer.cc:200] [prediction] Ego vehicle has no history
```