### PR TITLE
mktime called with properly initialized data

### DIFF
--- a/cyber/common/time_conversion.h
+++ b/cyber/common/time_conversion.h
@@ -115,11 +115,11 @@ inline uint64_t GpsToUnixNanoseconds(uint64_t gps_nanoseconds) {
 inline uint64_t StringToUnixSeconds(
     const std::string& time_str,
     const std::string& format_str = "%Y-%m-%d %H:%M:%S") {
-  struct tm* tmp_time = (struct tm*)malloc(sizeof(struct tm));
-  strptime(time_str.c_str(), format_str.c_str(), tmp_time);
-  time_t time = mktime(tmp_time);
-  free(tmp_time);
-  return (uint64_t)time;
+  tm tmp_time;
+  strptime(time_str.c_str(), format_str.c_str(), &tmp_time);
+  tmp_time.tm_isdst = -1;
+  time_t time = mktime(&tmp_time);
+  return static_cast<uint64_t>(time);
 }
 
 inline std::string UnixSecondsToString(


### PR DESCRIPTION
Undefined behavior in `-b` and `-e` arguments cause the `cyber_recorder play` program to add numbers incorrectly on my computer. This change was tested with `valgrind`.

Here is a explanation on the fix: https://stackoverflow.com/a/24185697