### PR TITLE
tools: fixed issue:#8759 configurator.sh is no longer functioning

### DIFF
--- a/modules/tools/configurator/ModuleConf.py
+++ b/modules/tools/configurator/ModuleConf.py
@@ -19,7 +19,6 @@
 Message Handle
 """
 
-import ast
 import curses
 import importlib
 from curses import panel
@@ -44,7 +43,7 @@ class ModuleConf(object):
 
     def parse_from_file(self):
         mod = importlib.import_module(self.proto_file)
-        self.proto = ast.literal_eval("mod." + self.proto_class)
+        self.proto = eval("mod." + self.proto_class)
 
         try:
             with open(APOLLO_ROOT + self.conf_file, 'r') as prototxt:


### PR DESCRIPTION
Value Error exception :
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/ast.py", line 80, in literal_eval
    return _convert(node_or_string)
  File "/usr/lib/python2.7/ast.py", line 79, in _convert
    raise ValueError('malformed string')
ValueError: malformed string
```