### PR TITLE
Planning: (effectively) reduce iou checkout ratio for trajectory switch

### DIFF
--- a/modules/planning/conf/planning_config.pb.txt
+++ b/modules/planning/conf/planning_config.pb.txt
@@ -227,6 +227,7 @@ default_task_config: {
     lateral_offset_to_midpoint: 0.5
     longitudinal_offset_to_midpoint: 0.2
     vehicle_box_iou_threshold_to_midpoint: 0.75
+    linear_velocity_threshold_on_ego: 0.2
   }
 }
 default_task_config: {

--- a/modules/planning/conf/scenario/valet_parking_config.pb.txt
+++ b/modules/planning/conf/scenario/valet_parking_config.pb.txt
@@ -90,7 +90,7 @@ stage_config: {
             heading_offset_to_midpoint: 0.79
             lateral_offset_to_midpoint: 0.5
             longitudinal_offset_to_midpoint: 0.2
-            vehicle_box_iou_threshold_to_midpoint: 0.9
+            vehicle_box_iou_threshold_to_midpoint: 0.75
             linear_velocity_threshold_on_ego: 0.1
         }
     }


### PR DESCRIPTION
Note: this modification will compensate the previous commit 5fc5579,  in which only the default value of the iou (but not the one eventually used) gets changed