### PR TITLE
Cyber: Make sure the accquired lock in segment will be release

### DIFF
--- a/cyber/transport/shm/segment.h
+++ b/cyber/transport/shm/segment.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "cyber/transport/shm/block.h"
 #include "cyber/transport/shm/shm_conf.h"
@@ -83,6 +84,9 @@ class Segment final {
   void* managed_shm_;
   std::mutex block_buf_lock_;
   std::unordered_map<uint32_t, uint8_t*> block_buf_addrs_;
+
+  std::vector<bool> acquired_read_lock_;
+  std::vector<bool> acquired_write_lock_;
 };
 
 }  // namespace transport


### PR DESCRIPTION
I found a issue while my development base on the segment component.
The segment will not release it owned lock if a exception happen before manually release the lock.

For example
1. Some one accquired a write lock
2. A exception happen
3. The program shutdown
4. The accquired block have been locked forever

So I suggest adding a bool array to make sure all the accquired lock must be release in destructor.

Since the accquire and release to the same lock will only do by the same process serially, so we can use a non thread safe vector to impl it. So the cost of this change is minior.