### PR TITLE
canbus data length can be less than 8

### DIFF
--- a/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
+++ b/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
@@ -187,7 +187,7 @@ ErrorCode SocketCanClientRaw::Receive(std::vector<CanFrame> *const frames,
       AERROR << "receive message failed, error code: " << ret;
       return ErrorCode::CAN_CLIENT_ERROR_BASE;
     }
-    if (recv_frames_[i].can_dlc != CANBUS_MESSAGE_LENGTH) {
+    if (recv_frames_[i].can_dlc > CANBUS_MESSAGE_LENGTH) {
       AERROR << "recv_frames_[" << i
              << "].can_dlc = " << recv_frames_[i].can_dlc
              << ", which is not equal to can message data length ("


### PR DESCRIPTION
In general, the can dlc could be any integer between 0 and 8.  This if-statement will filter out the can messages which have less than 8 byte data length. 