### PR TITLE
scripts: fix command exit status check

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -338,11 +338,11 @@ function main(){
         -v /dev/null:/dev/raw1394 \
         $IMG \
         /bin/bash
-    set +x
     if [ $? -ne 0 ];then
         error "Failed to start docker container \"${APOLLO_DEV}\" based on image: $IMG"
         exit 1
     fi
+    set +x
 
     if [ "${USER}" != "root" ]; then
         docker exec $APOLLO_DEV bash -c '/apollo/scripts/docker_adduser.sh'


### PR DESCRIPTION
We check the status of "docker run", not "set +x" 