### PR TITLE
cyber time default constructor

### DIFF
--- a/cyber/time/time.h
+++ b/cyber/time/time.h
@@ -32,14 +32,13 @@ class Time {
  public:
   static const Time MAX;
   static const Time MIN;
-  Time() {}
+  Time() = default;
   explicit Time(uint64_t nanoseconds);
   explicit Time(int nanoseconds);
   explicit Time(double seconds);
   Time(uint32_t seconds, uint32_t nanoseconds);
   Time(const Time& other);
   Time& operator=(const Time& other);
-  ~Time() {}
 
   /**
    * @brief get the current time.


### PR DESCRIPTION
It might be nice to enable value initialization or aggregate initialization for this class through the default constructor: https://stackoverflow.com/a/2418195. That way the class can be zero'd out if desired. Also, it seems that the destructor definition isn't doing anything.