### PR TITLE
only print docker run

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -194,6 +194,7 @@ fi
 IMG=${DOCKER_REPO}:$VERSION
 
 function local_volumes() {
+    set +x
     # Apollo root and bazel cache dirs are required.
     volumes="-v $APOLLO_ROOT_DIR:/apollo \
              -v $HOME/.cache:${DOCKER_HOME}/.cache"
@@ -212,6 +213,7 @@ function local_volumes() {
             ;;
     esac
     echo "${volumes}"
+    set -x
 }
 
 function main(){
@@ -338,11 +340,11 @@ function main(){
         -v /dev/null:/dev/raw1394 \
         $IMG \
         /bin/bash
+    set +x
     if [ $? -ne 0 ];then
         error "Failed to start docker container \"${APOLLO_DEV}\" based on image: $IMG"
         exit 1
     fi
-    set +x
 
     if [ "${USER}" != "root" ]; then
         docker exec $APOLLO_DEV bash -c '/apollo/scripts/docker_adduser.sh'


### PR DESCRIPTION
After:
```
[INFO] Starting docker container "apollo_dev_xmyqsh" ...
++ local_volumes
++ set +x
+ nvidia-docker run -it -d --privileged --name apollo_dev_xmyqsh --volumes-from apollo_map_volume-sunnyvale_big_loop_xmyqsh --volumes-from apollo_map_volume-sunnyvale_loop_xmyqsh --volumes-from apollo_map_volume-sunnyvale_with_two_offices_xmyqsh --volumes-from apollo_map_volume-san_mateo_xmyqsh --volumes-from apollo_yolo3d_volume_xmyqsh --volumes-from apollo_localization_volume_xmyqsh --volumes-from apollo_paddlepaddle_volume_xmyqsh --volumes-from apollo_local_third_party_volume_xmyqsh -e DISPLAY=:0 -e DOCKER_USER=xmyqsh -e USER=xmyqsh -e DOCKER_USER_ID=1000 -e DOCKER_GRP=xmyqsh -e DOCKER_GRP_ID=1000 -e DOCKER_IMG=apolloauto/apollo:dev-x86_64-20190617_1100 -e USE_GPU=1 -v /home/xmyqsh/project/apollo-5.0:/apollo -v /home/xmyqsh/.cache:/home/xmyqsh/.cache -v /dev:/dev -v /media:/media -v /tmp/.X11-unix:/tmp/.X11-unix:rw -v /etc/localtime:/etc/localtime:ro -v /usr/src:/usr/src -v /lib/modules:/lib/modules --net host -w /apollo --add-host in_dev_docker:127.0.0.1 --add-host xmyqsh-System-Product-Name:127.0.0.1 --hostname in_dev_docker --shm-size 2G --pid=host -v /dev/null:/dev/raw1394 apolloauto/apollo:dev-x86_64-20190617_1100 /bin/bash
7c9556de5b3e2b46f7410176bbca10c5cdb1bcbb4215d3671cb4e2ebe7e857e1
+ set +x
Adding group `xmyqsh' (GID 1000) ...
Done.
```
Before:
```
[INFO] Starting docker container "apollo_dev_xmyqsh" ...
++ local_volumes
++ volumes='-v /home/xmyqsh/project/apollo-5.0:/apollo              -v /home/xmyqsh/.cache:/home/xmyqsh/.cache'
++ case "$(uname -s)" in
+++ uname -s
++ volumes='-v /home/xmyqsh/project/apollo-5.0:/apollo              -v /home/xmyqsh/.cache:/home/xmyqsh/.cache -v /dev:/dev                                 -v /media:/media                                 -v /tmp/.X11-unix:/tmp/.X11-unix:rw                                 -v /etc/localtime:/etc/localtime:ro                                 -v /usr/src:/usr/src                                 -v /lib/modules:/lib/modules'
++ echo '-v /home/xmyqsh/project/apollo-5.0:/apollo              -v /home/xmyqsh/.cache:/home/xmyqsh/.cache -v /dev:/dev                                 -v /media:/media                                 -v /tmp/.X11-unix:/tmp/.X11-unix:rw                                 -v /etc/localtime:/etc/localtime:ro                                 -v /usr/src:/usr/src                                 -v /lib/modules:/lib/modules'
+ nvidia-docker run -it -d --privileged --name apollo_dev_xmyqsh --volumes-from apollo_map_volume-sunnyvale_big_loop_xmyqsh --volumes-from apollo_map_volume-sunnyvale_loop_xmyqsh --volumes-from apollo_map_volume-sunnyvale_with_two_offices_xmyqsh --volumes-from apollo_map_volume-san_mateo_xmyqsh --volumes-from apollo_yolo3d_volume_xmyqsh --volumes-from apollo_localization_volume_xmyqsh --volumes-from apollo_paddlepaddle_volume_xmyqsh --volumes-from apollo_local_third_party_volume_xmyqsh -e DISPLAY=:0 -e DOCKER_USER=xmyqsh -e USER=xmyqsh -e DOCKER_USER_ID=1000 -e DOCKER_GRP=xmyqsh -e DOCKER_GRP_ID=1000 -e DOCKER_IMG=apolloauto/apollo:dev-x86_64-20190617_1100 -e USE_GPU=1 -v /home/xmyqsh/project/apollo-5.0:/apollo -v /home/xmyqsh/.cache:/home/xmyqsh/.cache -v /dev:/dev -v /media:/media -v /tmp/.X11-unix:/tmp/.X11-unix:rw -v /etc/localtime:/etc/localtime:ro -v /usr/src:/usr/src -v /lib/modules:/lib/modules --net host -w /apollo --add-host in_dev_docker:127.0.0.1 --add-host xmyqsh-System-Product-Name:127.0.0.1 --hostname in_dev_docker --shm-size 2G --pid=host -v /dev/null:/dev/raw1394 apolloauto/apollo:dev-x86_64-20190617_1100 /bin/bash
61e561a121deaaeb7f1237e5e7b8d2e1d707fe61c7c3bfcf5eced642ada664e9
+ '[' 0 -ne 0 ']'
+ set +x
Adding group `xmyqsh' (GID 1000) ...
Done.
```