### PR TITLE
Perception: unify with cyber time

### DIFF
--- a/modules/perception/camera/lib/motion_service/motion_service.cc
+++ b/modules/perception/camera/lib/motion_service/motion_service.cc
@@ -23,9 +23,7 @@
 
 #include "cyber/common/log.h"
 #include "modules/common/math/math_utils.h"
-#include "modules/common/time/time_util.h"
 #include "modules/perception/common/sensor_manager/sensor_manager.h"
-#include "modules/perception/lib/utils/time_util.h"
 
 namespace apollo {
 namespace perception {

--- a/modules/perception/camera/lib/traffic_light/preprocessor/tl_preprocessor.cc
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/tl_preprocessor.cc
@@ -19,7 +19,6 @@
 #include "cyber/common/log.h"
 #include "modules/perception/camera/common/util.h"
 #include "modules/perception/lib/config_manager/config_manager.h"
-#include "modules/perception/lib/utils/time_util.h"
 
 namespace apollo {
 namespace perception {

--- a/modules/perception/onboard/component/fusion_camera_detection_component.cc
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.cc
@@ -25,7 +25,6 @@
 #include "modules/common/time/time_util.h"
 #include "modules/perception/common/perception_gflags.h"
 #include "modules/perception/common/sensor_manager/sensor_manager.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/onboard/common_flags/common_flags.h"
 #include "modules/perception/onboard/component/camera_perception_viz_message.h"
 
@@ -277,7 +276,7 @@ void FusionCameraDetectionComponent::OnReceiveImage(
 
   // for e2e lantency statistics
   {
-    const double cur_time = lib::TimeUtil::GetCurrentTime();
+    const double cur_time = cyber::Time::Now().ToSecond();
     const double start_latency = (cur_time - message->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:Camera:Start:msg_time[" << camera_name << "-"
           << GLOG_TIMESTAMP(message->measurement_time()) << "]:cur_time["
@@ -317,8 +316,7 @@ void FusionCameraDetectionComponent::OnReceiveImage(
   }
   // for e2e lantency statistics
   {
-    const double end_timestamp =
-        apollo::perception::lib::TimeUtil::GetCurrentTime();
+    const double end_timestamp = cyber::Time::Now().ToSecond();
     const double end_latency =
         (end_timestamp - message->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:Camera:End:msg_time[" << camera_name << "-"

--- a/modules/perception/onboard/component/fusion_component.cc
+++ b/modules/perception/onboard/component/fusion_component.cc
@@ -17,7 +17,6 @@
 
 #include "modules/perception/base/object_pool_types.h"
 #include "modules/perception/lib/utils/perf.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/onboard/common_flags/common_flags.h"
 #include "modules/perception/onboard/msg_serializer/msg_serializer.h"
 
@@ -184,7 +183,7 @@ bool FusionComponent::InternalProc(
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(
       std::string("fusion_serialize_message"), in_message->sensor_id_);
 
-  const double cur_time = lib::TimeUtil::GetCurrentTime();
+  const double cur_time = cyber::Time::Now().ToSecond();
   const double latency = (cur_time - timestamp) * 1e3;
   AINFO << "FRAME_STATISTICS:Obstacle:End:msg_time["
         << std::to_string(timestamp) << "]:cur_time["

--- a/modules/perception/onboard/component/lane_detection_component.cc
+++ b/modules/perception/onboard/component/lane_detection_component.cc
@@ -33,7 +33,6 @@
 #include "modules/common/time/time_util.h"
 #include "modules/perception/common/perception_gflags.h"
 #include "modules/perception/common/sensor_manager/sensor_manager.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/onboard/common_flags/common_flags.h"
 #include "modules/perception/onboard/component/camera_perception_viz_message.h"
 
@@ -287,7 +286,7 @@ void LaneDetectionComponent::OnReceiveImage(
 
   // for e2e lantency statistics
   {
-    const double cur_time = lib::TimeUtil::GetCurrentTime();
+    const double cur_time = cyber::Time::Now().ToSecond();
     const double start_latency = (cur_time - message->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:Camera:Start:msg_time[" << camera_name << "-"
           << GLOG_TIMESTAMP(message->measurement_time()) << "]:cur_time["
@@ -311,8 +310,7 @@ void LaneDetectionComponent::OnReceiveImage(
 
   // for e2e lantency statistics
   {
-    const double end_timestamp =
-        apollo::perception::lib::TimeUtil::GetCurrentTime();
+    const double end_timestamp = cyber::Time::Now().ToSecond();
     const double end_latency =
         (end_timestamp - message->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:Camera:End:msg_time[" << camera_name << "-"

--- a/modules/perception/onboard/component/radar_detection_component.cc
+++ b/modules/perception/onboard/component/radar_detection_component.cc
@@ -59,7 +59,7 @@ bool RadarDetectionComponent::Init() {
 bool RadarDetectionComponent::Proc(const std::shared_ptr<ContiRadar>& message) {
   AINFO << "Enter radar preprocess, message timestamp: "
         << std::to_string(message->header().timestamp_sec())
-        << " current timestamp " << lib::TimeUtil::GetCurrentTime();
+        << " current timestamp " << cyber::Time::Now().ToSecond();
   std::shared_ptr<SensorFrameMessage> out_message(new (std::nothrow)
                                                       SensorFrameMessage);
   if (!InternalProc(message, out_message)) {
@@ -104,7 +104,7 @@ bool RadarDetectionComponent::InternalProc(
     ++seq_num_;
   }
   double timestamp = in_message->header().timestamp_sec();
-  const double cur_time = lib::TimeUtil::GetCurrentTime();
+  const double cur_time = cyber::Time::Now().ToSecond();
   const double start_latency = (cur_time - timestamp) * 1e3;
   AINFO << "FRAME_STATISTICS:Radar:Start:msg_time[" << std::to_string(timestamp)
         << "]:cur_time[" << std::to_string(cur_time) << "]:cur_latency["
@@ -184,7 +184,7 @@ bool RadarDetectionComponent::InternalProc(
   out_message->frame_->sensor2world_pose = radar_trans;
   out_message->frame_->objects = radar_objects;
 
-  const double end_timestamp = lib::TimeUtil::GetCurrentTime();
+  const double end_timestamp = cyber::Time::Now().ToSecond();
   const double end_latency =
       (end_timestamp - in_message->header().timestamp_sec()) * 1e3;
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(radar_info_.name,

--- a/modules/perception/onboard/component/radar_detection_component.h
+++ b/modules/perception/onboard/component/radar_detection_component.h
@@ -22,7 +22,6 @@
 #include "cyber/component/component.h"
 #include "modules/localization/proto/localization.pb.h"
 #include "modules/perception/base/sensor_meta.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/map/hdmap/hdmap_input.h"
 #include "modules/perception/onboard/common_flags/common_flags.h"
 #include "modules/perception/onboard/inner_component_messages/inner_component_messages.h"

--- a/modules/perception/onboard/component/recognition_component.cc
+++ b/modules/perception/onboard/component/recognition_component.cc
@@ -17,7 +17,6 @@
 #include "modules/perception/base/object_pool_types.h"
 #include "modules/perception/common/sensor_manager/sensor_manager.h"
 #include "modules/perception/lib/utils/perf.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/lidar/common/lidar_error_code.h"
 #include "modules/perception/lidar/common/lidar_log.h"
 // #include "modules/perception/onboard/component/lidar_common_flags.h"
@@ -46,7 +45,7 @@ bool RecognitionComponent::Proc(
     const std::shared_ptr<LidarFrameMessage>& message) {
   AINFO << "Enter Tracking component, message timestamp: "
         << std::to_string(message->timestamp_) << " current timestamp: "
-        << std::to_string(lib::TimeUtil::GetCurrentTime());
+        << std::to_string(cyber::Time::Now().ToSecond());
 
   std::shared_ptr<SensorFrameMessage> out_message =
       std::make_shared<SensorFrameMessage>();
@@ -118,7 +117,7 @@ bool RecognitionComponent::InternalProc(
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name,
                                            "recognition_2::fill_out_message");
 
-  const double end_timestamp = lib::TimeUtil::GetCurrentTime();
+  const double end_timestamp = cyber::Time::Now().ToSecond();
   const double end_latency = (end_timestamp - in_message->timestamp_) * 1e3;
   AINFO << "FRAME_STATISTICS:Lidar:End:msg_time["
         << std::to_string(in_message->timestamp_) << "]:cur_time["

--- a/modules/perception/onboard/component/segmentation_component.cc
+++ b/modules/perception/onboard/component/segmentation_component.cc
@@ -17,7 +17,6 @@
 
 #include "modules/perception/common/sensor_manager/sensor_manager.h"
 #include "modules/perception/lib/utils/perf.h"
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/lidar/common/lidar_error_code.h"
 #include "modules/perception/lidar/common/lidar_frame_pool.h"
 #include "modules/perception/lidar/common/lidar_log.h"
@@ -56,7 +55,7 @@ bool SegmentationComponent::Proc(
     const std::shared_ptr<drivers::PointCloud>& message) {
   AINFO << "Enter segmentation component, message timestamp: "
         << std::to_string(message->measurement_time()) << " current timestamp: "
-        << std::to_string(lib::TimeUtil::GetCurrentTime());
+        << std::to_string(cyber::Time::Now().ToSecond());
 
   std::shared_ptr<LidarFrameMessage> out_message(new (std::nothrow)
                                                      LidarFrameMessage);
@@ -102,7 +101,7 @@ bool SegmentationComponent::InternalProc(
     s_seq_num_++;
   }
   const double timestamp = in_message->measurement_time();
-  const double cur_time = lib::TimeUtil::GetCurrentTime();
+  const double cur_time = cyber::Time::Now().ToSecond();
   const double start_latency = (cur_time - timestamp) * 1e3;
   AINFO << "FRAME_STATISTICS:Lidar:Start:msg_time[" << std::to_string(timestamp)
         << sensor_name_ << ":Start:msg_time["

--- a/modules/perception/onboard/component/trafficlights_perception_component.cc
+++ b/modules/perception/onboard/component/trafficlights_perception_component.cc
@@ -305,13 +305,13 @@ void TrafficLightsPerceptionComponent::OnReceiveImage(
     const std::shared_ptr<apollo::drivers::Image> msg,
     const std::string& camera_name) {
   std::lock_guard<std::mutex> lck(mutex_);
-  double receive_img_timestamp = lib::TimeUtil::GetCurrentTime();
+  double receive_img_timestamp = cyber::Time::Now().ToSecond();
   double image_msg_ts = msg->measurement_time();
   image_msg_ts += image_timestamp_offset_;
   last_sub_camera_image_ts_[camera_name] = image_msg_ts;
 
   {
-    const double cur_time = lib::TimeUtil::GetCurrentTime();
+    const double cur_time = cyber::Time::Now().ToSecond();
     const double start_latency = (cur_time - msg->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:TrafficLights:Start:msg_time["
           << GLOG_TIMESTAMP(msg->measurement_time()) << "]:cur_time["
@@ -405,7 +405,7 @@ void TrafficLightsPerceptionComponent::OnReceiveImage(
   const auto verify_lights_projection_time =
       PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(perf_indicator,
                                                "VerifyLightsProjection");
-  last_proc_image_ts_ = lib::TimeUtil::GetCurrentTime();
+  last_proc_image_ts_ = cyber::Time::Now().ToSecond();
 
   AINFO << "start proc.";
   traffic_light_pipeline_->Perception(camera_perception_options_, &frame_);
@@ -437,7 +437,7 @@ void TrafficLightsPerceptionComponent::OnReceiveImage(
       PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(perf_indicator, "SendMessage");
 
   const auto total_time = static_cast<int64_t>(
-      (lib::TimeUtil::GetCurrentTime() - receive_img_timestamp) * 1e3);
+      (cyber::Time::Now().ToSecond() - receive_img_timestamp) * 1e3);
   AINFO << "TrafficLightsPerception perf_info."
         << " number_of_lights: " << frame_.traffic_lights.size()
         << " check_camera_status_time: " << check_camera_status_time << " ms."
@@ -453,7 +453,7 @@ void TrafficLightsPerceptionComponent::OnReceiveImage(
         << " total: " << total_time << " ms.";
   AINFO << out_msg->DebugString();
   {
-    const double end_timestamp = lib::TimeUtil::GetCurrentTime();
+    const double end_timestamp = cyber::Time::Now().ToSecond();
     const double end_latency = (end_timestamp - msg->measurement_time()) * 1e3;
     AINFO << "FRAME_STATISTICS:TrafficLights:End:msg_time["
           << GLOG_TIMESTAMP(msg->measurement_time()) << "]:cur_time["
@@ -566,7 +566,7 @@ bool TrafficLightsPerceptionComponent::UpdateCameraSelection(
     double timestamp, const camera::TLPreprocessorOption& option,
     camera::CameraFrame* frame) {
   PERCEPTION_PERF_FUNCTION();
-  const double current_ts = lib::TimeUtil::GetCurrentTime();
+  const double current_ts = cyber::Time::Now().ToSecond();
   if (last_query_tf_ts_ > 0.0 &&
       current_ts - last_query_tf_ts_ < query_tf_interval_seconds_) {
     AINFO << "skip current tf msg, img_ts: " << std::to_string(timestamp)

--- a/modules/perception/onboard/msg_serializer/msg_serializer.cc
+++ b/modules/perception/onboard/msg_serializer/msg_serializer.cc
@@ -19,7 +19,6 @@
 
 #include "cyber/common/log.h"
 
-#include "modules/perception/lib/utils/time_util.h"
 #include "modules/perception/onboard/common_flags/common_flags.h"
 
 namespace apollo {
@@ -30,7 +29,6 @@ bool MsgSerializer::SerializeMsg(double timestamp, int seq_num,
                                  const std::vector<base::ObjectPtr> &objects,
                                  const apollo::common::ErrorCode &error_code,
                                  PerceptionObstacles *obstacles) {
-  // double publish_time = lib::TimeUtil::GetCurrentTime();
   double publish_time = cyber::Time::Now().ToSecond();
   ::apollo::common::Header *header = obstacles->mutable_header();
   header->set_timestamp_sec(publish_time);


### PR DESCRIPTION
Unify perception module with cyber time.
Because all of the perception sensor drivers use cyber time.

And if [9161](https://github.com/ApolloAuto/apollo/pull/9161) is approved.
Then we could unify all of the time with Clock time(Tick time).