### PR TITLE
Perception: fix RemoveGroundPointsInForegroundCluster and set points_in_rois

### DIFF
--- a/modules/perception/lidar/common/cloud_mask.cc
+++ b/modules/perception/lidar/common/cloud_mask.cc
@@ -67,6 +67,11 @@ void CloudMask::AddIndices(const base::PointIndices& indices, int value) {
   AddIndices(indices.indices, value);
 }
 
+void CloudMask::AddIndices(const base::PointIndices& indices0,
+                           const base::PointIndices& indices1) {
+  AddIndices(indices0.indices, indices1.indices);
+}
+
 void CloudMask::AddIndicesOfIndices(
     const base::PointIndices& indices,
     const base::PointIndices& indices_of_indices, int value) {

--- a/modules/perception/lidar/common/cloud_mask.h
+++ b/modules/perception/lidar/common/cloud_mask.h
@@ -96,6 +96,21 @@ class CloudMask {
   template <typename IntegerType>
   void AddIndices(const std::vector<IntegerType>& indices, int value = 1);
 
+  // @brief: add point indices, cross set of indices0 and indices1,
+  //                                    base::PointIndices version
+  // @param [in]: indices0
+  // @param [in]: indices1
+  void AddIndices(const base::PointIndices& indices0,
+                  const base::PointIndices& indices1);
+
+  // @brief: add point indices, cross set of indices0 and indices1,
+  //                              std::vector<IntegerType> version
+  // @param [in]: indices0
+  // @param [in]: indices1
+  template <typename IntegerType>
+  void AddIndices(const std::vector<IntegerType>& indices0,
+                  const std::vector<IntegerType>& indices1);
+
   // @brief: add point indices of indices
   // @param [in]: indices
   // @param [in]: indices of indices (first param)
@@ -142,6 +157,26 @@ template <typename IntegerType>
 void CloudMask::AddIndices(const std::vector<IntegerType>& indices, int value) {
   for (auto& id : indices) {
     mask_[id] = value;
+  }
+}
+
+template <typename IntegerType>
+void CloudMask::AddIndices(const std::vector<IntegerType>& indices0,
+                           const std::vector<IntegerType>& indices1) {
+  if (indices0.size() > indices1.size()) {
+    AddIndices(indices1, indices0);
+    return;
+  }
+  for (auto& id : indices0) {
+    mask_[id] = 1;
+  }
+  for (auto& id : indices1) {
+    if (mask_[id]) {
+      mask_[id] = 2;
+    }
+  }
+  for (auto& id : indices0) {
+    --mask_[id];
   }
 }
 

--- a/modules/perception/lidar/lib/segmentation/cnnseg/spp_engine/spp_engine.cc
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/spp_engine/spp_engine.cc
@@ -132,14 +132,14 @@ size_t SppEngine::ProcessForegroundSegmentation(
 size_t SppEngine::RemoveGroundPointsInForegroundCluster(
     const base::PointFCloudConstPtr full_point_cloud,
     const base::PointIndices& roi_indices,
-    const base::PointIndices& roi_non_ground_indices) {
+    const base::PointIndices& non_ground_indices) {
   mask_.Set(full_point_cloud->size(), 0);
-  mask_.AddIndices(roi_indices);
-  mask_.RemoveIndicesOfIndices(roi_indices, roi_non_ground_indices);
-  mask_.Flip();
-  // at this time, all ground points has mask value 0
+  mask_.AddIndices(roi_indices, non_ground_indices);
+  // at this time, all non roi points or ground points has mask value 0
   for (size_t i = 0; i < clusters_.size(); ++i) {
     clusters_[static_cast<int>(i)]->RemovePoints(mask_);
+    clusters_[static_cast<int>(i)]->points_in_roi =
+      clusters_[static_cast<int>(i)]->points.size();
   }
   clusters_.RemoveEmptyClusters();
   return clusters_.size();

--- a/modules/perception/lidar/lib/segmentation/cnnseg/spp_engine/spp_engine.h
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/spp_engine/spp_engine.h
@@ -50,11 +50,11 @@ class SppEngine {
   // @brief: remove ground points in foreground cluster
   // @param [in]: point cloud
   // @param [in]: roi indices of point cloud
-  // @param [in]: non ground indices in roi of point cloud
+  // @param [in]: non ground indices of point cloud
   size_t RemoveGroundPointsInForegroundCluster(
       const base::PointFCloudConstPtr full_point_cloud,
       const base::PointIndices& roi_indices,
-      const base::PointIndices& roi_non_ground_indices);
+      const base::PointIndices& non_ground_indices);
   // @brief: get cluster list, const version
   // @return: cluster list
   inline const SppClusterList& clusters() const { return clusters_; }


### PR DESCRIPTION
fix RemoveGroundPointsInForegroundCluster
     Note: the non_ground_indices is the indices of the cloud,
               not the indices of roi_indices
     (This mismatch may be caused by API update)

set points_in_roi