### PR TITLE
Cyber: moved common globaldata instance check

### DIFF
--- a/cyber/init.cc
+++ b/cyber/init.cc
@@ -53,7 +53,6 @@ void InitLogger(const char* binary_name) {
   } else {
     ::apollo::cyber::Binary::SetName(binary_name);
   }
-  CHECK_NOTNULL(common::GlobalData::Instance());
 
   // Init glog
   google::InitGoogleLogging(binary_name);

--- a/cyber/logger/logger_util.h
+++ b/cyber/logger/logger_util.h
@@ -73,6 +73,7 @@ inline void FindModuleName(std::string* log_message, std::string* module_name) {
     }
   }
   if (module_name->empty()) {
+    CHECK_NOTNULL(common::GlobalData::Instance());
     *module_name = common::GlobalData::Instance()->ProcessGroup();
   }
 }


### PR DESCRIPTION
There's a warning whenever any cyber program is run. To reproduce
```
bazel build //cyber/examples:talker
bazel-bin/cyber/examples/talker
```
The warning is
```
WARNING: Logging before InitGoogleLogging() is written to STDERR
```

After this change, the warning will go away. All glog calls should occur after the `google::InitGoogleLogging(binary_name);`. I assume this check is for async logger. Must all singletons be checked for not null?