### PR TITLE
Cyber: intra supports raw message pub proto sub

### DIFF
--- a/cyber/transport/dispatcher/dispatcher.h
+++ b/cyber/transport/dispatcher/dispatcher.h
@@ -97,7 +97,7 @@ void Dispatcher::AddListener(const RoleAttributes& self_attr,
     handler =
         std::dynamic_pointer_cast<ListenerHandler<MessageT>>(*handler_base);
     if (handler == nullptr) {
-      AERROR << "please ensure that readers with the same channel["
+      AFATAL << "please ensure that readers with the same channel["
              << self_attr.channel_name()
              << "] in the same process have the same message type";
       return;
@@ -126,7 +126,7 @@ void Dispatcher::AddListener(const RoleAttributes& self_attr,
     handler =
         std::dynamic_pointer_cast<ListenerHandler<MessageT>>(*handler_base);
     if (handler == nullptr) {
-      AERROR << "please ensure that readers with the same channel["
+      AFATAL << "please ensure that readers with the same channel["
              << self_attr.channel_name()
              << "] in the same process have the same message type";
       return;

--- a/cyber/transport/dispatcher/intra_dispatcher_test.cc
+++ b/cyber/transport/dispatcher/intra_dispatcher_test.cc
@@ -28,22 +28,23 @@ namespace apollo {
 namespace cyber {
 namespace transport {
 
-TEST(IntraDispatcherTest, on_message) {
+constexpr char kContent[] = "on_message";
+
+TEST(IntraDispatcherTest, on_chatter_message) {
+  constexpr char kChannelName[] = "on_chatter_message_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
   auto dispatcher = IntraDispatcher::Instance();
 
   auto send_pb_msg = std::make_shared<proto::Chatter>();
   send_pb_msg->set_timestamp(123);
   send_pb_msg->set_lidar_timestamp(456);
   send_pb_msg->set_seq(789);
-  send_pb_msg->set_content("on_message");
-
-  MessageInfo msg_info;
-
-  dispatcher->OnMessage(common::Hash("pb_channel"), send_pb_msg, msg_info);
+  send_pb_msg->set_content(kContent);
 
   RoleAttributes attr;
-  attr.set_channel_name("pb_channel");
-  attr.set_channel_id(common::Hash("pb_channel"));
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
   Identity pb_id;
   attr.set_id(pb_id.HashValue());
   auto recv_pb_msg = std::make_shared<proto::Chatter>();
@@ -53,15 +54,24 @@ TEST(IntraDispatcherTest, on_message) {
         (void)msg_info;
         recv_pb_msg->CopyFrom(*msg);
       });
-  dispatcher->OnMessage(common::Hash("pb_channel"), send_pb_msg, msg_info);
+  MessageInfo msg_info;
+  dispatcher->OnMessage(kChannelNameHash, send_pb_msg, msg_info);
 
   EXPECT_EQ(recv_pb_msg->timestamp(), 123);
   EXPECT_EQ(recv_pb_msg->lidar_timestamp(), 456);
   EXPECT_EQ(recv_pb_msg->seq(), 789);
-  EXPECT_EQ(recv_pb_msg->content(), "on_message");
+  EXPECT_EQ(recv_pb_msg->content(), kContent);
+}
 
-  attr.set_channel_name("raw_channel");
-  attr.set_channel_id(common::Hash("raw_channel"));
+TEST(IntraDispatcherTest, on_raw_message) {
+  constexpr char kChannelName[] = "on_raw_message_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
+  auto dispatcher = IntraDispatcher::Instance();
+
+  RoleAttributes attr;
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
   Identity raw_id;
   attr.set_id(raw_id.HashValue());
   auto recv_raw_msg = std::make_shared<message::RawMessage>();
@@ -72,12 +82,124 @@ TEST(IntraDispatcherTest, on_message) {
         recv_raw_msg->message = msg->message;
       });
 
-  auto send_raw_msg = std::make_shared<message::RawMessage>("on_message");
-  dispatcher->OnMessage(common::Hash("raw_channel"), send_raw_msg, msg_info);
+  auto send_raw_msg = std::make_shared<message::RawMessage>(kContent);
+  MessageInfo msg_info;
+  dispatcher->OnMessage(kChannelNameHash, send_raw_msg, msg_info);
 
   EXPECT_EQ(recv_raw_msg->message, send_raw_msg->message);
+}
+
+TEST(IntraDispatcherTest, raw_msg_pb_dispatcher_message) {
+  constexpr char kChannelName[] = "raw_msg_pb_dispatcher_message_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
+  auto dispatcher = IntraDispatcher::Instance();
+
+  RoleAttributes attr;
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
+  Identity raw_id;
+  attr.set_id(raw_id.HashValue());
+  auto recv_pb_msg = std::make_shared<proto::Chatter>();
+  dispatcher->AddListener<proto::Chatter>(
+      attr, [&recv_pb_msg](const std::shared_ptr<proto::Chatter>& msg,
+                           const MessageInfo& msg_info) {
+        (void)msg_info;
+        recv_pb_msg = msg;
+      });
+
+  proto::Chatter send_pb_msg;
+  send_pb_msg.set_content(kContent);
+  const std::string send_pb_msg_str = send_pb_msg.SerializeAsString();
+  auto send_raw_msg = std::make_shared<message::RawMessage>(send_pb_msg_str);
+  MessageInfo msg_info;
+  dispatcher->OnMessage(kChannelNameHash, send_raw_msg, msg_info);
+
+  std::string recv_pb_msg_str;
+  recv_pb_msg->SerializeToString(&recv_pb_msg_str);
+  EXPECT_EQ(recv_pb_msg_str, send_raw_msg->message);
+}
+
+TEST(IntraDispatcherTest, pb_msg_raw_dispatcher) {
+  constexpr char kChannelName[] = "pb_msg_raw_dispatcher_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
+  auto dispatcher = IntraDispatcher::Instance();
+
+  RoleAttributes attr;
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
+  Identity raw_id;
+  attr.set_id(raw_id.HashValue());
+  auto recv_raw_msg = std::make_shared<message::RawMessage>();
+  dispatcher->AddListener<message::RawMessage>(
+      attr, [&recv_raw_msg](const std::shared_ptr<message::RawMessage>& msg,
+                            const MessageInfo& msg_info) {
+        (void)msg_info;
+        recv_raw_msg->message = msg->message;
+      });
+
+  auto send_pb_msg = std::make_shared<proto::Chatter>();
+  send_pb_msg->set_content(kContent);
+  MessageInfo msg_info;
+  dispatcher->OnMessage(kChannelNameHash, send_pb_msg, msg_info);
+
+  std::string send_pb_msg_str;
+  send_pb_msg->SerializeToString(&send_pb_msg_str);
+  EXPECT_EQ(send_pb_msg_str, recv_raw_msg->message);
+}
+
+TEST(IntraDispatcherTest, chatter_msg_unit_test_dispatcher) {
+  constexpr char kChannelName[] = "chatter_msg_unit_test_dispatcher_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
+  auto dispatcher = IntraDispatcher::Instance();
+
+  RoleAttributes attr;
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
+  Identity raw_id;
+  attr.set_id(raw_id.HashValue());
+  dispatcher->AddListener<proto::UnitTest>(
+      attr, [](const std::shared_ptr<proto::UnitTest>& msg,
+               const MessageInfo& msg_info) {
+        (void)msg_info;
+        (void)msg;
+      });
+
+  auto send_pb_msg = std::make_shared<proto::Chatter>();
+  send_pb_msg->set_content(kContent);
+  MessageInfo msg_info;
+  ASSERT_DEATH(
+      dispatcher->OnMessage(kChannelNameHash, send_pb_msg, msg_info),
+      "please ensure that readers with the same channel\\[\\] in the same "
+      "process have the same message type");
+}
+
+TEST(IntraDispatcherTest, raw_msg_int_dispatcher) {
+  constexpr char kChannelName[] = "raw_msg_int_dispatcher_channel";
+  static const std::size_t kChannelNameHash = common::Hash(kChannelName);
+
+  auto dispatcher = IntraDispatcher::Instance();
+
+  RoleAttributes attr;
+  attr.set_channel_name(kChannelName);
+  attr.set_channel_id(kChannelNameHash);
+  Identity raw_id;
+  attr.set_id(raw_id.HashValue());
+  dispatcher->AddListener<int>(
+      attr, [](const std::shared_ptr<int>& msg, const MessageInfo& msg_info) {
+        (void)msg_info;
+        (void)msg;
+      });
+
+  auto send_pb_msg = std::make_shared<message::RawMessage>(kContent);
+  MessageInfo msg_info;
+  ASSERT_DEATH(dispatcher->OnMessage(kChannelNameHash, send_pb_msg, msg_info),
+               "i not supported.");
 }
 
 }  // namespace transport
 }  // namespace cyber
 }  // namespace apollo
+


### PR DESCRIPTION
This functionality should allow for cyber records to be published and subscribed by unmodified modules in the same process. A proto message can subscribe and read messages from a raw message publisher. It's implemented as overloads so there shouldn't be runtime overhead. A separate class was used because partial template specialization works at the class level and not the function level.

It may be slightly better to have the publisher do the type conversion so that multiple subscribers don't have to parse the RawMessage. For my use cases there are few subscribers on the same channel name so the optimization would do little.

There's a controversial part where the type checks are moved to fatal. I think this change is correct, because that is a programming error that we can only catch at runtime. Also, sometimes the error level messages are hard to see, but the crashes are more obvious. Generally, the subscribers are setup at boot so most modules would crash at boot. On the other hand, this means that a publisher can crash a node by publishing message with a different type. In practice, I think trading off correctness over preventing crashes in unusual situations is worth it.