### PR TITLE
cyber: align channel info for cyber_recorder info record

### DIFF
--- a/cyber/tools/cyber_recorder/info.cc
+++ b/cyber/tools/cyber_recorder/info.cc
@@ -91,7 +91,7 @@ bool Info::Display(const std::string& file) {
   }
 
   // channel info
-  std::cout << std::setw(w) << "channel_info: ";
+  std::cout << std::setw(w) << "channel_info: " << std::endl;
   Index idx = file_reader.GetIndex();
   for (int i = 0; i < idx.indexes_size(); ++i) {
     ChannelCache* cache = idx.mutable_indexes(i)->mutable_channel_cache();


### PR DESCRIPTION
Start new line to align `cyber_recorder ` field channel info.

![Screenshot from 2019-08-06 17-38-34](https://user-images.githubusercontent.com/3821311/62601358-c6188380-b923-11e9-9094-7d748dac4ceb.png)
