### PR TITLE
add scripts for perception sensors calibration

### DIFF
--- a/modules/tools/sensor_calibration/README.md
+++ b/modules/tools/sensor_calibration/README.md
@@ -1,0 +1,22 @@
+# Sensor Calibration
+
+## ins_stat_publisher.py
+
+Cause GNSS device NEWTON M2 can't generate topic "/apollo/sensor/gnss/ins_stat", this tool is used to publish a fake "/apollo/sensor/gnss/ins_stat"   
+
+Run the following command from your Apollo root dir:
+
+```
+python modules/tools/sensor_calibration/ins_stat_publisher.py
+```
+
+## odom_publisher.py
+
+Cause GNSS device NEWTON M2 can't generate topic "/apollo/sensor/gnss/odometry", this tool is used to publish topic "/apollo/sensor/gnss/odometry" through subscribe topic "/apollo/localization/pose" 
+
+Run the following command from your Apollo root dir:
+
+```
+python modules/tools/sensor_calibration/odom_publisher.py
+```
+

--- a/modules/tools/sensor_calibration/ins_stat_publisher.py
+++ b/modules/tools/sensor_calibration/ins_stat_publisher.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import argparse
+import atexit
+import logging
+import os
+import sys
+
+import rospy
+import scipy.signal as signal
+from numpy import genfromtxt
+
+from modules.drivers.gnss.proto import ins_pb2
+
+
+class InsStat(object):
+    def __init__(self):
+        self.insstat_pub = rospy.Publisher('/apollo/sensor/gnss/ins_stat', ins_pb2.InsStat, queue_size=1)
+        self.sequence_num = 0
+        self.terminating = False
+
+    def publish_statmsg(self):
+        insstat = ins_pb2.InsStat()
+        now = rospy.get_time()
+        insstat.header.timestamp_sec = now
+        insstat.ins_status = 3
+        insstat.pos_type = 56
+        rospy.loginfo("%s"%insstat)
+        self.insstat_pub.publish(insstat)
+
+    def shutdown(self):
+        """
+        shutdown rosnode
+        """
+        self.terminating = True
+        self.logger.info("Shutting Down...")
+        rospy.sleep(0.2)
+
+def main():
+    """
+    Main rosnode
+    """
+    rospy.init_node('ins_stat_publisher', anonymous=True)
+    ins_stat = InsStat()
+    rate = rospy.Rate(2)
+    while not rospy.is_shutdown():
+        ins_stat.publish_statmsg()
+        rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except rospy.ROSInterruptException:
+        pass

--- a/modules/tools/sensor_calibration/odom_publisher.py
+++ b/modules/tools/sensor_calibration/odom_publisher.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import argparse
+import atexit
+import logging
+import os
+import sys
+
+import rospy
+from gflags import FLAGS
+
+from modules.localization.proto import localization_pb2
+from modules.localization.proto import gps_pb2
+
+class OdomPublisher(object):
+    def __init__(self):
+        self.localization = localization_pb2.LocalizationEstimate()
+        self.gps_odom_pub = rospy.Publisher('/apollo/sensor/gnss/odometry', gps_pb2.Gps, queue_size=1) 
+        self.sequence_num = 0
+        self.terminating = False
+        self.position_x = 0
+        self.position_y = 0
+        self.position_z = 0
+        self.orientation_x = 0
+        self.orientation_y = 0
+        self.orientation_z = 0
+        self.orientation_w = 0
+        self.linear_velocity_x = 0 
+        self.linear_velocity_y = 0
+        self.linear_velocity_z = 0
+
+    def localization_callback(self, data):
+        """
+        New message received
+        """
+        self.localization.CopyFrom(data)
+        self.position_x = self.localization.pose.position.x
+        self.position_y = self.localization.pose.position.y
+        self.position_z = self.localization.pose.position.z
+        self.orientation_x = self.localization.pose.orientation.qx
+        self.orientation_y = self.localization.pose.orientation.qy
+        self.orientation_z = self.localization.pose.orientation.qz
+        self.orientation_w = self.localization.pose.orientation.qw
+        self.linear_velocity_x = self.localization.pose.linear_velocity.x
+        self.linear_velocity_y = self.localization.pose.linear_velocity.y
+        self.linear_velocity_z = self.localization.pose.linear_velocity.z
+
+    def odom_callback(self):
+        odom = gps_pb2.Gps()
+        now = rospy.get_time()
+        odom.header.timestamp_sec = now
+        odom.localization.position.x = self.position_x
+        odom.localization.position.y = self.position_y
+        odom.localization.position.z = self.position_z
+        odom.localization.orientation.qx = self.orientation_x
+        odom.localization.orientation.qy = self.orientation_y
+        odom.localization.orientation.qz = self.orientation_z
+        odom.localization.orientation.qw = self.orientation_w
+        odom.localization.linear_velocity.x = self.linear_velocity_x
+        odom.localization.linear_velocity.y = self.linear_velocity_y
+        odom.localization.linear_velocity.z = self.linear_velocity_z
+        rospy.loginfo("%s"%odom)
+        self.gps_odom_pub.publish(odom)
+
+    def shutdown(self):
+        """
+        shutdown rosnode
+        """
+        self.terminating = True
+        self.logger.info("Shutting Down...")
+        self.file_handler.close()
+        rospy.sleep(0.1)
+
+def main():
+    """
+    Main rosnode
+    """
+    rospy.init_node('odom_publisher', anonymous=True)
+    odom = OdomPublisher()
+    rospy.Subscriber('/apollo/localization/pose', localization_pb2.LocalizationEstimate, odom.localization_callback)
+    rate = rospy.Rate(100)
+    while not rospy.is_shutdown():
+        odom.odom_callback()
+        rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
Cause the GNSS device(NEWTON M2) of development_kits can't generate topic "/apollo/sensor/gnss/odometry" & "/apollo/sensor/gnss/ins_stat",  but those topics required by Apollo's sensor calibration tools ,  so the scripts are used to publish "/apollo/sensor/gnss/odometry" through subscribe "/apollo/localization/pose" and publish a fake "/apollo/sensor/gnss/ins_stat". 
