### PR TITLE
Planning: path_bounds_decider handles NO_BORROW

### DIFF
--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -1325,6 +1325,10 @@ void PathBoundsDecider::PathBoundsDebugString(
 bool PathBoundsDecider::CheckLaneBoundaryType(
     const ReferenceLineInfo& reference_line_info, const double check_s,
     const LaneBorrowInfo& lane_borrow_info) {
+  if (lane_borrow_info == LaneBorrowInfo::NO_BORROW) {
+    return false;
+  }
+
   const ReferenceLine& reference_line = reference_line_info.reference_line();
   auto ref_point = reference_line.GetNearestReferencePoint(check_s);
   if (ref_point.lane_waypoints().empty()) {


### PR DESCRIPTION
There is UB on reading unitialized `lane_boundary_type`, when `lane_borrow_info` is set to `NO_BORROW`.