### PR TITLE
container writes bash history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ docs/demo_guide/*.bag
 
 # Logs
 cyber/log/*
+
+# Bash Environment
+.dev_bash_hist

--- a/docker/scripts/dev_into.sh
+++ b/docker/scripts/dev_into.sh
@@ -19,6 +19,7 @@
 xhost +local:root 1>/dev/null 2>&1
 docker exec \
     -u $USER \
+    -e HISTFILE=/apollo/.dev_bash_hist \
     -it apollo_dev_$USER \
     /bin/bash
 xhost -local:root 1>/dev/null 2>&1


### PR DESCRIPTION
It's convenient to return to the container and lookup old commands in the bash history. For example,
```
docker/scripts/dev_into.sh
echo 1
exit
docker/scripts/dev_into.sh
```
Pressing up or using ctrl-R will use bashes history to lookup previous commands.