### PR TITLE
Planning: change obstacle to mutable_obstacle, obstacle and mutable_obstacle do not point to the same object

### DIFF
--- a/modules/planning/common/reference_line_info.cc
+++ b/modules/planning/common/reference_line_info.cc
@@ -369,7 +369,7 @@ Obstacle* ReferenceLineInfo::AddObstacle(const Obstacle* obstacle) {
   }
   mutable_obstacle->SetPerceptionSlBoundary(perception_sl);
   mutable_obstacle->CheckLaneBlocking(reference_line_);
-  if (obstacle->IsLaneBlocking()) {
+  if (mutable_obstacle->IsLaneBlocking()) {
     ADEBUG << "obstacle [" << obstacle->Id() << "] is lane blocking.";
   } else {
     ADEBUG << "obstacle [" << obstacle->Id() << "] is NOT lane blocking.";


### PR DESCRIPTION
obstacle and mutable_obstacle do not point to the same object