### PR TITLE
Move unset OMP_NUM_THREADS to apollo base.

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -446,6 +446,7 @@ function run() {
 }
 
 check_in_docker
+unset OMP_NUM_THREADS
 if [ $APOLLO_IN_DOCKER = "true" ]; then
   CYBER_SETUP="/apollo/cyber/setup.bash"
   if [ -e "${CYBER_SETUP}" ]; then

--- a/scripts/docker_adduser.sh
+++ b/scripts/docker_adduser.sh
@@ -30,7 +30,6 @@ if [ -e "/apollo/scripts/apollo_base.sh" ]; then
   source /apollo/scripts/apollo_base.sh
 fi
 
-unset OMP_NUM_THREADS
 ulimit -c unlimited
 ' >> "/home/${DOCKER_USER}/.bashrc"
 


### PR DESCRIPTION
In dreamland online service, docker_adduser.sh will not be called. "unset OMP_NUM_THREADS" will not work when dreamland build.