### PR TITLE
Planning: enhance intersection scenarios selection logic

### DIFF
--- a/modules/planning/scenarios/scenario_manager.cc
+++ b/modules/planning/scenarios/scenario_manager.cc
@@ -648,7 +648,6 @@ void ScenarioManager::ScenarioDispatch(const common::TrajectoryPoint& ego_point,
       } else if (FLAGS_enable_scenario_bare_intersection &&
                  overlap.first == ReferenceLineInfo::PNC_JUNCTION) {
         pnc_junction_overlap = const_cast<hdmap::PathOverlap*>(&overlap.second);
-        break;
       }
     }
 


### PR DESCRIPTION
One thing is exchange the order of `FLAGS_enable_scenario` checking to prevent the unenabled scenario affects other overlap scenario.

The other is to add the missing `break` after `pnc_junction_overlap` scenario is selected. I'm not sure this `break` is necesary or not. Please double check here.
NOTE: `first_encountered_overlaps` has already been sorted with `start_s`.