### PR TITLE
Planning: make Stage::tasks_ static

### DIFF
--- a/modules/planning/scenarios/stage.h
+++ b/modules/planning/scenarios/stage.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -89,9 +89,14 @@ class Stage {
   virtual Stage::StageStatus FinishScenario();
 
  protected:
-  std::map<TaskConfig::TaskType, std::unique_ptr<Task>> tasks_;
+  static std::unordered_map<ScenarioConfig::StageType,
+                            std::unordered_map<TaskConfig::TaskType,
+                                               std::unique_ptr<Task>,
+                                               std::hash<int>>,
+                            std::hash<int>> tasks_;
   std::vector<Task*> task_list_;
   ScenarioConfig::StageConfig config_;
+  ScenarioConfig::StageType cur_stage_;
   ScenarioConfig::StageType next_stage_;
   void* context_ = nullptr;
   std::string name_;


### PR DESCRIPTION
Because the task config may be different between different stages.
The type of tasks_ has been redefined.
tasks_[task_type]   --->  tasks_[stage_type][task_type]

Make tasks_ static to make it as a class member, not Stage object member, to guarantee that each (stage,  task) pair only initializes once, no need to initialize them every stage creation.