### PR TITLE
Planning: add move constructor for FrenetFramePath and DiscretizedPath and use it wherever it is possible

### DIFF
--- a/modules/planning/common/path/discretized_path.cc
+++ b/modules/planning/common/path/discretized_path.cc
@@ -29,8 +29,8 @@ namespace planning {
 
 using apollo::common::PathPoint;
 
-DiscretizedPath::DiscretizedPath(const std::vector<PathPoint> &path_points)
-    : std::vector<PathPoint>(path_points) {}
+DiscretizedPath::DiscretizedPath(std::vector<PathPoint> path_points)
+    : std::vector<PathPoint>(std::move(path_points)) {}
 
 double DiscretizedPath::Length() const {
   if (empty()) {

--- a/modules/planning/common/path/discretized_path.h
+++ b/modules/planning/common/path/discretized_path.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "modules/common/proto/pnc_point.pb.h"
@@ -31,7 +32,7 @@ class DiscretizedPath : public std::vector<common::PathPoint> {
  public:
   DiscretizedPath() = default;
 
-  explicit DiscretizedPath(const std::vector<common::PathPoint>& path_points);
+  explicit DiscretizedPath(std::vector<common::PathPoint> path_points);
 
   double Length() const;
 

--- a/modules/planning/common/path/frenet_frame_path.cc
+++ b/modules/planning/common/path/frenet_frame_path.cc
@@ -30,8 +30,8 @@ namespace planning {
 
 using apollo::common::FrenetFramePoint;
 
-FrenetFramePath::FrenetFramePath(const std::vector<FrenetFramePoint>& points)
-    : std::vector<FrenetFramePoint>(points) {}
+FrenetFramePath::FrenetFramePath(std::vector<FrenetFramePoint> points)
+    : std::vector<FrenetFramePoint>(std::move(points)) {}
 
 double FrenetFramePath::Length() const {
   if (empty()) {

--- a/modules/planning/common/path/frenet_frame_path.h
+++ b/modules/planning/common/path/frenet_frame_path.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "modules/common/proto/pnc_point.pb.h"
@@ -31,7 +32,7 @@ namespace planning {
 class FrenetFramePath : public std::vector<common::FrenetFramePoint> {
  public:
   FrenetFramePath() = default;
-  explicit FrenetFramePath(const std::vector<common::FrenetFramePoint> &points);
+  explicit FrenetFramePath(std::vector<common::FrenetFramePoint> points);
 
   double Length() const;
   common::FrenetFramePoint EvaluateByS(const double s) const;

--- a/modules/planning/common/path/frenet_frame_path_test.cc
+++ b/modules/planning/common/path/frenet_frame_path_test.cc
@@ -43,7 +43,7 @@ class FrenetFramePathTest : public ::testing::Test {
       point.set_dl(dl[i]);
       point.set_ddl(ddl[i]);
     }
-    path_.reset(new FrenetFramePath(sl_points));
+    path_.reset(new FrenetFramePath(std::move(sl_points)));
   }
   void SetUp() { InitFrenetFramePath(); }
 

--- a/modules/planning/tasks/deciders/speed_bounds_decider/speed_limit_decider_test.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/speed_limit_decider_test.cc
@@ -60,7 +60,7 @@ class SpeedLimitDeciderTest : public ::testing::Test {
       ff_point.set_l(0.1);
       ff_points.push_back(std::move(ff_point));
     }
-    frenet_frame_path_ = FrenetFramePath(ff_points);
+    frenet_frame_path_ = FrenetFramePath(std::move(ff_points));
     path_data_.SetFrenetPath(frenet_frame_path_);
   }
 

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
@@ -232,7 +232,7 @@ bool STBoundaryMapper::GetOverlapBoundaryPoints(
           sampled_path_points.push_back(path_points[i]);
         }
       }
-      discretized_path = DiscretizedPath(sampled_path_points);
+      discretized_path = DiscretizedPath(std::move(sampled_path_points));
     } else {
       discretized_path = DiscretizedPath(path_points);
     }

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper_test.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper_test.cc
@@ -61,7 +61,7 @@ class StBoundaryMapperTest : public ::testing::Test {
       ff_point.set_l(0.1);
       ff_points.push_back(std::move(ff_point));
     }
-    frenet_frame_path_ = FrenetFramePath(ff_points);
+    frenet_frame_path_ = FrenetFramePath(std::move(ff_points));
     path_data_.SetFrenetPath(frenet_frame_path_);
   }
 

--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -126,7 +126,7 @@ common::Status PiecewiseJerkPathOptimizer::Process(
       // final_path_data might carry info from upper stream
       PathData path_data = *final_path_data;
       path_data.SetReferenceLine(&reference_line);
-      path_data.SetFrenetPath(FrenetFramePath(frenet_frame_path));
+      path_data.SetFrenetPath(frenet_frame_path);
       path_data.set_path_label(path_boundary.label());
       path_data.set_blocking_obstacle_id(path_boundary.blocking_obstacle_id());
       candidate_path_data.push_back(std::move(path_data));
@@ -233,7 +233,7 @@ FrenetFramePath PiecewiseJerkPathOptimizer::ToPiecewiseJerkPath(
     accumulated_s += FLAGS_trajectory_space_resolution;
   }
 
-  return FrenetFramePath(frenet_frame_path);
+  return FrenetFramePath(std::move(frenet_frame_path));
 }
 
 double PiecewiseJerkPathOptimizer::EstimateJerkBoundary(


### PR DESCRIPTION
Motivation of this PR:
There is some piece of code intended to use [FrenetFramePath move constructor](https://github.com/ApolloAuto/apollo/blob/master/modules/planning/common/path/path_data.cc#L262) or [DiscretizedPath move constructor](https://github.com/ApolloAuto/apollo/blob/master/modules/planning/scenarios/lane_follow/lane_follow_stage.cc#L336), while there is no move constructor for FrenetFramePath and DiscretizedPath. Pieces of code like `SetFrenetPath(FrenetFramePath(std::move(frenet_frame_points)));` calls extra copy constructor additionally which is not intended for.