### PR TITLE
Canbus: add the takeover into the coolhigh report protocols

### DIFF
--- a/modules/canbus/proto/ch.proto
+++ b/modules/canbus/proto/ch.proto
@@ -21,7 +21,7 @@ message Gear_command_114 {
     GEAR_CMD_NEUTRAL = 3;
     GEAR_CMD_DRIVE = 4;
   }
-  // PRND control(Command) [] [0|3]
+  // PRND control(Command) [] [1|4]
   optional Gear_cmdType gear_cmd = 1;
 }
 
@@ -77,6 +77,7 @@ message Brake_status__511 {
   enum Brake_pedal_en_stsType {
     BRAKE_PEDAL_EN_STS_DISABLE = 0;
     BRAKE_PEDAL_EN_STS_ENABLE = 1;
+    BRAKE_PEDAL_EN_STS_TAKEOVER = 2;
   }
   // brake pedal enable bit(Status) [] [0|1]
   optional Brake_pedal_en_stsType brake_pedal_en_sts = 1;
@@ -89,6 +90,7 @@ message Throttle_status__510 {
   enum Throttle_pedal_en_stsType {
     THROTTLE_PEDAL_EN_STS_DISABLE = 0;
     THROTTLE_PEDAL_EN_STS_ENABLE = 1;
+    THROTTLE_PEDAL_EN_STS_TAKEOVER = 2;
   }
   // throttle pedal enable bit(Status) [] [0|1]
   optional Throttle_pedal_en_stsType throttle_pedal_en_sts = 1;
@@ -112,6 +114,7 @@ message Steer_status__512 {
   enum Steer_angle_en_stsType {
     STEER_ANGLE_EN_STS_DISABLE = 0;
     STEER_ANGLE_EN_STS_ENABLE = 1;
+    STEER_ANGLE_EN_STS_TAKEOVER = 2;
   }
   // steering angle enable bit(Status) [] [0|1]
   optional Steer_angle_en_stsType steer_angle_en_sts = 1;
@@ -145,7 +148,7 @@ message Gear_status_514 {
     GEAR_STS_NEUTRAL = 3;
     GEAR_STS_DRIVE = 4;
   }
-  // PRND control(Status) [] [0|3]
+  // PRND control(Status) [] [1|4]
   optional Gear_stsType gear_sts = 1;
 }
 
@@ -171,13 +174,13 @@ message Ecu_status_3_517 {
 
 message Ecu_status_2_516 {
 // Report Message
-  // Percentage of battery remaining (BMS status) [%] [0|0]
+  // Percentage of battery remaining (BMS status) [%] [0|100]
   optional int32 battery_remaining_capacity = 1;
-  // Current battery voltage (BMS status) [V] [0|0]
+  // Current battery voltage (BMS status) [V] [0|80]
   optional double battery_voltage = 2;
-  // Current battery current (BMS status) [A] [0|0]
+  // Current battery current (BMS status) [A] [-60|60]
   optional double battery_current = 3;
-  // Current battery temperature (BMS status) [?] [0|0]
+  // Current battery temperature (BMS status) [¡É] [-40|110]
   optional int32 battery_temperature = 4;
 }
 

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
@@ -39,10 +39,11 @@ void Brakestatus511::Parse(const std::uint8_t* bytes, int32_t length,
 }
 
 // config detail: {'description': 'brake pedal enable bit(Status)', 'enum': {0:
-// 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE'},
-// 'precision': 1.0, 'len': 8, 'name': 'brake_pedal_en_sts', 'is_signed_var':
-// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
-// 'order': 'intel', 'physical_unit': ''}
+// 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE', 2:
+// 'BRAKE_PEDAL_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+// 'brake_pedal_en_sts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
 Brake_status__511::Brake_pedal_en_stsType Brakestatus511::brake_pedal_en_sts(
     const std::uint8_t* bytes, int32_t length) const {
   Byte t0(bytes + 0);

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.h
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.h
@@ -33,10 +33,11 @@ class Brakestatus511 : public ::apollo::drivers::canbus::ProtocolData<
 
  private:
   // config detail: {'description': 'brake pedal enable bit(Status)', 'enum':
-  // {0: 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE'},
-  // 'precision': 1.0, 'len': 8, 'name': 'BRAKE_PEDAL_EN_STS', 'is_signed_var':
-  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
-  // 'order': 'intel', 'physical_unit': ''}
+  // {0: 'BRAKE_PEDAL_EN_STS_DISABLE', 1: 'BRAKE_PEDAL_EN_STS_ENABLE', 2:
+  // 'BRAKE_PEDAL_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'BRAKE_PEDAL_EN_STS', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
   Brake_status__511::Brake_pedal_en_stsType brake_pedal_en_sts(
       const std::uint8_t* bytes, const int32_t length) const;
 

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_1_515.cc
@@ -104,7 +104,7 @@ Ecu_status_1_515::Ctrl_stsType Ecustatus1515::ctrl_sts(
 // 'int', 'order': 'intel', 'physical_unit': ''}
 int Ecustatus1515::chassis_sts(const std::uint8_t* bytes,
                                int32_t length) const {
-  Byte t0(bytes + 4);
+  Byte t0(bytes + 5);
   int32_t x = t0.get_byte(0, 8);
 
   int ret = x;

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_1_515_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_1_515_test.cc
@@ -44,7 +44,7 @@ TEST_F(Ecustatus1515Test, General) {
   EXPECT_DOUBLE_EQ(cd.ch().ecu_status_1_515().speed(), 5.1299999999999999);
   EXPECT_DOUBLE_EQ(cd.ch().ecu_status_1_515().acc_speed(), 1.0269999999999999);
   EXPECT_EQ(cd.ch().ecu_status_1_515().ctrl_sts(), 1);
-  EXPECT_EQ(cd.ch().ecu_status_1_515().chassis_sts(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_1_515().chassis_sts(), 18);
   EXPECT_EQ(cd.ch().ecu_status_1_515().chassis_err(), 5139);
 }
 

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
@@ -45,7 +45,7 @@ void Ecustatus2516::Parse(const std::uint8_t* bytes, int32_t length,
 // config detail: {'description': 'Percentage of battery remaining (BMS
 // status)', 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name':
 // 'battery_remaining_capacity', 'is_signed_var': False, 'physical_range':
-// '[0|0]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
+// '[0|100]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
 int Ecustatus2516::battery_remaining_capacity(const std::uint8_t* bytes,
                                               int32_t length) const {
   Byte t0(bytes + 1);

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
@@ -41,20 +41,20 @@ class Ecustatus2516 : public ::apollo::drivers::canbus::ProtocolData<
 
   // config detail: {'description': 'Current battery voltage (BMS status)',
   // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_VOLTAGE',
-  // 'is_signed_var': False, 'physical_range': '[0|0]', 'bit': 16, 'type':
+  // 'is_signed_var': False, 'physical_range': '[0|80]', 'bit': 16, 'type':
   // 'double', 'order': 'intel', 'physical_unit': 'V'}
   double battery_voltage(const std::uint8_t* bytes, const int32_t length) const;
 
   // config detail: {'description': 'Current battery current (BMS status)',
   // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_CURRENT',
-  // 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 32, 'type':
+  // 'is_signed_var': True, 'physical_range': '[-60|60]', 'bit': 32, 'type':
   // 'double', 'order': 'intel', 'physical_unit': 'A'}
   double battery_current(const std::uint8_t* bytes, const int32_t length) const;
 
   // config detail: {'description': 'Current battery temperature (BMS status)',
   // 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'BATTERY_TEMPERATURE',
-  // 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 48, 'type': 'int',
-  // 'order': 'intel', 'physical_unit': '?'}
+  // 'is_signed_var': True, 'physical_range': '[-40|110]', 'bit': 48, 'type':
+  // 'int', 'order': 'intel', 'physical_unit': '\xc2\xa1\xc3\x89'}
   int battery_temperature(const std::uint8_t* bytes,
                           const int32_t length) const;
 };

--- a/modules/canbus/vehicle/ch/protocol/gear_command_114.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_command_114.cc
@@ -52,7 +52,7 @@ Gearcommand114* Gearcommand114::set_gear_cmd(
 // config detail: {'description': 'PRND control(Command)', 'enum': {1:
 // 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
 // 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
-// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[1|4]', 'bit': 0,
 // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
 void Gearcommand114::set_p_gear_cmd(uint8_t* data,
                                     Gear_command_114::Gear_cmdType gear_cmd) {

--- a/modules/canbus/vehicle/ch/protocol/gear_command_114.h
+++ b/modules/canbus/vehicle/ch/protocol/gear_command_114.h
@@ -39,7 +39,7 @@ class Gearcommand114 : public ::apollo::drivers::canbus::ProtocolData<
   // config detail: {'description': 'PRND control(Command)', 'enum': {1:
   // 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
   // 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
-  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[1|4]', 'bit': 0,
   // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
   Gearcommand114* set_gear_cmd(Gear_command_114::Gear_cmdType gear_cmd);
 
@@ -47,7 +47,7 @@ class Gearcommand114 : public ::apollo::drivers::canbus::ProtocolData<
   // config detail: {'description': 'PRND control(Command)', 'enum': {1:
   // 'GEAR_CMD_PARK', 2: 'GEAR_CMD_REVERSE', 3: 'GEAR_CMD_NEUTRAL', 4:
   // 'GEAR_CMD_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_CMD',
-  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[1|4]', 'bit': 0,
   // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
   void set_p_gear_cmd(uint8_t* data, Gear_command_114::Gear_cmdType gear_cmd);
 

--- a/modules/canbus/vehicle/ch/protocol/gear_status_514.cc
+++ b/modules/canbus/vehicle/ch/protocol/gear_status_514.cc
@@ -37,7 +37,7 @@ void Gearstatus514::Parse(const std::uint8_t* bytes, int32_t length,
 // config detail: {'description': 'PRND control(Status)', 'enum': {1:
 // 'GEAR_STS_PARK', 2: 'GEAR_STS_REVERSE', 3: 'GEAR_STS_NEUTRAL', 4:
 // 'GEAR_STS_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'gear_sts',
-// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[1|4]', 'bit': 0,
 // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
 Gear_status_514::Gear_stsType Gearstatus514::gear_sts(const std::uint8_t* bytes,
                                                       int32_t length) const {

--- a/modules/canbus/vehicle/ch/protocol/gear_status_514.h
+++ b/modules/canbus/vehicle/ch/protocol/gear_status_514.h
@@ -35,7 +35,7 @@ class Gearstatus514 : public ::apollo::drivers::canbus::ProtocolData<
   // config detail: {'description': 'PRND control(Status)', 'enum': {1:
   // 'GEAR_STS_PARK', 2: 'GEAR_STS_REVERSE', 3: 'GEAR_STS_NEUTRAL', 4:
   // 'GEAR_STS_DRIVE'}, 'precision': 1.0, 'len': 8, 'name': 'GEAR_STS',
-  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|3]', 'bit': 0,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[1|4]', 'bit': 0,
   // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
   Gear_status_514::Gear_stsType gear_sts(const std::uint8_t* bytes,
                                          const int32_t length) const;

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
@@ -39,10 +39,11 @@ void Steerstatus512::Parse(const std::uint8_t* bytes, int32_t length,
 }
 
 // config detail: {'description': 'steering angle enable bit(Status)', 'enum':
-// {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE'},
-// 'precision': 1.0, 'len': 8, 'name': 'steer_angle_en_sts', 'is_signed_var':
-// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
-// 'order': 'intel', 'physical_unit': ''}
+// {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE', 2:
+// 'STEER_ANGLE_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+// 'steer_angle_en_sts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
 Steer_status__512::Steer_angle_en_stsType Steerstatus512::steer_angle_en_sts(
     const std::uint8_t* bytes, int32_t length) const {
   Byte t0(bytes + 0);

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.h
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.h
@@ -33,10 +33,11 @@ class Steerstatus512 : public ::apollo::drivers::canbus::ProtocolData<
 
  private:
   // config detail: {'description': 'steering angle enable bit(Status)', 'enum':
-  // {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE'},
-  // 'precision': 1.0, 'len': 8, 'name': 'STEER_ANGLE_EN_STS', 'is_signed_var':
-  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
-  // 'order': 'intel', 'physical_unit': ''}
+  // {0: 'STEER_ANGLE_EN_STS_DISABLE', 1: 'STEER_ANGLE_EN_STS_ENABLE', 2:
+  // 'STEER_ANGLE_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'STEER_ANGLE_EN_STS', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
   Steer_status__512::Steer_angle_en_stsType steer_angle_en_sts(
       const std::uint8_t* bytes, const int32_t length) const;
 

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
@@ -40,10 +40,11 @@ void Throttlestatus510::Parse(const std::uint8_t* bytes, int32_t length,
 }
 
 // config detail: {'description': 'throttle pedal enable bit(Status)', 'enum':
-// {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE'},
-// 'precision': 1.0, 'len': 8, 'name': 'throttle_pedal_en_sts', 'is_signed_var':
-// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
-// 'order': 'intel', 'physical_unit': ''}
+// {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE', 2:
+// 'THROTTLE_PEDAL_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+// 'throttle_pedal_en_sts', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
 Throttle_status__510::Throttle_pedal_en_stsType
 Throttlestatus510::throttle_pedal_en_sts(const std::uint8_t* bytes,
                                          int32_t length) const {

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
@@ -33,10 +33,11 @@ class Throttlestatus510 : public ::apollo::drivers::canbus::ProtocolData<
 
  private:
   // config detail: {'description': 'throttle pedal enable bit(Status)', 'enum':
-  // {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE'},
-  // 'precision': 1.0, 'len': 8, 'name': 'THROTTLE_PEDAL_EN_STS',
-  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0,
-  // 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  // {0: 'THROTTLE_PEDAL_EN_STS_DISABLE', 1: 'THROTTLE_PEDAL_EN_STS_ENABLE', 2:
+  // 'THROTTLE_PEDAL_EN_STS_TAKEOVER'}, 'precision': 1.0, 'len': 8, 'name':
+  // 'THROTTLE_PEDAL_EN_STS', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
   Throttle_status__510::Throttle_pedal_en_stsType throttle_pedal_en_sts(
       const std::uint8_t* bytes, const int32_t length) const;
 


### PR DESCRIPTION
Coolhigh canbus repor protocols need to add takeover for checkresponse, and update some comments in master version and cherry-pick to r5.0.0