### PR TITLE
Planning: adjust traffic_light in stage_creep.cc

### DIFF
--- a/modules/planning/scenarios/traffic_light/unprotected_left_turn/stage_creep.cc
+++ b/modules/planning/scenarios/traffic_light/unprotected_left_turn/stage_creep.cc
@@ -84,6 +84,8 @@ Stage::StageStatus TrafficLightUnprotectedLeftTurnStageCreep::Process(
     reference_line_info.SetJunctionRightOfWay(
         current_traffic_light_overlap->start_s, false);
 
+    traffic_light = current_traffic_light_overlap;
+
     auto signal_color = frame->GetSignal(traffic_light_overlap_id).color();
     ADEBUG << "traffic_light_overlap_id[" << traffic_light_overlap_id
            << "] start_s[" << current_traffic_light_overlap->start_s
@@ -94,8 +96,6 @@ Stage::StageStatus TrafficLightUnprotectedLeftTurnStageCreep::Process(
       traffic_light_all_green = false;
       break;
     }
-
-    traffic_light = current_traffic_light_overlap;
   }
 
   if (traffic_light == nullptr) {

--- a/modules/planning/scenarios/traffic_light/unprotected_right_turn/stage_creep.cc
+++ b/modules/planning/scenarios/traffic_light/unprotected_right_turn/stage_creep.cc
@@ -86,6 +86,8 @@ Stage::StageStatus TrafficLightUnprotectedRightTurnStageCreep::Process(
     reference_line_info.SetJunctionRightOfWay(
         current_traffic_light_overlap->start_s, false);
 
+    traffic_light = current_traffic_light_overlap;
+
     auto signal_color = frame->GetSignal(traffic_light_overlap_id).color();
     ADEBUG << "traffic_light_overlap_id[" << traffic_light_overlap_id
            << "] start_s[" << current_traffic_light_overlap->start_s
@@ -96,8 +98,6 @@ Stage::StageStatus TrafficLightUnprotectedRightTurnStageCreep::Process(
       traffic_light_all_green = false;
       break;
     }
-
-    traffic_light = current_traffic_light_overlap;
   }
 
   if (traffic_light_all_green || traffic_light == nullptr) {


### PR DESCRIPTION
I don't think we can finish `TrafficLightUnprotectedLeftTurnStageCreep ` or `TrafficLightUnprotectedRightTurnStageCreep` stage when there is any overlaped traffic light is not green.