### PR TITLE
Prediction: deprecate t_position and use position instead to hold the filtered position who is used by following code actually

### DIFF
--- a/modules/prediction/container/obstacles/obstacle.cc
+++ b/modules/prediction/container/obstacles/obstacle.cc
@@ -348,9 +348,9 @@ void Obstacle::UpdateStatus(Feature* feature) {
   }
   auto state = kf_motion_tracker_.GetStateEstimate();
 
-  feature->mutable_t_position()->set_x(state(0, 0));
-  feature->mutable_t_position()->set_y(state(1, 0));
-  feature->mutable_t_position()->set_z(feature->position().z());
+  feature->mutable_position()->set_x(state(0, 0));
+  feature->mutable_position()->set_y(state(1, 0));
+  feature->mutable_position()->set_z(feature->position().z());
 
   double velocity_x = state(2, 0);
   double velocity_y = state(3, 0);
@@ -378,10 +378,10 @@ void Obstacle::UpdateStatus(Feature* feature) {
   feature->set_acc(acc);
 
   ADEBUG << "Obstacle [" << id_ << "] has tracked position [" << std::fixed
-         << std::setprecision(6) << feature->t_position().x() << ", "
-         << std::fixed << std::setprecision(6) << feature->t_position().y()
+         << std::setprecision(6) << feature->position().x() << ", "
+         << std::fixed << std::setprecision(6) << feature->position().y()
          << ", " << std::fixed << std::setprecision(6)
-         << feature->t_position().z() << "]";
+         << feature->position().z() << "]";
   ADEBUG << "Obstacle [" << id_ << "] has tracked velocity [" << std::fixed
          << std::setprecision(6) << feature->velocity().x() << ", "
          << std::fixed << std::setprecision(6) << feature->velocity().y()
@@ -403,15 +403,15 @@ void Obstacle::UpdateStatus(Feature* feature) {
              << "] has not initialized pedestrian tracker.";
       return;
     }
-    feature->mutable_t_position()->set_x(
+    feature->mutable_position()->set_x(
         kf_pedestrian_tracker_.GetStateEstimate()(0, 0));
-    feature->mutable_t_position()->set_y(
+    feature->mutable_position()->set_y(
         kf_pedestrian_tracker_.GetStateEstimate()(1, 0));
     ADEBUG << "Obstacle [" << id_ << "] has tracked pedestrian position ["
-           << std::setprecision(6) << feature->t_position().x() << std::fixed
-           << ", " << std::setprecision(6) << feature->t_position().y()
+           << std::setprecision(6) << feature->position().x() << std::fixed
+           << ", " << std::setprecision(6) << feature->position().y()
            << std::fixed << ", " << std::setprecision(6)
-           << feature->t_position().z() << std::fixed << "]";
+           << feature->position().z() << std::fixed << "]";
   }
 }
 

--- a/modules/prediction/container/obstacles/obstacle_test.cc
+++ b/modules/prediction/container/obstacles/obstacle_test.cc
@@ -64,24 +64,18 @@ TEST_F(ObstacleTest, VehiclePosition) {
 
   const Feature& start_feature = obstacle_ptr->feature(2);
   EXPECT_DOUBLE_EQ(start_feature.timestamp(), 0.0);
-  EXPECT_DOUBLE_EQ(start_feature.position().x(), -458.941);
-  EXPECT_DOUBLE_EQ(start_feature.position().y(), -159.240);
-  EXPECT_NEAR(start_feature.t_position().x(), -458.941, 0.001);
-  EXPECT_NEAR(start_feature.t_position().y(), -159.240, 0.001);
+  EXPECT_NEAR(start_feature.position().x(), -458.941, 0.001);
+  EXPECT_NEAR(start_feature.position().y(), -159.240, 0.001);
 
   Feature* mid_feature_ptr = obstacle_ptr->mutable_feature(1);
   EXPECT_DOUBLE_EQ(mid_feature_ptr->timestamp(), 0.1);
-  EXPECT_DOUBLE_EQ(mid_feature_ptr->position().x(), -457.010);
-  EXPECT_DOUBLE_EQ(mid_feature_ptr->position().y(), -160.023);
-  EXPECT_NEAR(mid_feature_ptr->t_position().x(), -457.010, 0.1);
-  EXPECT_NEAR(mid_feature_ptr->t_position().y(), -160.023, 0.1);
+  EXPECT_NEAR(mid_feature_ptr->position().x(), -457.010, 0.1);
+  EXPECT_NEAR(mid_feature_ptr->position().y(), -160.023, 0.1);
 
   const Feature& latest_feature = obstacle_ptr->latest_feature();
   EXPECT_DOUBLE_EQ(latest_feature.timestamp(), 0.2);
-  EXPECT_DOUBLE_EQ(latest_feature.position().x(), -455.182);
-  EXPECT_DOUBLE_EQ(latest_feature.position().y(), -160.608);
-  EXPECT_NEAR(latest_feature.t_position().x(), -455.182, 0.1);
-  EXPECT_NEAR(latest_feature.t_position().y(), -160.608, 0.1);
+  EXPECT_NEAR(latest_feature.position().x(), -455.182, 0.1);
+  EXPECT_NEAR(latest_feature.position().y(), -160.608, 0.1);
 }
 
 TEST_F(ObstacleTest, VehicleVelocity) {
@@ -142,24 +136,18 @@ TEST_F(ObstacleTest, PedestrianPosition) {
 
   const Feature& start_feature = obstacle_ptr->feature(2);
   EXPECT_DOUBLE_EQ(start_feature.timestamp(), 0.0);
-  EXPECT_DOUBLE_EQ(start_feature.position().x(), -438.879);
-  EXPECT_DOUBLE_EQ(start_feature.position().y(), -161.931);
-  EXPECT_NEAR(start_feature.t_position().x(), -438.879, 0.001);
-  EXPECT_NEAR(start_feature.t_position().y(), -161.931, 0.001);
+  EXPECT_NEAR(start_feature.position().x(), -438.879, 0.001);
+  EXPECT_NEAR(start_feature.position().y(), -161.931, 0.001);
 
   Feature* mid_feature_ptr = obstacle_ptr->mutable_feature(1);
   EXPECT_DOUBLE_EQ(mid_feature_ptr->timestamp(), 0.1);
-  EXPECT_DOUBLE_EQ(mid_feature_ptr->position().x(), -438.610);
-  EXPECT_DOUBLE_EQ(mid_feature_ptr->position().y(), -161.521);
-  EXPECT_NEAR(mid_feature_ptr->t_position().x(), -438.610, 0.05);
-  EXPECT_NEAR(mid_feature_ptr->t_position().y(), -161.521, 0.05);
+  EXPECT_NEAR(mid_feature_ptr->position().x(), -438.610, 0.05);
+  EXPECT_NEAR(mid_feature_ptr->position().y(), -161.521, 0.05);
 
   const Feature& latest_feature = obstacle_ptr->latest_feature();
   EXPECT_DOUBLE_EQ(latest_feature.timestamp(), 0.2);
-  EXPECT_DOUBLE_EQ(latest_feature.position().x(), -438.537);
-  EXPECT_DOUBLE_EQ(latest_feature.position().y(), -160.991);
-  EXPECT_NEAR(latest_feature.t_position().x(), -438.537, 0.05);
-  EXPECT_NEAR(latest_feature.t_position().y(), -160.991, 0.05);
+  EXPECT_NEAR(latest_feature.position().x(), -438.537, 0.05);
+  EXPECT_NEAR(latest_feature.position().y(), -160.991, 0.05);
 }
 
 TEST_F(ObstacleTest, PedestrianVelocity) {

--- a/modules/prediction/proto/feature.proto
+++ b/modules/prediction/proto/feature.proto
@@ -98,7 +98,7 @@ message Feature {
   optional JunctionFeature junction_feature = 26;
 
   // Obstacle tracked features
-  optional apollo.common.Point3D t_position = 16;
+  optional apollo.common.Point3D t_position = 16 [deprecated = true];
   optional apollo.common.Point3D t_velocity = 17 [deprecated = true];
   optional double t_velocity_heading = 18 [deprecated = true];
   optional double t_speed = 19 [deprecated = true];


### PR DESCRIPTION
deprecate t_position and use position instead to hold the filtered position who is used by the following code actually