### PR TITLE
Canbus: add the coolhigh vehicle chassis error report protocols

### DIFF
--- a/modules/canbus/proto/ch.proto
+++ b/modules/canbus/proto/ch.proto
@@ -79,10 +79,40 @@ message Brake_status__511 {
     BRAKE_PEDAL_EN_STS_ENABLE = 1;
     BRAKE_PEDAL_EN_STS_TAKEOVER = 2;
   }
+  enum Brake_errType {
+    BRAKE_ERR_NOERR = 0;
+    BRAKE_ERR_BRAKE_SYSTEM_ERR = 1;
+  }
+  enum Emergency_btn_envType {
+    EMERGENCY_BTN_ENV_NOENV = 0;
+    EMERGENCY_BTN_ENV_EMERGENCY_BUTTON_ENV = 1;
+  }
+  enum Front_bump_envType {
+    FRONT_BUMP_ENV_NOENV = 0;
+    FRONT_BUMP_ENV_FRONT_BUMPER_ENV = 1;
+  }
+  enum Back_bump_envType {
+    BACK_BUMP_ENV_NOENV = 0;
+    BACK_BUMP_ENV_BACK_BUMPER_ENV = 1;
+  }
+  enum Overspd_envType {
+    OVERSPD_ENV_NOENV = 0;
+    OVERSPD_ENV_OVERSPEED_ENV = 1;
+  }
   // brake pedal enable bit(Status) [] [0|1]
   optional Brake_pedal_en_stsType brake_pedal_en_sts = 1;
   // Percentage of brake pedal(Status) [%] [0|100]
   optional int32 brake_pedal_sts = 2;
+  // [] [0|1]
+  optional Brake_errType brake_err = 3;
+  // [] [0|1]
+  optional Emergency_btn_envType emergency_btn_env = 4;
+  // [] [0|1]
+  optional Front_bump_envType front_bump_env = 5;
+  // [] [0|1]
+  optional Back_bump_envType back_bump_env = 6;
+  // [] [0|1]
+  optional Overspd_envType overspd_env = 7;
 }
 
 message Throttle_status__510 {
@@ -92,10 +122,22 @@ message Throttle_status__510 {
     THROTTLE_PEDAL_EN_STS_ENABLE = 1;
     THROTTLE_PEDAL_EN_STS_TAKEOVER = 2;
   }
+  enum Drive_motor_errType {
+    DRIVE_MOTOR_ERR_NOERR = 0;
+    DRIVE_MOTOR_ERR_DRV_MOTOR_ERR = 1;
+  }
+  enum Battery_bms_errType {
+    BATTERY_BMS_ERR_NOERR = 0;
+    BATTERY_BMS_ERR_BATTERY_ERR = 1;
+  }
   // throttle pedal enable bit(Status) [] [0|1]
   optional Throttle_pedal_en_stsType throttle_pedal_en_sts = 1;
   // Percentage of throttle pedal(Status) [%] [0|100]
   optional int32 throttle_pedal_sts = 2;
+  // [] [0|1]
+  optional Drive_motor_errType drive_motor_err = 3;
+  // [] [0|1]
+  optional Battery_bms_errType battery_bms_err = 4;
 }
 
 message Turnsignal_status__513 {
@@ -116,10 +158,22 @@ message Steer_status__512 {
     STEER_ANGLE_EN_STS_ENABLE = 1;
     STEER_ANGLE_EN_STS_TAKEOVER = 2;
   }
+  enum Steer_errType {
+    STEER_ERR_NOERR = 0;
+    STEER_ERR_STEER_MOTOR_ERR = 1;
+  }
+  enum Sensor_errType {
+    SENSOR_ERR_NOERR = 0;
+    SENSOR_ERR_STEER_SENSOR_ERR = 1;
+  }
   // steering angle enable bit(Status) [] [0|1]
   optional Steer_angle_en_stsType steer_angle_en_sts = 1;
   // Current steering angle(Status) [radian] [-0.524|0.524]
   optional double steer_angle_sts = 2;
+  // [] [0|1]
+  optional Steer_errType steer_err = 3;
+  // [] [0|1]
+  optional Sensor_errType sensor_err = 4;
 }
 
 message Ecu_status_1_515 {

--- a/modules/canbus/vehicle/ch/ch_controller.cc
+++ b/modules/canbus/vehicle/ch/ch_controller.cc
@@ -408,7 +408,46 @@ void ChController::SetTurningSignal(const ControlCommand& command) {}
 
 void ChController::ResetProtocol() { message_manager_->ResetSendMessages(); }
 
-bool ChController::CheckChassisError() { return false; }
+bool ChController::CheckChassisError() {
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+  if (!chassis_detail.has_ch()) {
+    AERROR_EVERY(100) << "ChassisDetail has NO ch vehicle info."
+                      << chassis_detail.DebugString();
+    return false;
+  }
+  Ch ch = chassis_detail.ch();
+  // steer motor fault
+  if (ch.has_steer_status__512()) {
+    if (Steer_status__512::STEER_ERR_STEER_MOTOR_ERR ==
+        ch.steer_status__512().steer_err()) {
+      return true;
+    }
+    if (Steer_status__512::SENSOR_ERR_STEER_SENSOR_ERR ==
+        ch.steer_status__512().sensor_err()) {
+      return true;
+    }
+  }
+  // drive error
+  if (ch.has_throttle_status__510()) {
+    if (Throttle_status__510::DRIVE_MOTOR_ERR_DRV_MOTOR_ERR ==
+        ch.throttle_status__510().drive_motor_err()) {
+      return true;
+    }
+    if (Throttle_status__510::BATTERY_BMS_ERR_BATTERY_ERR ==
+        ch.throttle_status__510().battery_bms_err()) {
+      return true;
+    }
+  }
+  // brake error
+  if (ch.has_brake_status__511()) {
+    if (Brake_status__511::BRAKE_ERR_BRAKE_SYSTEM_ERR ==
+        ch.brake_status__511().brake_err()) {
+      return true;
+    }
+  }
+  return false;
+}
 
 void ChController::SecurityDogThreadFunc() {
   int32_t vertical_ctrl_fail = 0;

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.cc
@@ -34,6 +34,16 @@ void Brakestatus511::Parse(const std::uint8_t* bytes, int32_t length,
       brake_pedal_en_sts(bytes, length));
   chassis->mutable_ch()->mutable_brake_status__511()->set_brake_pedal_sts(
       brake_pedal_sts(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_brake_err(
+      brake_err(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_emergency_btn_env(
+      emergency_btn_env(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_front_bump_env(
+      front_bump_env(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_back_bump_env(
+      back_bump_env(bytes, length));
+  chassis->mutable_ch()->mutable_brake_status__511()->set_overspd_env(
+      overspd_env(bytes, length));
   chassis->mutable_check_response()->set_is_esp_online(
       brake_pedal_en_sts(bytes, length) == 1);
 }
@@ -63,6 +73,77 @@ int Brakestatus511::brake_pedal_sts(const std::uint8_t* bytes,
   int32_t x = t0.get_byte(0, 8);
 
   int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'brake_err', 'enum': {0: 'BRAKE_ERR_NOERR', 1:
+// 'BRAKE_ERR_BRAKE_SYSTEM_ERR'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 16, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Brake_status__511::Brake_errType Brakestatus511::brake_err(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_status__511::Brake_errType ret =
+      static_cast<Brake_status__511::Brake_errType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'emergency_btn_env', 'enum': {0:
+// 'EMERGENCY_BTN_ENV_NOENV', 1: 'EMERGENCY_BTN_ENV_EMERGENCY_BUTTON_ENV'},
+// 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 24, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
+Brake_status__511::Emergency_btn_envType Brakestatus511::emergency_btn_env(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_status__511::Emergency_btn_envType ret =
+      static_cast<Brake_status__511::Emergency_btn_envType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'front_bump_env', 'enum': {0: 'FRONT_BUMP_ENV_NOENV',
+// 1: 'FRONT_BUMP_ENV_FRONT_BUMPER_ENV'}, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 32,
+// 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+Brake_status__511::Front_bump_envType Brakestatus511::front_bump_env(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_status__511::Front_bump_envType ret =
+      static_cast<Brake_status__511::Front_bump_envType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'back_bump_env', 'enum': {0: 'BACK_BUMP_ENV_NOENV',
+// 1: 'BACK_BUMP_ENV_BACK_BUMPER_ENV'}, 'precision': 1.0, 'len': 8,
+// 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 40,
+// 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+Brake_status__511::Back_bump_envType Brakestatus511::back_bump_env(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_status__511::Back_bump_envType ret =
+      static_cast<Brake_status__511::Back_bump_envType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'overspd_env', 'enum': {0: 'OVERSPD_ENV_NOENV', 1:
+// 'OVERSPD_ENV_OVERSPEED_ENV'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 48, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Brake_status__511::Overspd_envType Brakestatus511::overspd_env(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_status__511::Overspd_envType ret =
+      static_cast<Brake_status__511::Overspd_envType>(x);
   return ret;
 }
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511.h
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511.h
@@ -46,6 +46,43 @@ class Brakestatus511 : public ::apollo::drivers::canbus::ProtocolData<
   // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
   // 'int', 'order': 'intel', 'physical_unit': '%'}
   int brake_pedal_sts(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'BRAKE_ERR', 'enum': {0: 'BRAKE_ERR_NOERR', 1:
+  // 'BRAKE_ERR_BRAKE_SYSTEM_ERR'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 16, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Brake_status__511::Brake_errType brake_err(const std::uint8_t* bytes,
+                                             const int32_t length) const;
+
+  // config detail: {'name': 'EMERGENCY_BTN_ENV', 'enum': {0:
+  // 'EMERGENCY_BTN_ENV_NOENV', 1: 'EMERGENCY_BTN_ENV_EMERGENCY_BUTTON_ENV'},
+  // 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 24, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Brake_status__511::Emergency_btn_envType emergency_btn_env(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'FRONT_BUMP_ENV', 'enum': {0:
+  // 'FRONT_BUMP_ENV_NOENV', 1: 'FRONT_BUMP_ENV_FRONT_BUMPER_ENV'},
+  // 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Brake_status__511::Front_bump_envType front_bump_env(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'BACK_BUMP_ENV', 'enum': {0: 'BACK_BUMP_ENV_NOENV',
+  // 1: 'BACK_BUMP_ENV_BACK_BUMPER_ENV'}, 'precision': 1.0, 'len': 8,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit':
+  // 40, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Brake_status__511::Back_bump_envType back_bump_env(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'OVERSPD_ENV', 'enum': {0: 'OVERSPD_ENV_NOENV', 1:
+  // 'OVERSPD_ENV_OVERSPEED_ENV'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 48, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Brake_status__511::Overspd_envType overspd_env(const std::uint8_t* bytes,
+                                                 const int32_t length) const;
 };
 
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/brake_status__511_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/brake_status__511_test.cc
@@ -26,7 +26,7 @@ class Brakestatus511Test : public ::testing::Test {
 };
 
 TEST_F(Brakestatus511Test, General) {
-  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  uint8_t data[8] = {0x01, 0x02, 0x01, 0x00, 0x01, 0x01, 0x00, 0x01};
   int32_t length = 8;
   ChassisDetail cd;
   Brakestatus511 brake;
@@ -34,15 +34,20 @@ TEST_F(Brakestatus511Test, General) {
 
   EXPECT_EQ(data[0], 0b00000001);
   EXPECT_EQ(data[1], 0b00000010);
-  EXPECT_EQ(data[2], 0b00000011);
-  EXPECT_EQ(data[3], 0b00000100);
-  EXPECT_EQ(data[4], 0b00010001);
-  EXPECT_EQ(data[5], 0b00010010);
-  EXPECT_EQ(data[6], 0b00010011);
-  EXPECT_EQ(data[7], 0b00010100);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000000);
+  EXPECT_EQ(data[4], 0b00000001);
+  EXPECT_EQ(data[5], 0b00000001);
+  EXPECT_EQ(data[6], 0b00000000);
+  EXPECT_EQ(data[7], 0b00000001);
 
   EXPECT_EQ(cd.ch().brake_status__511().brake_pedal_en_sts(), 1);
   EXPECT_EQ(cd.ch().brake_status__511().brake_pedal_sts(), 2);
+  EXPECT_EQ(cd.ch().brake_status__511().brake_err(), 1);
+  EXPECT_EQ(cd.ch().brake_status__511().emergency_btn_env(), 0);
+  EXPECT_EQ(cd.ch().brake_status__511().front_bump_env(), 1);
+  EXPECT_EQ(cd.ch().brake_status__511().back_bump_env(), 1);
+  EXPECT_EQ(cd.ch().brake_status__511().overspd_env(), 0);
 }
 
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.cc
@@ -34,6 +34,10 @@ void Steerstatus512::Parse(const std::uint8_t* bytes, int32_t length,
       steer_angle_en_sts(bytes, length));
   chassis->mutable_ch()->mutable_steer_status__512()->set_steer_angle_sts(
       steer_angle_sts(bytes, length));
+  chassis->mutable_ch()->mutable_steer_status__512()->set_steer_err(
+      steer_err(bytes, length));
+  chassis->mutable_ch()->mutable_steer_status__512()->set_sensor_err(
+      sensor_err(bytes, length));
   chassis->mutable_check_response()->set_is_eps_online(
       steer_angle_en_sts(bytes, length) == 1);
 }
@@ -72,6 +76,34 @@ double Steerstatus512::steer_angle_sts(const std::uint8_t* bytes,
   x >>= 16;
 
   double ret = x * 0.001000;
+  return ret;
+}
+
+// config detail: {'name': 'steer_err', 'enum': {0: 'STEER_ERR_NOERR', 1:
+// 'STEER_ERR_STEER_MOTOR_ERR'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 24, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Steer_status__512::Steer_errType Steerstatus512::steer_err(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Steer_status__512::Steer_errType ret =
+      static_cast<Steer_status__512::Steer_errType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'sensor_err', 'enum': {0: 'SENSOR_ERR_NOERR', 1:
+// 'SENSOR_ERR_STEER_SENSOR_ERR'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 32, 'type': 'enum',
+// 'order': 'intel', 'physical_unit': ''}
+Steer_status__512::Sensor_errType Steerstatus512::sensor_err(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Steer_status__512::Sensor_errType ret =
+      static_cast<Steer_status__512::Sensor_errType>(x);
   return ret;
 }
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512.h
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512.h
@@ -46,6 +46,20 @@ class Steerstatus512 : public ::apollo::drivers::canbus::ProtocolData<
   // 'is_signed_var': True, 'physical_range': '[-0.524|0.524]', 'bit': 8,
   // 'type': 'double', 'order': 'intel', 'physical_unit': 'radian'}
   double steer_angle_sts(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'STEER_ERR', 'enum': {0: 'STEER_ERR_NOERR', 1:
+  // 'STEER_ERR_STEER_MOTOR_ERR'}, 'precision': 1.0, 'len': 8, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 24, 'type': 'enum',
+  // 'order': 'intel', 'physical_unit': ''}
+  Steer_status__512::Steer_errType steer_err(const std::uint8_t* bytes,
+                                             const int32_t length) const;
+
+  // config detail: {'name': 'SENSOR_ERR', 'enum': {0: 'SENSOR_ERR_NOERR', 1:
+  // 'SENSOR_ERR_STEER_SENSOR_ERR'}, 'precision': 1.0, 'len': 8,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit':
+  // 32, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+  Steer_status__512::Sensor_errType sensor_err(const std::uint8_t* bytes,
+                                               const int32_t length) const;
 };
 
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/steer_status__512_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/steer_status__512_test.cc
@@ -26,7 +26,7 @@ class Steerstatus512Test : public ::testing::Test {
 };
 
 TEST_F(Steerstatus512Test, General) {
-  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  uint8_t data[8] = {0x01, 0x02, 0x03, 0x01, 0x00, 0x12, 0x13, 0x14};
   int32_t length = 8;
   ChassisDetail cd;
   Steerstatus512 steerstatus;
@@ -35,8 +35,8 @@ TEST_F(Steerstatus512Test, General) {
   EXPECT_EQ(data[0], 0b00000001);
   EXPECT_EQ(data[1], 0b00000010);
   EXPECT_EQ(data[2], 0b00000011);
-  EXPECT_EQ(data[3], 0b00000100);
-  EXPECT_EQ(data[4], 0b00010001);
+  EXPECT_EQ(data[3], 0b00000001);
+  EXPECT_EQ(data[4], 0b00000000);
   EXPECT_EQ(data[5], 0b00010010);
   EXPECT_EQ(data[6], 0b00010011);
   EXPECT_EQ(data[7], 0b00010100);
@@ -44,6 +44,8 @@ TEST_F(Steerstatus512Test, General) {
   EXPECT_EQ(cd.ch().steer_status__512().steer_angle_en_sts(), 1);
   EXPECT_DOUBLE_EQ(cd.ch().steer_status__512().steer_angle_sts(),
                    0.77000000000000002);
+  EXPECT_EQ(cd.ch().steer_status__512().steer_err(), 1);
+  EXPECT_EQ(cd.ch().steer_status__512().sensor_err(), 0);
 }
 
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.cc
@@ -35,6 +35,10 @@ void Throttlestatus510::Parse(const std::uint8_t* bytes, int32_t length,
       ->set_throttle_pedal_en_sts(throttle_pedal_en_sts(bytes, length));
   chassis->mutable_ch()->mutable_throttle_status__510()->set_throttle_pedal_sts(
       throttle_pedal_sts(bytes, length));
+  chassis->mutable_ch()->mutable_throttle_status__510()->set_drive_motor_err(
+      drive_motor_err(bytes, length));
+  chassis->mutable_ch()->mutable_throttle_status__510()->set_battery_bms_err(
+      battery_bms_err(bytes, length));
   chassis->mutable_check_response()->set_is_vcu_online(
       throttle_pedal_en_sts(bytes, length) == 1);
 }
@@ -66,6 +70,35 @@ int Throttlestatus510::throttle_pedal_sts(const std::uint8_t* bytes,
   int32_t x = t0.get_byte(0, 8);
 
   int ret = x;
+  return ret;
+}
+
+// config detail: {'name': 'drive_motor_err', 'enum': {0:
+// 'DRIVE_MOTOR_ERR_NOERR', 1: 'DRIVE_MOTOR_ERR_DRV_MOTOR_ERR'},
+// 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 16, 'type': 'enum', 'order': 'intel',
+// 'physical_unit': ''}
+Throttle_status__510::Drive_motor_errType Throttlestatus510::drive_motor_err(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Throttle_status__510::Drive_motor_errType ret =
+      static_cast<Throttle_status__510::Drive_motor_errType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'battery_bms_err', 'enum': {0:
+// 'BATTERY_BMS_ERR_NOERR', 1: 'BATTERY_BMS_ERR_BATTERY_ERR'}, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+// 'bit': 24, 'type': 'enum', 'order': 'intel', 'physical_unit': ''}
+Throttle_status__510::Battery_bms_errType Throttlestatus510::battery_bms_err(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Throttle_status__510::Battery_bms_errType ret =
+      static_cast<Throttle_status__510::Battery_bms_errType>(x);
   return ret;
 }
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510.h
@@ -46,6 +46,22 @@ class Throttlestatus510 : public ::apollo::drivers::canbus::ProtocolData<
   // 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 8, 'type':
   // 'int', 'order': 'intel', 'physical_unit': '%'}
   int throttle_pedal_sts(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'DRIVE_MOTOR_ERR', 'enum': {0:
+  // 'DRIVE_MOTOR_ERR_NOERR', 1: 'DRIVE_MOTOR_ERR_DRV_MOTOR_ERR'},
+  // 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 16, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Throttle_status__510::Drive_motor_errType drive_motor_err(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'BATTERY_BMS_ERR', 'enum': {0:
+  // 'BATTERY_BMS_ERR_NOERR', 1: 'BATTERY_BMS_ERR_BATTERY_ERR'},
+  // 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 24, 'type': 'enum', 'order': 'intel',
+  // 'physical_unit': ''}
+  Throttle_status__510::Battery_bms_errType battery_bms_err(
+      const std::uint8_t* bytes, const int32_t length) const;
 };
 
 }  // namespace ch

--- a/modules/canbus/vehicle/ch/protocol/throttle_status__510_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/throttle_status__510_test.cc
@@ -26,7 +26,7 @@ class Throttlestatus510Test : public ::testing::Test {
 };
 
 TEST_F(Throttlestatus510Test, General) {
-  uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14};
+  uint8_t data[8] = {0x01, 0x02, 0x01, 0x00, 0x11, 0x12, 0x13, 0x14};
   int32_t length = 8;
   ChassisDetail cd;
   Throttlestatus510 throttlestatus;
@@ -34,8 +34,8 @@ TEST_F(Throttlestatus510Test, General) {
 
   EXPECT_EQ(data[0], 0b00000001);
   EXPECT_EQ(data[1], 0b00000010);
-  EXPECT_EQ(data[2], 0b00000011);
-  EXPECT_EQ(data[3], 0b00000100);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000000);
   EXPECT_EQ(data[4], 0b00010001);
   EXPECT_EQ(data[5], 0b00010010);
   EXPECT_EQ(data[6], 0b00010011);
@@ -43,6 +43,8 @@ TEST_F(Throttlestatus510Test, General) {
 
   EXPECT_EQ(cd.ch().throttle_status__510().throttle_pedal_en_sts(), 1);
   EXPECT_EQ(cd.ch().throttle_status__510().throttle_pedal_sts(), 2);
+  EXPECT_EQ(cd.ch().throttle_status__510().drive_motor_err(), 1);
+  EXPECT_EQ(cd.ch().throttle_status__510().battery_bms_err(), 0);
 }
 
 }  // namespace ch


### PR DESCRIPTION
Canbus: add the coolhigh vehicle chassis error report protocols and check them in Apollo canbus chassis error.