### PR TITLE
Perception: Fix bugs after Ubuntu18 update

### DIFF
--- a/modules/perception/camera/lib/calibrator/common/histogram_estimator.h
+++ b/modules/perception/camera/lib/calibrator/common/histogram_estimator.h
@@ -105,7 +105,9 @@ class HistogramEstimator {
       return false;
     }
     int index = GetIndex(val);
-    assert(index >= 0 && index < params_.nr_bins_in_histogram);
+    if (index < 0 || index >= params_.nr_bins_in_histogram) {
+      return false;
+    }
     ++hist_[index];
     val_cur_ = val;
     return true;

--- a/modules/perception/camera/lib/lane/common/common_functions.h
+++ b/modules/perception/camera/lib/lane/common/common_functions.h
@@ -110,7 +110,8 @@ template <typename Dtype>
 bool RansacFitting(const std::vector<Eigen::Matrix<Dtype, 2, 1>>& pos_vec,
                    std::vector<Eigen::Matrix<Dtype, 2, 1>>* selected_points,
                    Eigen::Matrix<Dtype, 4, 1>* coeff, const int max_iters = 100,
-                   const int N = 5, Dtype inlier_thres = 0.1) {
+                   const int N = 5, const Dtype inlier_thres = 0.1,
+                   const Dtype data_thres = 2.0) {
   if (coeff == nullptr) {
     AERROR << "The coefficient pointer is NULL.";
     return false;
@@ -145,6 +146,13 @@ bool RansacFitting(const std::vector<Eigen::Matrix<Dtype, 2, 1>>& pos_vec,
         pos_vec[index[1]](0), 1,
         pos_vec[index[2]](0) * pos_vec[index[2]](0),
         pos_vec[index[2]](0), 1;
+
+    // Filter out points which cause degenerate cases
+    if ((std::abs(pos_vec[index[0]](0) - pos_vec[index[1]](0) < data_thres)) ||
+        (std::abs(pos_vec[index[1]](0) - pos_vec[index[2]](0) < data_thres)) ||
+        (std::abs(pos_vec[index[0]](0) - pos_vec[index[2]](0) < data_thres))) {
+      continue;
+    }
 
     Eigen::Matrix<Dtype, 3, 1> matB;
     matB << pos_vec[index[0]](1), pos_vec[index[1]](1), pos_vec[index[2]](1);

--- a/modules/perception/camera/lib/lane/postprocessor/darkSCNN/darkSCNN_lane_postprocessor.cc
+++ b/modules/perception/camera/lib/lane/postprocessor/darkSCNN/darkSCNN_lane_postprocessor.cc
@@ -227,8 +227,8 @@ bool DarkSCNNLanePostprocessor::Process2D(
     if (xy_points[i].size() < minNumPoints_) continue;
     Eigen::Matrix<float, 4, 1> coeff;
     // Solve linear system to estimate polynomial coefficients
-    if (RansacFitting(xy_points[i], &selected_xy_points, &coeff, 200,
-                      static_cast<int>(minNumPoints_), 0.1f)) {
+    if (RansacFitting<float>(xy_points[i], &selected_xy_points, &coeff, 200,
+                      static_cast<int>(minNumPoints_), 0.1f, 2.0f)) {
       coeffs[i] = coeff;
 
       xy_points[i].clear();

--- a/modules/perception/camera/lib/traffic_light/preprocessor/multi_camera_projection.cc
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/multi_camera_projection.cc
@@ -87,10 +87,11 @@ bool MultiCamerasProjection::Project(const CarPose& pose,
   }
 
   Eigen::Matrix4d c2w_pose;
-  if (!pose.GetCameraPose(option.camera_name, &c2w_pose)) {
-    AERROR << "invalid camera_name: " << option.camera_name;
+
+  if (pose.c2w_poses_.find(option.camera_name) == pose.c2w_poses_.end()) {
     return false;
   }
+  c2w_pose = pose.c2w_poses_.at(option.camera_name);
 
   bool ret = false;
   AINFO << "project use camera_name: " << option.camera_name;

--- a/modules/perception/camera/lib/traffic_light/preprocessor/pose.h
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/pose.h
@@ -45,11 +45,11 @@ class CarPose {
   void setTimestamp(double ts) { timestamp_ = ts; }
   double getTimestamp() const { return timestamp_; }
 
- private:
   Eigen::Matrix4d pose_;  // car(novatel) to world pose
   std::map<std::string, Eigen::Matrix4d> c2w_poses_;  // camera to world poses
   double timestamp_;
 
+ private:
   friend std::ostream& operator<<(std::ostream& os, const CarPose&);
 };
 

--- a/modules/perception/camera/tools/offline/visualizer.cc
+++ b/modules/perception/camera/tools/offline/visualizer.cc
@@ -997,14 +997,6 @@ void Visualizer::Draw2Dand3D_all_info_single_camera(
     cv::line(image_2D, ground2image(vp1_), ground2image(vp2_),
              apollo::perception::white_color, 2);
   }
-  AINFO << "vp1_: " << vp1_ << ", vp1_image: " << ground2image(vp1_);
-  AINFO << "vp2_: " << vp2_ << ", vp2_image: " << ground2image(vp2_);
-
-  // AINFO << "FOV point 1: " << image2ground(p_fov_1_);
-  // AINFO << "FOV point 2: " << image2ground(p_fov_2_);
-  // AINFO << "FOV point 3: " << image2ground(p_fov_3_);
-  // AINFO << "FOV point 4: " << image2ground(p_fov_4_);
-
   // plot laneline on image and ground plane
   for (const auto &object : frame.lane_objects) {
     cv::Scalar lane_color = colormapline[object.pos_type];
@@ -1012,7 +1004,6 @@ void Visualizer::Draw2Dand3D_all_info_single_camera(
     p_prev.x = static_cast<int>(object.curve_image_point_set[0].x);
     p_prev.y = static_cast<int>(object.curve_image_point_set[0].y);
     Eigen::Vector2d p_prev_ground = image2ground(p_prev);
-
     for (unsigned i = 1; i < object.curve_image_point_set.size(); i++) {
       cv::Point p_cur;
       p_cur.x = static_cast<int>(object.curve_image_point_set[i].x);
@@ -1257,16 +1248,12 @@ void Visualizer::Draw2Dand3D_all_info_single_camera(
     p_prev_ground(0) = virtual_egolane_ground.left_line.line_point[0](0);
     p_prev_ground(1) = virtual_egolane_ground.left_line.line_point[0](1);
     cv::Point p_prev = ground2image(p_prev_ground);
-    AINFO << "[Left] p_prev_ground: " << p_prev_ground << ", "
-          << "p_prev: " << p_prev;
     for (unsigned i = 1;
          i < virtual_egolane_ground.left_line.line_point.size(); i++) {
       Eigen::Vector2d p_cur_ground;
       p_cur_ground(0) = virtual_egolane_ground.left_line.line_point[i](0);
       p_cur_ground(1) = virtual_egolane_ground.left_line.line_point[i](1);
       cv::Point p_cur = ground2image(p_cur_ground);
-      AINFO << "[Left] p_cur_ground: " << p_cur_ground
-            << ", " << "p_cur: " << p_prev;
       if (p_cur.x >= 0 && p_cur.y >= 0 && p_prev.x >= 0 && p_prev.y >= 0 &&
           p_cur.x < image_width_ && p_cur.y < image_height_ &&
           p_prev.x < image_width_ && p_prev.y <  image_height_) {

--- a/modules/perception/onboard/component/trafficlights_perception_component.cc
+++ b/modules/perception/onboard/component/trafficlights_perception_component.cc
@@ -653,11 +653,8 @@ bool TrafficLightsPerceptionComponent::GetCarPose(const double timestamp,
            << tf2_child_frame_id_;
     return false;
   }
-  if (!pose->Init(timestamp, pose_matrix)) {
-    AERROR << "PreprocessComponent::get_car_pose failed, ts:"
-           << std::to_string(timestamp) << " pose:" << pose_matrix;
-    return false;
-  }
+  pose->timestamp_ = timestamp;
+  pose->pose_ = pose_matrix;
 
   int state = 0;
   bool ret = true;
@@ -670,7 +667,7 @@ bool TrafficLightsPerceptionComponent::GetCarPose(const double timestamp,
       pose->ClearCameraPose(camera_name);
       AERROR << "get pose from tf failed, camera_name: " << camera_name;
     } else {
-      pose->SetCameraPose(camera_name, pose_matrix);
+      pose->c2w_poses_[camera_name] = pose_matrix;
       state += 1;
     }
   }
@@ -953,7 +950,7 @@ bool TrafficLightsPerceptionComponent::TransformDebugMessage(
     camera::CarPose pose;
     if (GetCarPose(frame->timestamp, &pose)) {
       Eigen::Matrix4d cam_pose;
-      pose.GetCameraPose("front_6mm", &cam_pose);
+      cam_pose = pose.c2w_poses_.at("front_6mm");
       light_debug->set_distance_to_stop_line(stopline_distance(cam_pose));
     } else {
       AERROR << "error occurred in calc distance to stop line";


### PR DESCRIPTION
1. Unnecessary Assert caused perception crash
2. The new Eigen::colPivHouseholderQr crashed with degenerate dataset (Added data filtering before the linear solver)
3. Default template became <int>. Added data type in the template
4. Pose class crashes on multiple cases. Direct call solved the issue.
5. Removed unnecessary AINFO in visualizer.cc