### PR TITLE
Planning: change two version task name to one

### DIFF
--- a/modules/planning/tasks/deciders/open_space_decider/open_space_pre_stop_decider.cc
+++ b/modules/planning/tasks/deciders/open_space_decider/open_space_pre_stop_decider.cc
@@ -41,7 +41,6 @@ using apollo::hdmap::ParkingSpaceInfoConstPtr;
 OpenSpacePreStopDecider::OpenSpacePreStopDecider(const TaskConfig& config)
     : Decider(config) {
   CHECK(config.has_open_space_pre_stop_decider_config());
-  SetName("OpenSpacePreStopDecider");
 }
 
 Status OpenSpacePreStopDecider::Process(

--- a/modules/planning/tasks/deciders/path_decider/path_decider.cc
+++ b/modules/planning/tasks/deciders/path_decider/path_decider.cc
@@ -35,9 +35,7 @@ using apollo::common::ErrorCode;
 using apollo::common::Status;
 using apollo::common::VehicleConfigHelper;
 
-PathDecider::PathDecider(const TaskConfig &config) : Task(config) {
-  SetName("PathDecider");
-}
+PathDecider::PathDecider(const TaskConfig &config) : Task(config) {}
 
 Status PathDecider::Execute(Frame *frame,
                             ReferenceLineInfo *reference_line_info) {

--- a/modules/planning/tasks/deciders/rule_based_stop_decider/rule_based_stop_decider.cc
+++ b/modules/planning/tasks/deciders/rule_based_stop_decider/rule_based_stop_decider.cc
@@ -45,7 +45,6 @@ RuleBasedStopDecider::RuleBasedStopDecider(const TaskConfig &config)
     : Decider(config) {
   CHECK(config.has_rule_based_stop_decider_config());
   rule_based_stop_decider_config_ = config.rule_based_stop_decider_config();
-  SetName("RuleBasedStopDecider");
 }
 
 apollo::common::Status RuleBasedStopDecider::Process(

--- a/modules/planning/tasks/deciders/speed_bounds_decider/speed_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/speed_bounds_decider.cc
@@ -46,7 +46,6 @@ SpeedBoundsDecider::SpeedBoundsDecider(const TaskConfig &config)
     : Decider(config) {
   CHECK(config.has_speed_bounds_decider_config());
   speed_bounds_config_ = config.speed_bounds_decider_config();
-  SetName("SpeedBoundsDecider");
 }
 
 Status SpeedBoundsDecider::Process(

--- a/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
+++ b/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
@@ -43,9 +43,7 @@ using apollo::common::math::Vec2d;
 using apollo::common::time::Clock;
 using apollo::perception::PerceptionObstacle;
 
-SpeedDecider::SpeedDecider(const TaskConfig& config) : Task(config) {
-  SetName("SpeedDecider");
-}
+SpeedDecider::SpeedDecider(const TaskConfig& config) : Task(config) {}
 
 common::Status SpeedDecider::Execute(Frame* frame,
                                      ReferenceLineInfo* reference_line_info) {

--- a/modules/planning/tasks/optimizers/path_time_heuristic/path_time_heuristic_optimizer.cc
+++ b/modules/planning/tasks/optimizers/path_time_heuristic/path_time_heuristic_optimizer.cc
@@ -41,8 +41,6 @@ PathTimeHeuristicOptimizer::PathTimeHeuristicOptimizer(const TaskConfig& config)
     : SpeedOptimizer(config) {
   CHECK(config.has_dp_st_speed_config());
   dp_st_speed_config_ = config.dp_st_speed_config();
-  // TODO(all): fix the name
-  SetName("DpStSpeedOptimizer");
 }
 
 bool PathTimeHeuristicOptimizer::SearchPathTimeGraph(

--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -39,7 +39,6 @@ using apollo::common::Status;
 
 PiecewiseJerkPathOptimizer::PiecewiseJerkPathOptimizer(const TaskConfig& config)
     : PathOptimizer(config) {
-  SetName("PiecewiseJerkPathOptimizer");
   CHECK(config_.has_piecewise_jerk_path_config());
 }
 

--- a/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_optimizer.cc
@@ -46,7 +46,6 @@ using apollo::common::TrajectoryPoint;
 PiecewiseJerkSpeedOptimizer::PiecewiseJerkSpeedOptimizer(
     const TaskConfig& config)
     : SpeedOptimizer(config) {
-  SetName("PiecewiseJerkSpeedOptimizer");
   CHECK(config_.has_piecewise_jerk_speed_config());
 }
 

--- a/modules/planning/tasks/rss/decider_rss.cc
+++ b/modules/planning/tasks/rss/decider_rss.cc
@@ -38,9 +38,7 @@ using ad_rss::world::Object;
 using ad_rss::world::RoadArea;
 using ad_rss::world::Scene;
 
-RssDecider::RssDecider(const TaskConfig &config) : Task(config) {
-  SetName("RssDecider");
-}
+RssDecider::RssDecider(const TaskConfig &config) : Task(config) {}
 
 apollo::common::Status RssDecider::Execute(
     Frame *frame, ReferenceLineInfo *reference_line_info) {

--- a/modules/planning/tasks/task.h
+++ b/modules/planning/tasks/task.h
@@ -37,8 +37,6 @@ class Task {
 
   virtual ~Task() = default;
 
-  void SetName(const std::string& name) { name_ = name; }
-
   const std::string& Name() const;
 
   const TaskConfig& Config() const { return config_; }


### PR DESCRIPTION
There are two versions of the task name:
1. 
```
 30 Task::Task(const TaskConfig& config) : config_(config) {
 31   name_ = TaskConfig::TaskType_Name(config_.task_type());
 32 }
```

2.
```
void SetName(const std::string& name) { name_ = name; }
```
```
PathDecider::PathDecider(const TaskConfig &config) : Task(config) {
  SetName("PathDecider");
}
```

We preserve the first one for simplicity and coincide.