### PR TITLE
Planning: refine path reuse decider to make it more efficiency and accurate

### DIFF
--- a/modules/planning/tasks/deciders/path_reuse_decider/path_reuse_decider.h
+++ b/modules/planning/tasks/deciders/path_reuse_decider/path_reuse_decider.h
@@ -39,12 +39,12 @@ class PathReuseDecider : public Decider {
   common::Status Process(Frame* frame,
                          ReferenceLineInfo* reference_line_info) override;
   bool CheckPathReusable(Frame* frame);
-  void GetCurrentStopPositions(
-      Frame* frame, std::vector<common::PointENU>* current_stop_positions);
+  void GetCurrentStopPositions(Frame* frame,
+      std::vector<const common::PointENU*>* current_stop_positions);
   void GetHistoryStopPositions(
       const std::vector<const HistoryObjectDecision*>&
           history_objects_decisions,
-      std::vector<common::PointENU>* history_stop_positions);
+      std::vector<const common::PointENU*>* history_stop_positions);
 
  private:
   History* history_ = History::Instance();


### PR DESCRIPTION
From
```
      if (current_stop_positions[i].x() != history_stop_positions[i].x() &&
          current_stop_positions[i].y() != history_stop_positions[i].y())
```
To
```
      if (std::fabs(current_stop_positions[i]->x() -
                    history_stop_positions[i]->x()) > 1e-6 ||
          std::fabs(current_stop_positions[i]->y() -
                    history_stop_positions[i]->y()) > 1e-6)
```