### PR TITLE
Dreamview: replace boost rwlock by std rwlock

### DIFF
--- a/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
+++ b/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
@@ -200,7 +200,7 @@ void DataCollectionMonitor::OnChassis(const std::shared_ptr<Chassis>& chassis) {
               category_frame_count_[scenario_name][category_name]) /
           static_cast<double>(category.total_frames());
       {
-        boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
+        std::unique_lock<std::shared_timed_mutex> writer_lock(mutex_);
         current_progress_json_[scenario_name][category.description()] =
             progress_percentage;
       }
@@ -245,7 +245,7 @@ bool DataCollectionMonitor::IsCompliedWithCriteria(
 }
 
 nlohmann::json DataCollectionMonitor::GetProgressAsJson() {
-  boost::unique_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::unique_lock<std::shared_timed_mutex> reader_lock(mutex_);
   return current_progress_json_;
 }
 

--- a/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.h
+++ b/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include <shared_mutex>
 #include <memory>
 #include <string>
 #include <unordered_map>
 
-#include "boost/thread/shared_mutex.hpp"
 #include "gtest/gtest_prod.h"
 #include "third_party/json/json.hpp"
 
@@ -103,8 +103,7 @@ class DataCollectionMonitor {
   nlohmann::json current_progress_json_;
 
   // Mutex to protect concurrent access to current_progress_json_.
-  // NOTE: Use boost until we have std version of rwlock support.
-  boost::shared_mutex mutex_;
+  std::shared_timed_mutex mutex_;
 
   FRIEND_TEST(DataCollectionMonitorTest, UpdateCollectionProgress);
 };

--- a/modules/dreamview/backend/hmi/BUILD
+++ b/modules/dreamview/backend/hmi/BUILD
@@ -76,7 +76,6 @@ cc_library(
         "//modules/dreamview/proto:hmi_config_proto",
         "//modules/dreamview/proto:hmi_mode_proto",
         "//modules/dreamview/proto:hmi_status_proto",
-        "@boost",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/modules/dreamview/backend/hmi/hmi_worker.cc
+++ b/modules/dreamview/backend/hmi/hmi_worker.cc
@@ -59,8 +59,8 @@ using apollo::cyber::Node;
 using apollo::monitor::ComponentStatus;
 using apollo::monitor::SystemStatus;
 using google::protobuf::Map;
-using RLock = boost::shared_lock<boost::shared_mutex>;
-using WLock = boost::unique_lock<boost::shared_mutex>;
+using RLock = std::shared_lock<std::shared_timed_mutex>;
+using WLock = std::unique_lock<std::shared_timed_mutex>;
 
 constexpr char kNavigationModeName[] = "Navigation";
 

--- a/modules/dreamview/backend/hmi/hmi_worker.h
+++ b/modules/dreamview/backend/hmi/hmi_worker.h
@@ -16,12 +16,10 @@
 
 #pragma once
 
+#include <shared_mutex>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "boost/thread/locks.hpp"
-#include "boost/thread/shared_mutex.hpp"
 
 #include "cyber/cyber.h"
 #include "modules/canbus/proto/chassis.pb.h"
@@ -100,7 +98,7 @@ class HMIWorker {
   HMIMode current_mode_;
   bool status_changed_ = false;
   bool stop_ = false;
-  mutable boost::shared_mutex status_mutex_;
+  mutable std::shared_timed_mutex status_mutex_;
   std::future<void> thread_future_;
   std::vector<StatusUpdateHandler> status_update_handlers_;
 

--- a/modules/dreamview/backend/map/BUILD
+++ b/modules/dreamview/backend/map/BUILD
@@ -16,7 +16,6 @@ cc_library(
         "//modules/map/hdmap:hdmap_util",
         "//modules/map/pnc_map",
         "//third_party/json",
-        "@boost",
         "@glog",
     ],
 )

--- a/modules/dreamview/backend/map/map_service.cc
+++ b/modules/dreamview/backend/map/map_service.cc
@@ -88,7 +88,7 @@ MapService::MapService(bool use_sim_map) : use_sim_map_(use_sim_map) {
 }
 
 bool MapService::ReloadMap(bool force_reload) {
-  boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
+  std::unique_lock<std::shared_timed_mutex> writer_lock(mutex_);
   bool ret = true;
   if (force_reload) {
     ret = HDMapUtil::ReloadMaps();
@@ -160,7 +160,7 @@ void MapService::CollectMapElementIds(const PointENU &point, double radius,
   if (!MapReady()) {
     return;
   }
-  boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
 
   std::vector<LaneInfoConstPtr> lanes;
   if (SimMap()->GetLanes(point, radius, &lanes) != 0) {
@@ -225,7 +225,7 @@ void MapService::CollectMapElementIds(const PointENU &point, double radius,
 }
 
 Map MapService::RetrieveMapElements(const MapElementIds &ids) const {
-  boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
 
   Map result;
   if (!MapReady()) {
@@ -332,7 +332,7 @@ Map MapService::RetrieveMapElements(const MapElementIds &ids) const {
 bool MapService::GetNearestLane(const double x, const double y,
                                 LaneInfoConstPtr *nearest_lane,
                                 double *nearest_s, double *nearest_l) const {
-  boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
 
   PointENU point;
   point.set_x(x);
@@ -349,7 +349,7 @@ bool MapService::GetNearestLaneWithHeading(const double x, const double y,
                                            LaneInfoConstPtr *nearest_lane,
                                            double *nearest_s, double *nearest_l,
                                            const double heading) const {
-  boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
 
   PointENU point;
   point.set_x(x);
@@ -486,7 +486,7 @@ bool MapService::AddPathFromPassageRegion(
   if (!MapReady()) {
     return false;
   }
-  boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+  std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
 
   std::vector<MapPathPoint> path_points;
   for (const auto &segment : passage_region.segment()) {

--- a/modules/dreamview/backend/map/map_service.h
+++ b/modules/dreamview/backend/map/map_service.h
@@ -20,11 +20,9 @@
 
 #pragma once
 
+#include <shared_mutex>
 #include <string>
 #include <vector>
-
-#include "boost/thread/locks.hpp"
-#include "boost/thread/shared_mutex.hpp"
 
 #include "modules/dreamview/proto/simulation_world.pb.h"
 #include "modules/map/pnc_map/pnc_map.h"
@@ -114,7 +112,7 @@ class MapService {
   double y_offset_ = 0.0;
 
   // RW lock to protect map data
-  mutable boost::shared_mutex mutex_;
+  mutable std::shared_timed_mutex mutex_;
 };
 
 }  // namespace dreamview

--- a/modules/dreamview/backend/point_cloud/BUILD
+++ b/modules/dreamview/backend/point_cloud/BUILD
@@ -19,7 +19,6 @@ cc_library(
         "//modules/drivers/proto:sensor_proto",
         "//modules/localization/proto:localization_proto",
         "//third_party/json",
-        "@boost",
         "@com_google_protobuf//:protobuf",
         "@pcl",
         "@yaml_cpp//:yaml",

--- a/modules/dreamview/backend/point_cloud/point_cloud_updater.h
+++ b/modules/dreamview/backend/point_cloud/point_cloud_updater.h
@@ -20,11 +20,9 @@
 
 #pragma once
 
+#include <shared_mutex>
 #include <memory>
 #include <string>
-
-#include "boost/thread/locks.hpp"
-#include "boost/thread/shared_mutex.hpp"
 
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
@@ -69,8 +67,7 @@ class PointCloudUpdater {
   static float lidar_height_;
 
   // Mutex to protect concurrent access to point_cloud_str_ and lidar_height_.
-  // NOTE: Use boost until we have std version of rwlock support.
-  static boost::shared_mutex mutex_;
+  static std::shared_timed_mutex mutex_;
 
  private:
   void RegisterMessageHandlers();

--- a/modules/dreamview/backend/simulation_world/BUILD
+++ b/modules/dreamview/backend/simulation_world/BUILD
@@ -70,7 +70,6 @@ cc_library(
         "//modules/dreamview/backend/handlers:websocket_handler",
         "//modules/dreamview/backend/map:map_service",
         "//modules/dreamview/backend/sim_control",
-        "@boost",
     ],
 )
 

--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
@@ -84,7 +84,7 @@ void SimulationWorldUpdater::RegisterMessageHandlers() {
       [this](const Json &json, WebSocketHandler::Connection *conn) {
         std::string to_send;
         {
-          boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+          std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
           to_send = relative_map_string_;
         }
         map_ws_->SendBinaryData(conn, to_send, true);
@@ -173,7 +173,7 @@ void SimulationWorldUpdater::RegisterMessageHandlers() {
         {
           // Pay the price to copy the data instead of sending data over the
           // wire while holding the lock.
-          boost::shared_lock<boost::shared_mutex> reader_lock(mutex_);
+          std::shared_lock<std::shared_timed_mutex> reader_lock(mutex_);
           to_send = enable_pnc_monitor ? simulation_world_with_planning_data_
                                        : simulation_world_;
         }
@@ -387,7 +387,7 @@ void SimulationWorldUpdater::OnTimer() {
   sim_world_service_.Update();
 
   {
-    boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
+    std::unique_lock<std::shared_timed_mutex> writer_lock(mutex_);
     sim_world_service_.GetWireFormatString(
         FLAGS_sim_map_radius, &simulation_world_,
         &simulation_world_with_planning_data_);

--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.h
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.h
@@ -20,11 +20,9 @@
 
 #pragma once
 
+#include <shared_mutex>
 #include <memory>
 #include <string>
-
-#include "boost/thread/locks.hpp"
-#include "boost/thread/shared_mutex.hpp"
 
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
@@ -152,8 +150,7 @@ class SimulationWorldUpdater {
   std::string relative_map_string_;
 
   // Mutex to protect concurrent access to simulation_world_json_.
-  // NOTE: Use boost until we have std version of rwlock support.
-  boost::shared_mutex mutex_;
+  std::shared_timed_mutex mutex_;
 };
 
 }  // namespace dreamview


### PR DESCRIPTION
@unacao  reply to #9578
> [23:55:31]./modules/dreamview/backend/data_collection_monitor/data_collection_monitor.h:23:24: fatal error: shared_mutex: No such file or directory
> [23:55:31] #include <shared_mutex>
> 
> We use C++11 in our build environment, and rwlock is not supported in this version.


The master branch use [C++1y(C++14)](https://github.com/ApolloAuto/apollo/blob/master/tools/bazel.rc#L76-L77), not C++11.
```
 76 # Enable C++14
 77 build --cxxopt="-std=c++1y"
 78 # Enable colorful output of GCC
 79 # build --cxxopt="-fdiagnostics-color=always"
```