### PR TITLE
Dreamview: camera view backend

### DIFF
--- a/modules/dreamview/backend/BUILD
+++ b/modules/dreamview/backend/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "//modules/dreamview/backend/handlers:websocket_handler",
         "//modules/dreamview/backend/hmi",
         "//modules/dreamview/backend/map:map_service",
+        "//modules/dreamview/backend/perception_camera_updater",
         "//modules/dreamview/backend/point_cloud:point_cloud_updater",
         "//modules/dreamview/backend/sim_control",
         "//modules/dreamview/backend/simulation_world:simulation_world_updater",

--- a/modules/dreamview/backend/dreamview.h
+++ b/modules/dreamview/backend/dreamview.h
@@ -27,6 +27,7 @@
 #include "modules/dreamview/backend/handlers/websocket_handler.h"
 #include "modules/dreamview/backend/hmi/hmi.h"
 #include "modules/dreamview/backend/map/map_service.h"
+#include "modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h"
 #include "modules/dreamview/backend/point_cloud/point_cloud_updater.h"
 #include "modules/dreamview/backend/sim_control/sim_control.h"
 #include "modules/dreamview/backend/simulation_world/simulation_world_updater.h"
@@ -58,10 +59,12 @@ class Dreamview {
   std::unique_ptr<WebSocketHandler> websocket_;
   std::unique_ptr<WebSocketHandler> map_ws_;
   std::unique_ptr<WebSocketHandler> point_cloud_ws_;
+  std::unique_ptr<WebSocketHandler> camera_ws_;
   std::unique_ptr<ImageHandler> image_;
   std::unique_ptr<MapService> map_service_;
   std::unique_ptr<HMI> hmi_;
   std::unique_ptr<DataCollectionMonitor> data_collection_monitor_;
+  std::unique_ptr<PerceptionCameraUpdater> perception_camera_updater_;
 };
 
 }  // namespace dreamview

--- a/modules/dreamview/backend/perception_camera_updater/BUILD
+++ b/modules/dreamview/backend/perception_camera_updater/BUILD
@@ -22,10 +22,10 @@ cc_library(
         "//modules/drivers/proto:sensor_proto",
         "//modules/localization/proto:localization_proto",
         "//modules/common/proto:geometry_proto",
+        "//modules/transform:tf2_buffer_lib",
         "//modules/transform/proto:transform_proto",
         "//modules/dreamview/backend/handlers:websocket_handler",
         "//modules/dreamview/proto:camera_update_proto",
-        "//third_party/json",
         "@eigen",
     ],
 )

--- a/modules/dreamview/backend/perception_camera_updater/BUILD
+++ b/modules/dreamview/backend/perception_camera_updater/BUILD
@@ -1,0 +1,33 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "perception_camera_updater",
+    srcs = [
+        "perception_camera_updater.cc",
+    ],
+    hdrs = [
+        "perception_camera_updater.h",
+    ],
+    copts = ['-DMODULE_NAME=\\"dreamview\\"'],
+    linkopts = [
+        "-lopencv_core",
+        "-lopencv_highgui",
+        "-lopencv_imgproc",
+    ],
+    deps = [
+        "//cyber",
+        "//modules/common/adapters:adapter_gflags",
+        "//modules/drivers/proto:sensor_proto",
+        "//modules/localization/proto:localization_proto",
+        "//modules/common/proto:geometry_proto",
+        "//modules/transform/proto:transform_proto",
+        "//modules/dreamview/backend/handlers:websocket_handler",
+        "//modules/dreamview/proto:camera_update_proto",
+        "//third_party/json",
+        "@eigen",
+    ],
+)
+
+cpplint()

--- a/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.cc
+++ b/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.cc
@@ -1,0 +1,221 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h"
+
+#include <float.h>
+#include <map>
+#include <string>
+#include "cyber/common/file.h"
+#include "modules/common/adapters/adapter_gflags.h"
+#include "opencv2/opencv.hpp"
+
+namespace apollo {
+namespace dreamview {
+
+using apollo::drivers::CompressedImage;
+using apollo::localization::LocalizationEstimate;
+using apollo::localization::Pose;
+using apollo::transform::TransformStampeds;
+using apollo::transform::Transform;
+
+namespace {
+  void ConvertMatrixToArray(
+      const Eigen::Matrix4d &matrix, std::vector<double> *array) {
+    const double* pointer = matrix.data();
+    for (int i = 0; i < matrix.size(); ++i) {
+      array->push_back(pointer[i]);
+    }
+  }
+}  // namespace
+
+PerceptionCameraUpdater::PerceptionCameraUpdater(WebSocketHandler* websocket)
+    : websocket_(websocket),
+      node_(cyber::CreateNode("perception_camera_updater")) {
+  InitReaders();
+}
+
+void PerceptionCameraUpdater::Start() {
+  enabled_ = true;
+}
+
+void PerceptionCameraUpdater::Stop() {
+  if (enabled_) {
+    localization_queue_.clear();
+    image_buffer_.clear();
+    tf_static_.clear();
+    current_image_timestamp_ = 0.0;
+  }
+  enabled_ = false;
+}
+
+void PerceptionCameraUpdater::GetImageLocalization(
+    std::vector<double> *localization) {
+  double timestamp_diff = DBL_MAX;
+  auto iter = localization_queue_.rbegin();
+  Pose image_pos;
+  for (; iter != localization_queue_.rend(); ++iter) {
+    const double tmp_diff = (*iter)->measurement_time()
+        - current_image_timestamp_;
+    if (tmp_diff > 0) {
+      timestamp_diff = tmp_diff;
+      image_pos = (*iter)->pose();
+    } else {
+      if (std::abs(tmp_diff) < timestamp_diff) {
+        image_pos = (*iter)->pose();
+      }
+      break;
+    }
+  }
+  // clean useless localization
+  auto iter_begin = localization_queue_.begin();
+  while ((*iter_begin) != (*iter)) {
+    iter_begin = localization_queue_.erase(iter_begin);
+  }
+
+  Eigen::Matrix4d localization_matrix;
+  localization_matrix.setConstant(0);
+  Eigen::Quaterniond q;
+  q.x() = image_pos.orientation().qx();
+  q.y() = image_pos.orientation().qy();
+  q.z() = image_pos.orientation().qz();
+  q.w() = image_pos.orientation().qw();
+  localization_matrix.block<3, 3>(0, 0) = q.normalized().toRotationMatrix();
+  localization_matrix(0, 3) = image_pos.position().x();
+  localization_matrix(1, 3) = image_pos.position().y();
+  localization_matrix(2, 3) = image_pos.position().z();
+  localization_matrix(3, 3) = 1;
+
+  ConvertMatrixToArray(localization_matrix, localization);
+}
+
+void PerceptionCameraUpdater::OnImage(
+    const std::shared_ptr<CompressedImage> &compressed_image) {
+  if (!enabled_
+      || compressed_image->format() == "h265" /* skip video format */) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(image_mutex_);
+  if (compressed_image->has_measurement_time()) {
+    current_image_timestamp_ = compressed_image->measurement_time();
+  } else {
+    current_image_timestamp_ = compressed_image->header().timestamp_sec();
+  }
+
+  std::vector<uint8_t> compressed_raw_data(compressed_image->data().begin(),
+                                           compressed_image->data().end());
+  cv::Mat mat_image = cv::imdecode(compressed_raw_data, CV_LOAD_IMAGE_COLOR);
+  // Scale down image size properly to reduce data transfer latency through
+  // websocket and ensure image quality is acceptable meanwhile
+  cv::resize(
+      mat_image, mat_image,
+      cv::Size(static_cast<int>(mat_image.cols * kImageScale),
+               static_cast<int>(mat_image.rows * kImageScale)),
+      0, 0, CV_INTER_LINEAR);
+  std::vector<uint8_t> tmp_buffer;
+  cv::imencode(".jpg", mat_image, tmp_buffer, std::vector<int>() /* params */);
+
+  camera_update_.set_data(&(tmp_buffer[0]), tmp_buffer.size());
+}
+
+void PerceptionCameraUpdater::OnLocalization(
+    const std::shared_ptr<LocalizationEstimate> &localization) {
+  if (!enabled_) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(localization_mutex_);
+  localization_queue_.push_back(localization);
+}
+
+void PerceptionCameraUpdater::OnStaticTransform(
+    const std::shared_ptr<TransformStampeds> &static_tf) {
+  if (static_tf->transforms().size() > 0) {
+    std::map<std::string, Eigen::Matrix4d> transforms;
+    for (const auto &tf : static_tf->transforms()) {
+      const std::string frame_id = tf.header().frame_id();
+      const std::string child_frame_id = tf.child_frame_id();
+      Transform transform = tf.transform();
+      Eigen::Matrix4d matrix;
+      matrix.setConstant(0);
+      Eigen::Quaterniond q;
+      q.x() = transform.rotation().qx();
+      q.y() = transform.rotation().qy();
+      q.z() = transform.rotation().qz();
+      q.w() = transform.rotation().qw();
+      matrix.block<3, 3>(0, 0) = q.normalized().toRotationMatrix();
+      matrix(0, 3) = transform.translation().x();
+      matrix(1, 3) = transform.translation().y();
+      matrix(2, 3) = transform.translation().z();
+      matrix(3, 3) = 1;
+      std::string key = frame_id + "_" + child_frame_id;
+      transforms[key] = matrix;
+    }
+    Eigen::Matrix4d localization2camera_mat = Eigen::Matrix4d::Identity();
+    if (transforms.find("localization_novatel") != transforms.end()) {
+      localization2camera_mat *= transforms["localization_novatel"];
+    }
+    if (transforms.find("novatel_velodyne128") != transforms.end()) {
+      localization2camera_mat *= transforms["novatel_velodyne128"];
+    }
+    if (transforms.find("velodyne128_front_6mm") != transforms.end()) {
+      localization2camera_mat *= transforms["velodyne128_front_6mm"];
+    }
+    std::vector<double> localization2camera_arr;
+    ConvertMatrixToArray(localization2camera_mat, &localization2camera_arr);
+    *camera_update_.mutable_tf_static() = {localization2camera_arr.begin(),
+                                           localization2camera_arr.end()};
+  }
+}
+
+void PerceptionCameraUpdater::InitReaders() {
+  node_->CreateReader<CompressedImage>(
+      FLAGS_image_short_topic,
+      [this](const std::shared_ptr<CompressedImage> &image) {
+        OnImage(image);
+      });
+
+  node_->CreateReader<LocalizationEstimate>(
+      FLAGS_localization_topic,
+      [this](const std::shared_ptr<LocalizationEstimate> &localization) {
+        OnLocalization(localization);
+      });
+
+  node_->CreateReader<TransformStampeds>(
+      FLAGS_tf_static_topic,
+      [this](const std::shared_ptr<TransformStampeds> &static_transform) {
+        OnStaticTransform(static_transform);
+      });
+}
+
+void PerceptionCameraUpdater::GetUpdate(std::string *camera_update) {
+  {
+    std::lock(image_mutex_, localization_mutex_);
+    std::lock_guard<std::mutex> lock1(image_mutex_, std::adopt_lock);
+    std::lock_guard<std::mutex> lock2(localization_mutex_, std::adopt_lock);
+
+    std::vector<double> localization;
+    GetImageLocalization(&localization);
+    *camera_update_.mutable_localization() = {localization.begin(),
+                                              localization.end()};
+
+    camera_update_.SerializeToString(camera_update);
+  }
+}
+
+}  // namespace dreamview
+}  // namespace apollo

--- a/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
+++ b/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
@@ -19,15 +19,15 @@
 #include <Eigen/Dense>
 
 #include <memory>
-#include <list>
+#include <deque>
 #include <string>
 #include <vector>
 
-#include "third_party/json/json.hpp"
 #include "cyber/cyber.h"
 #include "modules/drivers/proto/sensor_image.pb.h"
 #include "modules/localization/proto/localization.pb.h"
 #include "modules/localization/proto/pose.pb.h"
+#include "modules/transform/buffer.h"
 #include "modules/transform/proto/transform.pb.h"
 #include "modules/dreamview/backend/handlers/websocket_handler.h"
 #include "modules/dreamview/proto/camera_update.pb.h"
@@ -60,8 +60,6 @@ class PerceptionCameraUpdater {
   void OnImage(const std::shared_ptr<apollo::drivers::CompressedImage> &image);
   void OnLocalization(
       const std::shared_ptr<apollo::localization::LocalizationEstimate> &loc);
-  void OnStaticTransform(
-      const std::shared_ptr<apollo::transform::TransformStampeds> &static_tf);
 
   /**
    * @brief Since localization is updated more frequently than camera image,
@@ -69,6 +67,12 @@ class PerceptionCameraUpdater {
    * for image.
    */
   void GetImageLocalization(std::vector<double> *localization);
+
+  apollo::transform::Buffer *tf_buffer_ =
+      apollo::transform::Buffer::Instance();
+  bool QueryTF(const std::string &frame_id, const std::string &child_frame_id,
+      Eigen::Matrix4d *matrix);
+  void GetStaticTF(std::vector<double> *tf_static);
 
   WebSocketHandler *websocket_;
   CameraUpdate camera_update_;

--- a/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
+++ b/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
@@ -70,9 +70,9 @@ class PerceptionCameraUpdater {
 
   apollo::transform::Buffer *tf_buffer_ =
       apollo::transform::Buffer::Instance();
-  bool QueryTF(const std::string &frame_id, const std::string &child_frame_id,
-      Eigen::Matrix4d *matrix);
-  void GetStaticTF(std::vector<double> *tf_static);
+  bool QueryStaticTF(const std::string &frame_id,
+      const std::string &child_frame_id, Eigen::Matrix4d *matrix);
+  void GetLocalization2CameraTF(std::vector<double> *localization2camera_tf);
 
   WebSocketHandler *websocket_;
   CameraUpdate camera_update_;

--- a/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
+++ b/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
@@ -78,7 +78,7 @@ class PerceptionCameraUpdater {
 
   std::unique_ptr<cyber::Node> node_;
 
-  std::list<std::shared_ptr<apollo::localization::LocalizationEstimate>>
+  std::deque<std::shared_ptr<apollo::localization::LocalizationEstimate>>
       localization_queue_;
   std::vector<uint8_t> image_buffer_;
   std::vector<double> tf_static_;

--- a/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
+++ b/modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h
@@ -1,0 +1,91 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Dense>
+
+#include <memory>
+#include <list>
+#include <string>
+#include <vector>
+
+#include "third_party/json/json.hpp"
+#include "cyber/cyber.h"
+#include "modules/drivers/proto/sensor_image.pb.h"
+#include "modules/localization/proto/localization.pb.h"
+#include "modules/localization/proto/pose.pb.h"
+#include "modules/transform/proto/transform.pb.h"
+#include "modules/dreamview/backend/handlers/websocket_handler.h"
+#include "modules/dreamview/proto/camera_update.pb.h"
+
+namespace apollo {
+namespace dreamview {
+
+class PerceptionCameraUpdater {
+ public:
+  /**
+   * @class PerceptionCameraUpdater
+   * 
+   * @brief A module that collects camera image and localization (by collecting
+   * localization & static transforms) to adjust camera as its real position/
+   * rotation in front-end camera view for projecting HDmap to camera image
+   */
+  explicit PerceptionCameraUpdater(WebSocketHandler *websocket);
+
+  void Start();
+  void Stop();
+
+  bool IsEnabled() const { return enabled_; }
+
+  void GetUpdate(std::string *camera_update);
+
+ private:
+  static constexpr double kImageScale = 0.6;
+
+  void InitReaders();
+  void OnImage(const std::shared_ptr<apollo::drivers::CompressedImage> &image);
+  void OnLocalization(
+      const std::shared_ptr<apollo::localization::LocalizationEstimate> &loc);
+  void OnStaticTransform(
+      const std::shared_ptr<apollo::transform::TransformStampeds> &static_tf);
+
+  /**
+   * @brief Since localization is updated more frequently than camera image,
+   * compare image and localization timestamp to get the nearest localization
+   * for image.
+   */
+  void GetImageLocalization(std::vector<double> *localization);
+
+  WebSocketHandler *websocket_;
+  CameraUpdate camera_update_;
+
+  bool enabled_ = false;
+  double current_image_timestamp_;
+
+  std::unique_ptr<cyber::Node> node_;
+
+  std::list<std::shared_ptr<apollo::localization::LocalizationEstimate>>
+      localization_queue_;
+  std::vector<uint8_t> image_buffer_;
+  std::vector<double> tf_static_;
+
+  std::mutex image_mutex_;
+  std::mutex localization_mutex_;
+};
+
+}  // namespace dreamview
+}  // namespace apollo

--- a/modules/dreamview/backend/simulation_world/BUILD
+++ b/modules/dreamview/backend/simulation_world/BUILD
@@ -67,6 +67,7 @@ cc_library(
         "//modules/common/util:map_util",
         "//modules/dreamview/backend/common:dreamview_gflags",
         "//modules/dreamview/backend/data_collection_monitor",
+        "//modules/dreamview/backend/perception_camera_updater",
         "//modules/dreamview/backend/handlers:websocket_handler",
         "//modules/dreamview/backend/map:map_service",
         "//modules/dreamview/backend/sim_control",

--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
@@ -39,14 +39,18 @@ using google::protobuf::util::MessageToJsonString;
 
 SimulationWorldUpdater::SimulationWorldUpdater(
     WebSocketHandler *websocket, WebSocketHandler *map_ws,
-    SimControl *sim_control, const MapService *map_service,
-    DataCollectionMonitor *data_collection_monitor, bool routing_from_file)
+    WebSocketHandler *camera_ws, SimControl *sim_control,
+    const MapService *map_service,
+    DataCollectionMonitor *data_collection_monitor,
+    PerceptionCameraUpdater *perception_camera_updater, bool routing_from_file)
     : sim_world_service_(map_service, routing_from_file),
       map_service_(map_service),
       websocket_(websocket),
       map_ws_(map_ws),
+      camera_ws_(camera_ws),
       sim_control_(sim_control),
-      data_collection_monitor_(data_collection_monitor) {
+      data_collection_monitor_(data_collection_monitor),
+      perception_camera_updater_(perception_camera_updater) {
   RegisterMessageHandlers();
 }
 
@@ -260,6 +264,16 @@ void SimulationWorldUpdater::RegisterMessageHandlers() {
         response["type"] = "DataCollectionProgress";
         response["data"] = data_collection_monitor_->GetProgressAsJson();
         websocket_->SendData(conn, response.dump());
+      });
+  camera_ws_->RegisterMessageHandler(
+      "RequestCameraData",
+      [this](const Json &json, WebSocketHandler::Connection *conn) {
+        if (!perception_camera_updater_->IsEnabled()) {
+          return;
+        }
+        std::string to_send;
+        perception_camera_updater_->GetUpdate(&to_send);
+        camera_ws_->SendBinaryData(conn, to_send, true);
       });
 }
 

--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.h
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.h
@@ -35,6 +35,7 @@
 #include "modules/dreamview/backend/map/map_service.h"
 #include "modules/dreamview/backend/sim_control/sim_control.h"
 #include "modules/dreamview/backend/simulation_world/simulation_world_service.h"
+#include "modules/dreamview/backend/perception_camera_updater/perception_camera_updater.h"
 #include "modules/routing/proto/poi.pb.h"
 
 /**
@@ -62,8 +63,10 @@ class SimulationWorldUpdater {
    * @param routing_from_file whether to read initial routing from file.
    */
   SimulationWorldUpdater(WebSocketHandler *websocket, WebSocketHandler *map_ws,
-                         SimControl *sim_control, const MapService *map_service,
+                         WebSocketHandler *camera_ws, SimControl *sim_control,
+                         const MapService *map_service,
                          DataCollectionMonitor *data_collection_monitor,
+                         PerceptionCameraUpdater *perception_camera_updater,
                          bool routing_from_file = false);
 
   /**
@@ -137,8 +140,10 @@ class SimulationWorldUpdater {
   const MapService *map_service_ = nullptr;
   WebSocketHandler *websocket_ = nullptr;
   WebSocketHandler *map_ws_ = nullptr;
+  WebSocketHandler *camera_ws_ = nullptr;
   SimControl *sim_control_ = nullptr;
   DataCollectionMonitor *data_collection_monitor_ = nullptr;
+  PerceptionCameraUpdater *perception_camera_updater_ = nullptr;
 
   // End point for requesting default route
   apollo::routing::POI poi_;

--- a/modules/dreamview/proto/BUILD
+++ b/modules/dreamview/proto/BUILD
@@ -101,3 +101,15 @@ proto_library(
     name = "data_collection_table_proto_lib",
     srcs = ["data_collection_table.proto"],
 )
+
+cc_proto_library(
+    name = "camera_update_proto",
+    deps = [
+        ":camera_update_proto_lib",
+    ],
+)
+
+proto_library(
+    name = "camera_update_proto_lib",
+    srcs = ["camera_update.proto"],
+)

--- a/modules/dreamview/proto/camera_update.proto
+++ b/modules/dreamview/proto/camera_update.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package apollo.dreamview;
+
+message CameraUpdate {
+    repeated double localization = 1;
+    repeated double tf_static = 2;
+    optional bytes data = 3;
+}

--- a/modules/dreamview/proto/camera_update.proto
+++ b/modules/dreamview/proto/camera_update.proto
@@ -3,7 +3,14 @@ syntax = "proto2";
 package apollo.dreamview;
 
 message CameraUpdate {
+    // The transformation matrix of localization in world coordinate system
+    // are stored in the double array in column-major order
     repeated double localization = 1;
+
+    // The transformation matrix of localization to camera are stored in the
+    // double array in column-major order
     repeated double tf_static = 2;
+
+    // Camera image data
     optional bytes data = 3;
 }

--- a/modules/dreamview/proto/camera_update.proto
+++ b/modules/dreamview/proto/camera_update.proto
@@ -9,8 +9,8 @@ message CameraUpdate {
 
     // The transformation matrix of localization to camera are stored in the
     // double array in column-major order
-    repeated double tf_static = 2;
+    repeated double localization2camera_tf = 2;
 
     // Camera image data
-    optional bytes data = 3;
+    optional bytes image = 3;
 }

--- a/modules/transform/buffer.cc
+++ b/modules/transform/buffer.cc
@@ -111,6 +111,18 @@ void Buffer::SubscriptionCallbackImpl(
   }
 }
 
+bool Buffer::GetStaticTF(const std::string &frame_id,
+    const std::string &child_frame_id, TransformStamped *tf) {
+  for (auto &static_msg : static_msgs_) {
+    if (static_msg.header.frame_id == frame_id
+        && static_msg.child_frame_id == child_frame_id) {
+      TF2MsgToCyber(static_msg, (*tf));
+      return true;
+    }
+  }
+  return false;
+}
+
 void Buffer::TF2MsgToCyber(
     const geometry_msgs::TransformStamped& tf2_trans_stamped,
     TransformStamped& trans_stamped) const {

--- a/modules/transform/buffer.cc
+++ b/modules/transform/buffer.cc
@@ -111,12 +111,13 @@ void Buffer::SubscriptionCallbackImpl(
   }
 }
 
-bool Buffer::GetStaticTF(const std::string &frame_id,
+bool Buffer::GetLatestStaticTF(const std::string &frame_id,
     const std::string &child_frame_id, TransformStamped *tf) {
-  for (auto &static_msg : static_msgs_) {
-    if (static_msg.header.frame_id == frame_id
-        && static_msg.child_frame_id == child_frame_id) {
-      TF2MsgToCyber(static_msg, (*tf));
+  for (auto reverse_iter = static_msgs_.rbegin();
+      reverse_iter != static_msgs_.rend(); ++reverse_iter) {
+    if ((*reverse_iter).header.frame_id == frame_id
+        && (*reverse_iter).child_frame_id == child_frame_id) {
+      TF2MsgToCyber((*reverse_iter), (*tf));
       return true;
     }
   }

--- a/modules/transform/buffer.h
+++ b/modules/transform/buffer.h
@@ -115,6 +115,9 @@ class Buffer : public BufferInterface, public tf2::BufferCore {
                             const float timeout_second = 0.01f,
                             std::string* errstr = nullptr) const;
 
+  bool GetStaticTF(const std::string &frame_id,
+      const std::string &child_frame_id, TransformStamped *tf);
+
  private:
   void SubscriptionCallback(
       const std::shared_ptr<const TransformStampeds>& transform);

--- a/modules/transform/buffer.h
+++ b/modules/transform/buffer.h
@@ -115,7 +115,7 @@ class Buffer : public BufferInterface, public tf2::BufferCore {
                             const float timeout_second = 0.01f,
                             std::string* errstr = nullptr) const;
 
-  bool GetStaticTF(const std::string &frame_id,
+  bool GetLatestStaticTF(const std::string &frame_id,
       const std::string &child_frame_id, TransformStamped *tf);
 
  private:


### PR DESCRIPTION
To provide projecting HDmap to camera view, the frontend adds a 'Camera View' under the point of view, and by default this option is not displayed to users, thus users won't feel any difference; the backend adds a websocket for sending camera image & related transformation matrix (transformation matrix is for calculating camera real-world position & rotation, based on static transforms and localization) to frontend.