### PR TITLE
Dreamview: add rwlock on route_paths_

### DIFF
--- a/modules/dreamview/backend/simulation_world/simulation_world_service.cc
+++ b/modules/dreamview/backend/simulation_world/simulation_world_service.cc
@@ -328,7 +328,10 @@ void SimulationWorldService::Update() {
     world_.Clear();
     *world_.mutable_auto_driving_car() = car;
 
-    route_paths_.clear();
+    {
+      boost::unique_lock<boost::shared_mutex> writer_lock(route_paths_mutex_);
+      route_paths_.clear();
+    }
 
     to_clear_ = false;
   }
@@ -1050,10 +1053,13 @@ void SimulationWorldService::UpdateSimulationWorld(
 template <>
 void SimulationWorldService::UpdateSimulationWorld(
     const RoutingResponse &routing_response) {
-  if (world_.has_routing_time() &&
-      world_.routing_time() == routing_response.header().timestamp_sec()) {
-    // This routing response has been processed.
-    return;
+  {
+    boost::shared_lock<boost::shared_mutex> reader_lock(route_paths_mutex_);
+    if (world_.has_routing_time() &&
+        world_.routing_time() == routing_response.header().timestamp_sec()) {
+      // This routing response has been processed.
+      return;
+    }
   }
 
   std::vector<Path> paths;
@@ -1062,16 +1068,15 @@ void SimulationWorldService::UpdateSimulationWorld(
   }
 
   world_.clear_route_path();
-  route_paths_.clear();
-  world_.set_routing_time(routing_response.header().timestamp_sec());
 
+  std::vector<RoutePath> route_paths;
   for (const Path &path : paths) {
     // Downsample the path points for frontend display.
     auto sampled_indices =
         DownsampleByAngle(path.path_points(), kAngleThreshold);
 
-    route_paths_.emplace_back();
-    RoutePath *route_path = &route_paths_.back();
+    route_paths.emplace_back();
+    RoutePath *route_path = &route_paths.back();
     for (const size_t index : sampled_indices) {
       const auto &path_point = path.path_points()[index];
       PolygonPoint *route_point = route_path->add_point();
@@ -1085,15 +1090,23 @@ void SimulationWorldService::UpdateSimulationWorld(
       *new_path = *route_path;
     }
   }
+  {
+    boost::unique_lock<boost::shared_mutex> writer_lock(route_paths_mutex_);
+    std::swap(route_paths, route_paths_);
+    world_.set_routing_time(routing_response.header().timestamp_sec());
+  }
 }
 
 Json SimulationWorldService::GetRoutePathAsJson() const {
   Json response;
-  response["routingTime"] = world_.routing_time();
   response["routePath"] = Json::array();
-  // TODO(simulation): there might be a race if there are multiple
-  // RoutingResponse arrived at the same time.
-  for (const auto &route_path : route_paths_) {
+  std::vector<RoutePath> route_paths;
+  {
+    boost::shared_lock<boost::shared_mutex> reader_lock(route_paths_mutex_);
+    response["routingTime"] = world_.routing_time();
+    route_paths = route_paths_;
+  }
+  for (const auto &route_path : route_paths) {
     Json path;
     path["point"] = Json::array();
     for (const auto &route_point : route_path.point()) {

--- a/modules/dreamview/backend/simulation_world/simulation_world_service.h
+++ b/modules/dreamview/backend/simulation_world/simulation_world_service.h
@@ -28,6 +28,9 @@
 #include <utility>
 #include <vector>
 
+#include "boost/thread/locks.hpp"
+#include "boost/thread/shared_mutex.hpp"
+
 #include "cyber/common/log.h"
 
 #include "gtest/gtest_prod.h"
@@ -308,6 +311,7 @@ class SimulationWorldService {
   SimulationWorld world_;
 
   // Downsampled route paths to be rendered in frontend.
+  mutable boost::shared_mutex route_paths_mutex_;
   std::vector<RoutePath> route_paths_;
 
   // The handle of MapService, not owned by SimulationWorldService.


### PR DESCRIPTION
Three main fixes on the previous one: #9584 who is reverted by #9591
1. add `mutable` on `boost::shared_mutex route_paths_mutex_;` who will be modified in const member function `Json SimulationWorldService::GetRoutePathAsJson() const {`.
2. fix the scope of temp variable `route_paths` in function `Json SimulationWorldService::GetRoutePathAsJson() const {`.
3. add redundant read lock on 
```
  {
    boost::shared_lock<boost::shared_mutex> reader_lock(route_paths_mutex_);
    if (world_.has_routing_time() &&
        world_.routing_time() == routing_response.header().timestamp_sec()) {
      // This routing response has been processed.
      return;
    }
```
by replacing
```
  // NOTICE: No need to add read lock here. Because no elsewhere place
  //         modifys the world_.routing_time() field concurrently.
  //         Consider to uncomment here after concurrency modification on
  //         this related field has been added.
  //
  //{
  //  boost::shared_lock<boost::shared_mutex> reader_lock(route_paths_mutex_);
    if (world_.has_routing_time() &&
        world_.routing_time() == routing_response.header().timestamp_sec()) {
      // This routing response has been processed.
      return;
    }
  //}
```
who may cause problem on the further upgrade who may write `world_.routing_time()` in another concurrency place.