### PR TITLE
Cyber: sorts map by string keys in cyber_monitor

### DIFF
--- a/cyber/tools/cyber_monitor/general_message_base.cc
+++ b/cyber/tools/cyber_monitor/general_message_base.cc
@@ -300,9 +300,12 @@ void GeneralMessageBase::PrintField(
     case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
       if (!jumpLines) {
         const std::string& fieldName = field->name();
-        outStr << fieldName << ": ";
-        if (field->is_repeated()) {
-          outStr << "[" << index << "] ";
+        outStr << fieldName;
+        if (!field->is_map()) {
+          outStr << ": ";
+          if (field->is_repeated()) {
+            outStr << "[" << index << "] ";
+          }
         }
         s->AddStr(indent, lineNo++, outStr.str().c_str());
       } else {


### PR DESCRIPTION
It's difficult to view messages like `apollo.monitor.SystemStatus.hmi_modules` because the indices keep changing. Protobufs map's indices are not consistent, which is fine for most use cases. For visualizing them, it makes sense to sort the keys lexicographically.