### PR TITLE
Planning: use std::move on path related data wherever it is possible

### DIFF
--- a/modules/planning/common/path/path_data.cc
+++ b/modules/planning/common/path/path_data.cc
@@ -35,13 +35,13 @@ namespace planning {
 using apollo::common::SLPoint;
 using apollo::common::math::CartesianFrenetConverter;
 
-bool PathData::SetDiscretizedPath(const DiscretizedPath &path) {
+bool PathData::SetDiscretizedPath(DiscretizedPath path) {
   if (reference_line_ == nullptr) {
     AERROR << "Should NOT set discretized path when reference line is nullptr. "
               "Please set reference line first.";
     return false;
   }
-  discretized_path_ = path;
+  discretized_path_ = std::move(path);
   if (!XYToSL(discretized_path_, &frenet_path_)) {
     AERROR << "Fail to transfer discretized path to frenet path.";
     return false;
@@ -51,13 +51,13 @@ bool PathData::SetDiscretizedPath(const DiscretizedPath &path) {
   return true;
 }
 
-bool PathData::SetFrenetPath(const FrenetFramePath &frenet_path) {
+bool PathData::SetFrenetPath(FrenetFramePath frenet_path) {
   if (reference_line_ == nullptr) {
     AERROR << "Should NOT set frenet path when reference line is nullptr. "
               "Please set reference line first.";
     return false;
   }
-  frenet_path_ = frenet_path;
+  frenet_path_ = std::move(frenet_path);
   if (!SLToXY(frenet_path_, &discretized_path_)) {
     AERROR << "Fail to transfer frenet path to discretized path.";
     return false;
@@ -68,8 +68,8 @@ bool PathData::SetFrenetPath(const FrenetFramePath &frenet_path) {
 }
 
 bool PathData::SetPathPointDecisionGuide(
-    const std::vector<std::tuple<double, PathPointType, double>>
-        &path_point_decision_guide) {
+    std::vector<std::tuple<double, PathPointType, double>>
+        path_point_decision_guide) {
   if (reference_line_ == nullptr) {
     AERROR << "Should NOT set path_point_decision_guide when reference line is "
               "nullptr. ";
@@ -80,7 +80,7 @@ bool PathData::SetPathPointDecisionGuide(
               "world frame trajectory is empty. ";
     return false;
   }
-  path_point_decision_guide_ = path_point_decision_guide;
+  path_point_decision_guide_ = std::move(path_point_decision_guide);
   return true;
 }
 

--- a/modules/planning/common/path/path_data.h
+++ b/modules/planning/common/path/path_data.h
@@ -45,15 +45,15 @@ class PathData {
 
   PathData() = default;
 
-  bool SetDiscretizedPath(const DiscretizedPath &path);
+  bool SetDiscretizedPath(DiscretizedPath path);
 
-  bool SetFrenetPath(const FrenetFramePath &frenet_path);
+  bool SetFrenetPath(FrenetFramePath frenet_path);
 
   void SetReferenceLine(const ReferenceLine *reference_line);
 
   bool SetPathPointDecisionGuide(
-      const std::vector<std::tuple<double, PathPointType, double>>
-          &path_point_decision_guide);
+      std::vector<std::tuple<double, PathPointType, double>>
+          path_point_decision_guide);
 
   const DiscretizedPath &discretized_path() const;
 

--- a/modules/planning/navi/decider/navi_path_decider.cc
+++ b/modules/planning/navi/decider/navi_path_decider.cc
@@ -135,9 +135,8 @@ apollo::common::Status NaviPathDecider::Process(
 
   KeepLane(dest_ref_line_y, &path_points);
 
-  DiscretizedPath discretized_path(path_points);
   path_data->SetReferenceLine(&(reference_line_info_->reference_line()));
-  if (!path_data->SetDiscretizedPath(discretized_path)) {
+  if (!path_data->SetDiscretizedPath(DiscretizedPath(std::move(path_points)))) {
     AERROR << "Set path data failed.";
     return Status(apollo::common::ErrorCode::PLANNING_ERROR,
                   "NaviPathDecider SetDiscretizedPath");

--- a/modules/planning/tasks/deciders/path_assessment_decider/path_assessment_decider.cc
+++ b/modules/planning/tasks/deciders/path_assessment_decider/path_assessment_decider.cc
@@ -397,7 +397,7 @@ void PathAssessmentDecider::SetPathInfo(
     SetPathPointType(reference_line_info, *path_data, &path_decision);
   }
   // SetObstacleDistance(reference_line_info, *path_data, &path_decision);
-  path_data->SetPathPointDecisionGuide(path_decision);
+  path_data->SetPathPointDecisionGuide(std::move(path_decision));
 }
 
 void PathAssessmentDecider::TrimTailingOutLanePoints(
@@ -428,8 +428,8 @@ void PathAssessmentDecider::TrimTailingOutLanePoints(
     frenet_path.pop_back();
     path_point_decision.pop_back();
   }
-  path_data->SetFrenetPath(frenet_path);
-  path_data->SetPathPointDecisionGuide(path_point_decision);
+  path_data->SetFrenetPath(std::move(frenet_path));
+  path_data->SetPathPointDecisionGuide(std::move(path_point_decision));
 }
 
 bool PathAssessmentDecider::IsGreatlyOffReferenceLine(

--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -1402,10 +1402,10 @@ void PathBoundsDecider::RecordDebugInfo(
 
   PathData left_path_data;
   left_path_data.SetReferenceLine(&(reference_line_info->reference_line()));
-  left_path_data.SetFrenetPath(frenet_frame_left_path);
+  left_path_data.SetFrenetPath(std::move(frenet_frame_left_path));
   PathData right_path_data;
   right_path_data.SetReferenceLine(&(reference_line_info->reference_line()));
-  right_path_data.SetFrenetPath(frenet_frame_right_path);
+  right_path_data.SetFrenetPath(std::move(frenet_frame_right_path));
 
   // Insert the transformed PathData into the simulator display.
   auto* ptr_display_path_1 =

--- a/modules/planning/tasks/deciders/speed_bounds_decider/speed_limit_decider_test.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/speed_limit_decider_test.cc
@@ -61,7 +61,7 @@ class SpeedLimitDeciderTest : public ::testing::Test {
       ff_points.push_back(std::move(ff_point));
     }
     frenet_frame_path_ = FrenetFramePath(std::move(ff_points));
-    path_data_.SetFrenetPath(frenet_frame_path_);
+    path_data_.SetFrenetPath(std::move(frenet_frame_path_));
   }
 
  protected:

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper_test.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper_test.cc
@@ -62,7 +62,7 @@ class StBoundaryMapperTest : public ::testing::Test {
       ff_points.push_back(std::move(ff_point));
     }
     frenet_frame_path_ = FrenetFramePath(std::move(ff_points));
-    path_data_.SetFrenetPath(frenet_frame_path_);
+    path_data_.SetFrenetPath(std::move(frenet_frame_path_));
   }
 
  protected:

--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -125,7 +125,7 @@ common::Status PiecewiseJerkPathOptimizer::Process(
       // final_path_data might carry info from upper stream
       PathData path_data = *final_path_data;
       path_data.SetReferenceLine(&reference_line);
-      path_data.SetFrenetPath(frenet_frame_path);
+      path_data.SetFrenetPath(std::move(frenet_frame_path));
       path_data.set_path_label(path_boundary.label());
       path_data.set_blocking_obstacle_id(path_boundary.blocking_obstacle_id());
       candidate_path_data.push_back(std::move(path_data));

--- a/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
+++ b/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
@@ -103,9 +103,8 @@ bool DpRoadGraph::FindPathTunnel(const common::TrajectoryPoint &init_point,
       accumulated_s += path_length;
     }
   }
-  FrenetFramePath tunnel(frenet_path);
   path_data->SetReferenceLine(&reference_line_);
-  path_data->SetFrenetPath(tunnel);
+  path_data->SetFrenetPath(FrenetFramePath(std::move(frenet_path)));
   return true;
 }
 


### PR DESCRIPTION
Using default move copy/copy construction and move assignment/assignment operation here on `DiscretizedPath`, `FrenetFramePath` and  `std::vector<std::tuple<double, PathPointType, double>>` should be OK. All their member data are on stack.