### PR TITLE
added NVIDIA_DRIVER_DEVICES and NVIDIA_DRIVER_CAPABILITIES

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -332,6 +332,8 @@ function main(){
         -e DOCKER_GRP_ID=$GRP_ID \
         -e DOCKER_IMG=$IMG \
         -e USE_GPU=$USE_GPU \
+        -e NVIDIA_VISIBLE_DEVICES=all \
+        -e NVIDIA_DRIVER_CAPABILITIES=compute,video,utility \
         $(local_volumes) \
         --net host \
         -w /apollo \


### PR DESCRIPTION
Added these env variables to the docker run command in order to get access to nvidia libraries. 
This looks like a necessary step for nvidia docker v2.