### PR TITLE
Perception: Fix Eigen::solver crash. 

### DIFF
--- a/modules/perception/camera/lib/lane/common/common_functions.h
+++ b/modules/perception/camera/lib/lane/common/common_functions.h
@@ -156,9 +156,12 @@ bool RansacFitting(const std::vector<Eigen::Matrix<Dtype, 2, 1>>& pos_vec,
       continue;
     }
 
+    // Since Eigen::solver was crashing, simple inverse of 3x3 matrix is used
+    // Note that Eigen::inverse of 3x3 and 4x4 is a closed form solution
     Eigen::Matrix<Dtype, 3, 1> matB;
     matB << pos_vec[index[0]](1), pos_vec[index[1]](1), pos_vec[index[2]](1);
-    Eigen::Matrix<Dtype, 3, 1> c = mat.solve(matB);
+    Eigen::Vector3f c =
+        static_cast<Eigen::Matrix<Dtype, 3, 1>> (matA.inverse() * matB);
     if (!(matA * c).isApprox(matB)) {
       ADEBUG << "No solution.";
       continue;


### PR DESCRIPTION
Instead of using solver, inverse of 3x3 or 4x4 matrix is used which is a closed form solution