### PR TITLE
Perception: Replaced run-time CHECK

### DIFF
--- a/modules/perception/base/distortion_model.cc
+++ b/modules/perception/base/distortion_model.cc
@@ -23,8 +23,10 @@ namespace base {
 
 Eigen::Vector2f BrownCameraDistortionModel::Project(
     const Eigen::Vector3f& point3d) {
-  CHECK(std::isgreater(point3d[2], 0.f))
-      << "the input point should be in front of the camera";
+  if (std::isless(point3d[2], 0.f)) {
+    AERROR << "The input point (" << point3d
+           << ") should be in front of the camera";
+  }
   // radial distortion coefficients
   const float k1 = distort_params_[0];
   const float k2 = distort_params_[1];

--- a/modules/perception/base/omnidirectional_model.cc
+++ b/modules/perception/base/omnidirectional_model.cc
@@ -28,8 +28,11 @@ namespace base {
 
 Eigen::Vector2f OmnidirectionalCameraDistortionModel::Project(
     const Eigen::Vector3f& point3d) {
-  CHECK_GT(point3d[2], 0.f)
-      << "the input point should be in front of the camera";
+  if (std::isgreater(point3d[2], 0.f)) {
+    AERROR << "The input point (" << point3d
+           << ") should be in front of the camera";
+  }
+
   // rotate:
   // [0 1 0;
   //  1 0 0;

--- a/modules/perception/camera/app/cipv_camera.cc
+++ b/modules/perception/camera/app/cipv_camera.cc
@@ -933,7 +933,9 @@ bool Cipv::DetermineCipv(const std::vector<base::LaneLine> &lane_objects,
 bool Cipv::TranformPoint(const Eigen::VectorXf &in,
                          const Eigen::Matrix4f &motion_matrix,
                          Eigen::Vector3d *out) {
-  CHECK(in.rows() == motion_matrix.cols());
+  if (in.rows() != motion_matrix.cols()) {
+    AERROR << "Matrix mismatch";
+  }
   Eigen::VectorXf trans_pt = motion_matrix * in;
   if (fabs(trans_pt(3)) < kFloatEpsilon) {
     return false;

--- a/modules/perception/camera/app/lane_camera_perception.cc
+++ b/modules/perception/camera/app/lane_camera_perception.cc
@@ -168,7 +168,10 @@ void LaneCameraPerception::SetCameraHeightAndPitch(
     const std::map<std::string, float> name_camera_ground_height_map,
     const std::map<std::string, float> name_camera_pitch_angle_diff_map,
     const float &pitch_angle_calibrator_working_sensor) {
-  CHECK(calibration_service_ != nullptr);
+  if (calibration_service_ == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return;
+  }
   calibration_service_->SetCameraHeightAndPitch(
       name_camera_ground_height_map, name_camera_pitch_angle_diff_map,
       pitch_angle_calibrator_working_sensor);
@@ -176,7 +179,10 @@ void LaneCameraPerception::SetCameraHeightAndPitch(
 
 void LaneCameraPerception::SetIm2CarHomography(
     Eigen::Matrix3d homography_im2car) {
-  CHECK(calibration_service_ != nullptr);
+  if (calibration_service_ == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return;
+  }
   lane_postprocessor_->SetIm2CarHomography(homography_im2car);
 }
 
@@ -192,7 +198,10 @@ bool LaneCameraPerception::Perception(const CameraPerceptionOptions &options,
   inference::CudaUtil::set_device_id(perception_param_.gpu_id());
   PERCEPTION_PERF_BLOCK_START();
 
-  CHECK(frame->calibration_service != nullptr);
+  if (frame->calibration_service == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return false;
+  }
 
   // Lane detector and postprocessor: work on front_6mm only
   if (lane_calibration_working_sensor_name_ ==

--- a/modules/perception/camera/app/obstacle_camera_perception.cc
+++ b/modules/perception/camera/app/obstacle_camera_perception.cc
@@ -281,7 +281,10 @@ void ObstacleCameraPerception::SetCameraHeightAndPitch(
     const std::map<std::string, float> &name_camera_ground_height_map,
     const std::map<std::string, float> &name_camera_pitch_angle_diff_map,
     const float &pitch_angle_calibrator_working_sensor) {
-  CHECK(calibration_service_ != nullptr);
+  if (calibration_service_ == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return;
+  }
   calibration_service_->SetCameraHeightAndPitch(
       name_camera_ground_height_map, name_camera_pitch_angle_diff_map,
       pitch_angle_calibrator_working_sensor);
@@ -289,7 +292,10 @@ void ObstacleCameraPerception::SetCameraHeightAndPitch(
 
 void ObstacleCameraPerception::SetIm2CarHomography(
     Eigen::Matrix3d homography_im2car) {
-  CHECK(calibration_service_ != nullptr);
+  if (calibration_service_ == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return;
+  }
   lane_postprocessor_->SetIm2CarHomography(homography_im2car);
 }
 
@@ -311,7 +317,10 @@ bool ObstacleCameraPerception::Perception(
   PERCEPTION_PERF_BLOCK_START();
   frame->camera_k_matrix =
       name_intrinsic_map_.at(frame->data_provider->sensor_name());
-  CHECK(frame->calibration_service != nullptr);
+  if (frame->calibration_service == nullptr) {
+    AERROR << "Calibraion service is not available";
+    return false;
+  }
 
   LaneDetectorOptions lane_detetor_options;
   LanePostprocessorOptions lane_postprocessor_options;

--- a/modules/perception/camera/common/camera_ground_plane.cc
+++ b/modules/perception/camera/common/camera_ground_plane.cc
@@ -111,7 +111,9 @@ void GetGround3FromPitchHeight(const std::vector<float> &k_mat,
 }
 
 GroundPlaneTracker::GroundPlaneTracker(int track_length) {
-  CHECK_GT(track_length, 0);
+  if (track_length <= 0) {
+    AERROR << "track_length, " << track_length << ", should be positive";
+  }
   pitch_height_inlier_tracks_.resize(track_length * 3);
   const_weight_temporal_.resize(track_length, 0.0f);
 
@@ -278,8 +280,14 @@ bool CameraGroundPlaneDetector::DetetGround(float pitch, float camera_height,
 
 bool CameraGroundPlaneDetector::DetectGroundFromSamples(float *vd, int count_vd,
                                                         float *inlier_ratio) {
-  CHECK(vd != nullptr);
-  CHECK(inlier_ratio != nullptr);
+  if (vd == nullptr) {
+    AERROR << "vd is nullptr";
+    return false;
+  }
+  if (inlier_ratio == nullptr) {
+    AERROR << "inlier_ratio is nullptr";
+    return false;
+  }
   *inlier_ratio = 0.0f;
   if (count_vd < params_.min_nr_samples) {
     l_[0] = l_[1] = l_[2] = 0.0f;

--- a/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
+++ b/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
@@ -117,7 +117,10 @@ bool OnlineCalibrationService::QueryPoint3dOnGroundPlane(
 
 bool OnlineCalibrationService::QueryGroundPlaneInCameraFrame(
     Eigen::Vector4d *plane_param) const {
-  CHECK(plane_param != nullptr);
+  if (plane_param == nullptr) {
+    AERROR << "plane_param is nullptr";
+    return false;
+  }
   if (!is_service_ready_) {
     (*plane_param)(0) = (*plane_param)(1) = (*plane_param)(2) =
         (*plane_param)(3) = 0.0;
@@ -133,8 +136,14 @@ bool OnlineCalibrationService::QueryGroundPlaneInCameraFrame(
 
 bool OnlineCalibrationService::QueryCameraToGroundHeightAndPitchAngle(
     float *height, float *pitch) const {
-  CHECK(height != nullptr);
-  CHECK(pitch != nullptr);
+  if (height == nullptr) {
+    AERROR << "height is nullptr";
+    return false;
+  }
+  if (pitch == nullptr) {
+    AERROR << "pitch is nullptr";
+    return false;
+  }
   if (!is_service_ready_) {
     *height = *pitch = 0.0;
     return false;
@@ -146,7 +155,10 @@ bool OnlineCalibrationService::QueryCameraToGroundHeightAndPitchAngle(
 }
 
 void OnlineCalibrationService::Update(CameraFrame *frame) {
-  CHECK(frame != nullptr);
+  if (frame == nullptr) {
+    AERROR << "frame is nullptr";
+    return;
+  }
   sensor_name_ = frame->data_provider->sensor_name();
   if (sensor_name_ == master_sensor_name_) {
     CalibratorOptions calibrator_options;

--- a/modules/perception/camera/lib/calibrator/laneline/laneline_calibrator.cc
+++ b/modules/perception/camera/lib/calibrator/laneline/laneline_calibrator.cc
@@ -33,7 +33,10 @@ bool LaneLineCalibrator::Init(const CalibratorInitOptions &options) {
 
 bool LaneLineCalibrator::Calibrate(const CalibratorOptions &options,
                                    float *pitch_angle) {
-  CHECK(pitch_angle != nullptr);
+  if (pitch_angle == nullptr) {
+    AERROR << "pitch_angle is not available";
+    return false;
+  }
   EgoLane ego_lane;
   if (!LoadEgoLaneline(*options.lane_objects, &ego_lane)) {
     AINFO << "Failed to get the ego lane.";
@@ -94,7 +97,11 @@ bool LaneLineCalibrator::Calibrate(const CalibratorOptions &options,
 
 bool LaneLineCalibrator::LoadEgoLaneline(
     const std::vector<base::LaneLine> &lane_objects, EgoLane *ego_lane) {
-  CHECK(ego_lane != nullptr);
+  if (ego_lane == nullptr) {
+    AERROR << "ego_lane is not available";
+    return false;
+  }
+
   bool found_ego_left = false;
   bool found_ego_right = false;
   // Using points from model fitting

--- a/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
@@ -174,15 +174,21 @@ bool DarkSCNNLaneDetector::Detect(const LaneDetectorOptions &options,
 
   auto start = std::chrono::high_resolution_clock::now();
   auto data_provider = frame->data_provider;
-  CHECK_EQ(input_width_, data_provider->src_width())
-      << "Input size is not correct: " << input_width_ << " vs "
-      << data_provider->src_width();
-  CHECK_EQ(input_height_, data_provider->src_height())
-      << "Input size is not correct: " << input_height_ << " vs "
-      << data_provider->src_height();
+  if (input_width_ != data_provider->src_width()) {
+    AERROR << "Input size is not correct: " << input_width_ << " vs "
+           << data_provider->src_width();
+    return false;
+  }
+  if (input_height_ != data_provider->src_height()) {
+    AERROR  << "Input size is not correct: " << input_height_ << " vs "
+            << data_provider->src_height();
+    return false;
+  }
 
   // use data provider to crop input image
-  CHECK(data_provider->GetImage(data_provider_image_option_, &image_src_));
+  if (!data_provider->GetImage(data_provider_image_option_, &image_src_)) {
+    return false;
+  }
 
   //  bottom 0 is data
   auto input_blob = cnnadapter_lane_->get_blob(net_inputs_[0]);
@@ -192,11 +198,14 @@ bool DarkSCNNLaneDetector::Detect(const LaneDetectorOptions &options,
   ADEBUG << "input_blob: " << blob_channel << " " << blob_height << " "
          << blob_width << std::endl;
 
-  CHECK_EQ(blob_height, resize_height_)
-      << "height is not equal" << blob_height << " vs " << resize_height_;
-  CHECK_EQ(blob_width, resize_width_)
-      << "width is not equal" << blob_width << " vs " << resize_width_;
-
+  if (blob_height != resize_height_) {
+    AERROR << "height is not equal" << blob_height << " vs " << resize_height_;
+    return false;
+  }
+  if (blob_width != resize_width_) {
+    AERROR << "width is not equal" << blob_width << " vs " << resize_width_;
+    return false;
+  }
   ADEBUG << "image_blob: " << image_src_.blob()->shape_string();
   ADEBUG << "input_blob: " << input_blob->shape_string();
   // resize the cropped image into network input blob

--- a/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
@@ -155,14 +155,20 @@ bool DenselineLaneDetector::Detect(const LaneDetectorOptions &options,
   }
 
   auto data_provider = frame->data_provider;
-  CHECK_EQ(input_width_, data_provider->src_width())
-      << "Input size is not correct: " << input_width_ << " vs "
-      << data_provider->src_width();
-  CHECK_EQ(input_height_, data_provider->src_height())
-      << "Input size is not correct: " << input_height_ << " vs "
-      << data_provider->src_height();
+  if (input_width_ != data_provider->src_width()) {
+    AERROR << "Input size is not correct: " << input_width_ << " vs "
+           << data_provider->src_width();
+    return false;
+  }
+  if (input_height_ != data_provider->src_height()) {
+    AERROR  << "Input size is not correct: " << input_height_ << " vs "
+            << data_provider->src_height();
+    return false;
+  }
 
-  CHECK(data_provider->GetImage(data_provider_image_option_, &image_src_));
+  if (!data_provider->GetImage(data_provider_image_option_, &image_src_)) {
+    return false;
+  }
 
   //  bottom 0 is data
   auto input_blob = rt_net_->get_blob(net_inputs_[0]);
@@ -172,10 +178,14 @@ bool DenselineLaneDetector::Detect(const LaneDetectorOptions &options,
   AINFO << "input_blob: " << blob_channel << " " << blob_height << " "
         << blob_width << std::endl;
 
-  CHECK_EQ(blob_height, resize_height_)
-      << "height is not equal" << blob_height << " vs " << resize_height_;
-  CHECK_EQ(blob_width, resize_width_)
-      << "width is not equal" << blob_width << " vs " << resize_width_;
+  if (blob_height != resize_height_) {
+    AERROR << "height is not equal" << blob_height << " vs " << resize_height_;
+    return false;
+  }
+  if (blob_width != resize_width_) {
+    AERROR << "width is not equal" << blob_width << " vs " << resize_width_;
+    return false;
+  }
   ADEBUG << "image_blob: " << image_src_.blob()->shape_string();
   ADEBUG << "input_blob: " << input_blob->shape_string();
 

--- a/modules/perception/camera/lib/lane/postprocessor/denseline/denseline_lane_postprocessor.cc
+++ b/modules/perception/camera/lib/lane/postprocessor/denseline/denseline_lane_postprocessor.cc
@@ -388,7 +388,11 @@ bool DenselineLanePostprocessor::LocateLanelinePointSet(
   input_image_height_ = data_provider->src_height();
   std::vector<int> out_put_shape = frame->lane_detected_blob->shape();
   int channels = frame->lane_detected_blob->channels();
-  CHECK_GE(channels, net_model_channel_num_);
+  if (channels < net_model_channel_num_) {
+    AERROR << "channel (" << channels << ") is less than net channel ("
+           << net_model_channel_num_ << ")";
+    return false;
+  }
 
   lane_map_height_ = frame->lane_detected_blob->height();
   lane_map_width_ = frame->lane_detected_blob->width();

--- a/modules/perception/camera/lib/obstacle/tracker/omt/obstacle_reference.cc
+++ b/modules/perception/camera/lib/obstacle/tracker/omt/obstacle_reference.cc
@@ -87,8 +87,16 @@ void ObstacleReference::UpdateReference(const CameraFrame *frame,
     if (box.ymax < frame->camera_k_matrix(1, 2) + 1) {
       continue;
     }
-    CHECK(box.ymax < img_height_ + 1) << box.ymax;
-    CHECK(box.xmax < img_width_ + 1) << box.xmax;
+    if (box.ymax >= img_height_ + 1) {
+      AERROR << "box.ymax (" << box.ymax
+             << ") is larger than img_height_ + 1 (" << img_height_ + 1 << ")";
+      return;
+    }
+    if (box.xmax >= img_width_ + 1) {
+      AERROR << "box.xmax (" << box.xmax
+             << ") is larger than img_width_ + 1 (" << img_width_ + 1 << ")";
+      return;
+    }
     float x = box.Center().x;
     float y = box.ymax;
 
@@ -239,7 +247,10 @@ void ObstacleReference::CorrectSize(CameraFrame *frame) {
         height.push_back(obj->size[2]);
       }
 
-      CHECK_GT(height.size(), 0);
+      if (height.size() <= 0) {
+        AERROR << "height vector is empty";
+        continue;
+      }
       std::sort(height.begin(), height.end());
       int nr_hs = static_cast<int>(height.size());
       float h_updated = height[nr_hs / 2];

--- a/modules/perception/camera/lib/obstacle/transformer/multicue/obj_mapper.cc
+++ b/modules/perception/camera/lib/obstacle/transformer/multicue/obj_mapper.cc
@@ -49,7 +49,10 @@ bool ObjMapper::SolveCenterFromNearestVerticalEdge(const float *bbox,
   center[0] = center[1] = center[2] = 0.0f;
   float height_bbox = bbox[3] - bbox[1];
   float width_bbox = bbox[2] - bbox[0];
-  CHECK(width_bbox > 0.0f && height_bbox > 0.0f);
+  if (width_bbox <= 0.0f || height_bbox <= 0.0f) {
+    AERROR << "width or height of bbox is 0";
+    return false;
+  }
 
   if (common::IRound(bbox[3]) >= height_ - 1) {
     height_bbox /= params_.occ_ratio;

--- a/modules/perception/camera/lib/traffic_light/detector/detection/detection.cc
+++ b/modules/perception/camera/lib/traffic_light/detector/detection/detection.cc
@@ -374,7 +374,10 @@ bool TrafficLightDetection::SelectOutputBoxes(
 
 void TrafficLightDetection::ApplyNMS(std::vector<base::TrafficLightPtr> *lights,
                                      double iou_thresh) {
-  CHECK_NOTNULL(lights);
+  if (lights == nullptr) {
+    AERROR << "lights are not available";
+    return;
+  }
 
   // (score, index) pairs sorted by detect score
   std::vector<std::pair<float, int>> score_index_vec(lights->size());

--- a/modules/perception/camera/lib/traffic_light/preprocessor/multi_camera_projection.cc
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/multi_camera_projection.cc
@@ -136,13 +136,15 @@ bool MultiCamerasProjection::BoundaryBasedProject(
     const Eigen::Matrix4d& c2w_pose,
     const std::vector<base::PointXYZID>& points,
     base::TrafficLight* light) const {
-  CHECK_NOTNULL(camera_model.get());
+  if (camera_model.get() == nullptr) {
+    AERROR << "camera_model is not available.";
+    return false;
+  }
   int width = static_cast<int>(camera_model->get_width());
   int height = static_cast<int>(camera_model->get_height());
   int bound_size = static_cast<int>(points.size());
-  AINFO << "bound size " << bound_size;
   if (bound_size < 4) {
-    AERROR << "invalid bound_size";
+    AERROR << "invalid bound_size " << bound_size;
     return false;
   }
   std::vector<Eigen::Vector2i> pts2d(bound_size);

--- a/modules/perception/camera/lib/traffic_light/preprocessor/pose.cc
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/pose.cc
@@ -44,7 +44,10 @@ void CarPose::SetCameraPose(const std::string &camera_name,
 
 bool CarPose::GetCameraPose(const std::string &camera_name,
                             Eigen::Matrix4d *c2w_pose) const {
-  CHECK_NOTNULL(c2w_pose);
+  if (c2w_pose == nullptr) {
+    AERROR << "c2w_pose is not available";
+    return false;
+  }
   if (c2w_poses_.find(camera_name) == c2w_poses_.end()) {
     return false;
   }

--- a/modules/perception/camera/lib/traffic_light/preprocessor/tl_preprocessor.cc
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/tl_preprocessor.cc
@@ -279,8 +279,15 @@ bool TLPreprocessor::ProjectLightsAndSelectCamera(
     const CarPose &pose, const TLPreprocessorOption &option,
     std::string *selected_camera_name,
     std::vector<base::TrafficLightPtr> *lights) {
-  CHECK_NOTNULL(selected_camera_name);
-  CHECK_NOTNULL(lights);
+
+  if (selected_camera_name == nullptr) {
+    AERROR << "selected_camera_name is not available";
+    return false;
+  }
+  if (lights == nullptr) {
+    AERROR << "lights is not available";
+    return false;
+  }
 
   for (auto &light_ptrs : lights_on_image_array_) {
     light_ptrs.clear();

--- a/modules/perception/camera/tools/offline/visualizer.cc
+++ b/modules/perception/camera/tools/offline/visualizer.cc
@@ -102,7 +102,10 @@ Eigen::Matrix3d Camera2CarHomograph(Eigen::Matrix3d intrinsic,
 bool Visualizer::Init(const std::vector<std::string> &camera_names,
                       TransformServer *tf_server) {
   tf_server_ = tf_server;
-  CHECK(tf_server_ != nullptr);
+  if (tf_server_ == nullptr) {
+    AERROR << "tf_server is unavailable";
+    return false;
+  }
   last_timestamp_ = 0;
   small_h_ = static_cast<int>(image_height_ * scale_ratio_);
   small_w_ = static_cast<int>(image_width_ * scale_ratio_);

--- a/modules/perception/common/graph/connected_component_analysis.cc
+++ b/modules/perception/common/graph/connected_component_analysis.cc
@@ -21,7 +21,10 @@ namespace common {
 
 void ConnectedComponentAnalysis(const std::vector<std::vector<int>>& graph,
                                 std::vector<std::vector<int>>* components) {
-  CHECK_NOTNULL(components);
+  if (components == nullptr) {
+    AERROR << "components is not available";
+    return;
+  }
   int num_item = static_cast<int>(graph.size());
   std::vector<int> visited;
   visited.resize(num_item, 0);

--- a/modules/perception/common/point_cloud_processing/downsampling.h
+++ b/modules/perception/common/point_cloud_processing/downsampling.h
@@ -108,7 +108,10 @@ void DownsamplingCircularOrgPartial(
     std::vector<std::pair<int, int>>* all_org_idx_ptr) {
   int smp_height = static_cast<int>(cloud->height()) / smp_ratio;
   int smp_width = org_num;
-  CHECK(smp_width >= 1 && smp_width < velodyne_model) << "org_num error!";
+  if (smp_width < 1 || smp_width >= velodyne_model) {
+    AERROR << "org_num error!";
+    return;
+  }
   size_t ii = 0;
   down_cloud->resize(smp_height * smp_width);
   all_org_idx_ptr->resize(smp_height * smp_width);
@@ -149,7 +152,10 @@ void DownsamplingRectangleOrgPartial(
     std::vector<std::pair<int, int>>* all_org_idx_ptr) {
   int smp_height = static_cast<int>(cloud->height()) / smp_ratio;
   int smp_width = org_num;
-  CHECK(smp_width >= 1 && smp_width < velodyne_model) << "org_num error!";
+  if (smp_width < 1 || smp_width >= velodyne_model) {
+    AERROR << "org_num error!";
+    return;
+  }
   size_t ii = 0;
   down_cloud->resize(smp_height * smp_width);
   all_org_idx_ptr->resize(smp_height * smp_width);
@@ -185,7 +191,11 @@ void DownsamplingRectangleNeighbour(
     float front_range, float side_range, double max_nei, int velo_model,
     typename std::shared_ptr<const base::PointCloud<PointT>> cloud,
     typename std::shared_ptr<base::PointCloud<PointT>> down_cloud) {
-  CHECK_EQ(cloud->width(), velo_model);
+  if (cloud->width() != velo_model) {
+    AERROR << "cloud->width (" << cloud->width() << ") does not match "
+           << "velo_model (" << velo_model << ")";
+    return;
+  }
   down_cloud->resize(cloud->size());
   size_t pt_num = 0;
   for (int ww = 0; ww < cloud->width(); ++ww) {

--- a/modules/perception/fusion/base/sensor.cc
+++ b/modules/perception/fusion/base/sensor.cc
@@ -25,7 +25,10 @@ size_t Sensor::kMaxCachedFrameNum = 10;
 
 void Sensor::QueryLatestFrames(double timestamp,
                                std::vector<SensorFramePtr>* frames) {
-  CHECK_NOTNULL(frames);
+  if (frames == nullptr) {
+    AERROR << "frames are not available";
+    return;
+  }
 
   frames->clear();
   for (size_t i = 0; i < frames_.size(); ++i) {
@@ -50,8 +53,10 @@ SensorFramePtr Sensor::QueryLatestFrame(double timestamp) {
 }
 
 bool Sensor::GetPose(double timestamp, Eigen::Affine3d* pose) const {
-  CHECK_NOTNULL(pose);
-
+  if (pose == nullptr) {
+    AERROR << "pose is not available";
+    return false;
+  }
   for (int i = static_cast<int>(frames_.size()) - 1; i >= 0; --i) {
     double time_diff = timestamp - frames_[i]->GetTimestamp();
     if (fabs(time_diff) < 1.0e-3) {  // > ?

--- a/modules/perception/fusion/base/sensor_frame.h
+++ b/modules/perception/fusion/base/sensor_frame.h
@@ -55,7 +55,10 @@ class SensorFrame {
   inline double GetTimestamp() const { return header_->timestamp; }
 
   inline bool GetPose(Eigen::Affine3d* pose) const {
-    CHECK_NOTNULL(pose);
+    if (pose == nullptr) {
+      AERROR << "pose is not available";
+      return false;
+    }
     *pose = header_->sensor2world_pose;
     return true;
   }

--- a/modules/perception/fusion/base/sensor_object.cc
+++ b/modules/perception/fusion/base/sensor_object.cc
@@ -49,7 +49,10 @@ double SensorObject::GetTimestamp() const {
 }
 
 bool SensorObject::GetRelatedFramePose(Eigen::Affine3d* pose) const {
-  CHECK_NOTNULL(pose);
+  if (pose == nullptr) {
+    AERROR << "pose is not available";
+    return false;
+  }
   if (frame_header_ == nullptr) {
     return false;
   }

--- a/modules/perception/fusion/common/dst_evidence.cc
+++ b/modules/perception/fusion/common/dst_evidence.cc
@@ -64,7 +64,10 @@ bool DstManager::IsAppAdded(const std::string &app_name) {
 }
 
 DstCommonDataPtr DstManager::GetAppDataPtr(const std::string &app_name) {
-  CHECK(IsAppAdded(app_name));
+  if (!IsAppAdded(app_name)) {
+    AERROR << "app_name is not available";
+    return nullptr;
+  }
   auto iter = dst_common_data_.find(app_name);
   if (iter != dst_common_data_.end()) {
     return &iter->second;

--- a/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion.cc
+++ b/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion.cc
@@ -108,7 +108,10 @@ bool ProbabilisticFusion::Init(const FusionInitOptions& init_options) {
 bool ProbabilisticFusion::Fuse(const FusionOptions& options,
                                const base::FrameConstPtr& sensor_frame,
                                std::vector<base::ObjectPtr>* fused_objects) {
-  CHECK(fused_objects != nullptr) << "fusion error: fused_objects is nullptr";
+  if (fused_objects == nullptr) {
+    AERROR << "fusion error: fused_objects is nullptr";
+    return false;
+  }
 
   auto* sensor_data_manager = SensorDataManager::Instance();
   // 1. save frame data

--- a/modules/perception/lib/registerer/registerer.cc
+++ b/modules/perception/lib/registerer/registerer.cc
@@ -28,7 +28,10 @@ BaseClassMap &GlobalFactoryMap() {
 bool GetRegisteredClasses(
     const std::string &base_class_name,
     std::vector<std::string> *registered_derived_classes_names) {
-  CHECK_NOTNULL(registered_derived_classes_names);
+  if (registered_derived_classes_names == nullptr) {
+    AERROR << "registered_derived_classes_names is not available";
+    return false;
+  }
   BaseClassMap &map = GlobalFactoryMap();
   auto iter = map.find(base_class_name);
   if (iter == map.end()) {

--- a/modules/perception/lidar/common/object_sequence.cc
+++ b/modules/perception/lidar/common/object_sequence.cc
@@ -69,7 +69,10 @@ bool ObjectSequence::GetTrackInTemporalWindow(TrackIdKey track_id,
 
 void ObjectSequence::RemoveStaleTracks(TimeStampKey current_stamp) {
   for (auto outer_iter = sequence_.begin(); outer_iter != sequence_.end();) {
-    CHECK(outer_iter->second.size() > 0) << "Find empty tracks.";
+    if (outer_iter->second.size() <= 0) {
+      AERROR << "Found empty tracks";
+      continue;
+    }
     auto& track = outer_iter->second;
 
     if (current_stamp - track.rbegin()->first > kMaxTimeOut) {

--- a/modules/perception/lidar/lib/roi_filter/hdmap_roi_filter/polygon_mask.h
+++ b/modules/perception/lidar/lib/roi_filter/hdmap_roi_filter/polygon_mask.h
@@ -45,7 +45,10 @@ bool DrawPolygonMask(const typename PolygonScanCvter<T>::Polygon& polygon,
   typedef typename PolygonScanCvter<T>::IntervalIn IntervalIn;
   typedef typename PolygonScanCvter<T>::IntervalOut IntervalOut;
   typedef typename PolygonScanCvter<T>::DirectionMajor PolyDirMajor;
-  CHECK(!bitmap->Empty());
+  if (bitmap->Empty()) {
+    AERROR << "bitmap is empty";
+    return false;
+  }
   Eigen::Vector2d poly_min_p, poly_max_p;
   poly_min_p.setConstant(std::numeric_limits<double>::max());
   poly_max_p = -poly_min_p;
@@ -56,9 +59,14 @@ bool DrawPolygonMask(const typename PolygonScanCvter<T>::Polygon& polygon,
     poly_max_p.x() = std::max(pt.x(), poly_max_p.x());
     poly_max_p.y() = std::max(pt.y(), poly_max_p.y());
   }
-  CHECK_GT(poly_max_p.x(), poly_min_p.x());
-  CHECK_GT(poly_max_p.y(), poly_min_p.y());
-
+  if (poly_max_p.x() <= poly_min_p.x()) {
+    AERROR << "Invalid polygon";
+    return false;
+  }
+  if (poly_max_p.y() <= poly_min_p.y()) {
+    AERROR << "Invalid polygon";
+    return false;
+  }
   const Eigen::Vector2d& bitmap_min_range = bitmap->min_range();
   const Eigen::Vector2d& bitmap_max_range = bitmap->max_range();
   const Eigen::Vector2d& cell_size = bitmap->cell_size();

--- a/modules/perception/lidar/lib/tracker/common/mlf_track_data.cc
+++ b/modules/perception/lidar/lib/tracker/common/mlf_track_data.cc
@@ -51,7 +51,10 @@ void MlfTrackData::PushTrackedObjectToTrack(TrackedObjectPtr obj) {
     sensor_history_objects_[obj->sensor_info.name].insert(pair);
     age_++;
     if (age_ == 1) {  // the first timestamp
-      CHECK(!obj->is_fake);
+      if (obj->is_fake) {
+        AERROR << "obj is fake";
+        return;
+      }
       latest_visible_time_ = timestamp;
       first_tracked_time_ = timestamp;
     }

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.cc
@@ -195,8 +195,11 @@ void MlfEngine::CollectTrackedResult(LidarFrame* frame) {
       if (!output_predict_objects_ && track_data->is_current_state_predicted_) {
         ++num_predict;
       } else {
-        CHECK(track_data->ToObject(-global_to_local_offset_, frame->timestamp,
-                                   tracked_objects[pos]));
+        if (!track_data->ToObject(-global_to_local_offset_, frame->timestamp,
+                                   tracked_objects[pos])) {
+          AERROR << "Tracking failed";
+          continue;
+        }
         ++pos;
       }
     }
@@ -206,7 +209,10 @@ void MlfEngine::CollectTrackedResult(LidarFrame* frame) {
   if (num_predict != 0) {
     AINFO << "MlfEngine, num_predict: " << num_predict
           << " num_objects: " << num_objects;
-    CHECK(num_predict <= num_objects);
+    if (num_predict > num_objects) {
+      AERROR << "num_predict > num_objects";
+      return;
+    }
     tracked_objects.resize(num_objects - num_predict);
   }
 }

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_measurement.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_measurement.cc
@@ -34,8 +34,10 @@ void MlfMotionMeasurement::ComputeMotionMeasurment(
   if (latest_object == nullptr) {
     latest_object = track_data->GetLatestObject().second;
   }
-  CHECK_NOTNULL(latest_object.get());
-
+  if (latest_object.get() == nullptr) {
+    AERROR << "latest_object is not available";
+    return;
+  }
   // should we estimate the measurement if the time diff is too small?
   double latest_time = latest_object->object_ptr->latest_tracked_time;
   double current_time = new_object->object_ptr->latest_tracked_time;

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_distance.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_distance.cc
@@ -105,7 +105,10 @@ float MlfTrackObjectDistance::ComputeDistance(
       weights = &iter->second;
     }
   }
-  CHECK(weights != nullptr && weights->size() >= 7);
+  if (weights == nullptr || weights->size() < 7) {
+    AERROR << "Invalid weights";
+    return 1e+10f;
+  }
   float distance = 0.f;
   float delta = 1e-10f;
 

--- a/modules/perception/map/hdmap/hdmap_input.cc
+++ b/modules/perception/map/hdmap/hdmap_input.cc
@@ -105,7 +105,10 @@ bool HDMapInput::GetRoiHDMapStruct(
     const base::PointD& pointd, const double distance,
     std::shared_ptr<base::HdmapStruct> hdmap_struct_ptr) {
   lib::MutexLock lock(&mutex_);
-  CHECK_NOTNULL(hdmap_.get());
+  if (hdmap_.get() == nullptr) {
+    AERROR << "hdmap is not available";
+    return false;
+  }
   // Get original road boundary and junction
   std::vector<RoadRoiPtr> road_boundary_vec;
   std::vector<JunctionInfoConstPtr> junctions_vec;
@@ -405,7 +408,10 @@ bool HDMapInput::GetSignals(const Eigen::Vector3d& pointd,
                             double forward_distance,
                             std::vector<apollo::hdmap::Signal>* signals) {
   lib::MutexLock lock(&mutex_);
-  CHECK_NOTNULL(hdmap_.get());
+  if (hdmap_.get() == nullptr) {
+    AERROR << "hdmap is not available";
+    return false;
+  }
   return GetSignalsFromHDMap(pointd, forward_distance, signals);
 }
 

--- a/modules/perception/onboard/component/fusion_camera_detection_component.cc
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.cc
@@ -975,7 +975,10 @@ int FusionCameraDetectionComponent::ConvertObjectToPb(
 int FusionCameraDetectionComponent::ConvertObjectToCameraObstacle(
     const base::ObjectPtr &object_ptr,
     apollo::perception::camera::CameraObstacle *camera_obstacle) {
-  CHECK_NOTNULL(camera_obstacle);
+  if (camera_obstacle == nullptr) {
+    AERROR << "camera_obstacle is not available";
+    return false;
+  }
   apollo::perception::PerceptionObstacle *obstacle =
       camera_obstacle->mutable_obstacle();
   ConvertObjectToPb(object_ptr, obstacle);
@@ -1008,7 +1011,10 @@ int FusionCameraDetectionComponent::ConvertObjectToCameraObstacle(
 int FusionCameraDetectionComponent::ConvertLaneToCameraLaneline(
     const base::LaneLine &lane_line,
     apollo::perception::camera::CameraLaneLine *camera_laneline) {
-  CHECK_NOTNULL(camera_laneline);
+  if (camera_laneline == nullptr) {
+    AERROR << "camera_laneline is not available";
+    return false;
+  }
   // fill the lane line attribute
   apollo::perception::camera::LaneLineType line_type =
       static_cast<apollo::perception::camera::LaneLineType>(lane_line.type);
@@ -1083,7 +1089,11 @@ int FusionCameraDetectionComponent::MakeCameraDebugMsg(
     double msg_timestamp, const std::string &camera_name,
     const camera::CameraFrame &camera_frame,
     apollo::perception::camera::CameraDebug *camera_debug_msg) {
-  CHECK_NOTNULL(camera_debug_msg);
+  if (camera_debug_msg == nullptr) {
+    AERROR << "camera_debug_msg is not available";
+    return false;
+  }
+
   auto itr = std::find(camera_names_.begin(), camera_names_.end(), camera_name);
   if (itr == camera_names_.end()) {
     AERROR << "invalid camera_name: " << camera_name;

--- a/modules/perception/onboard/component/lane_detection_component.cc
+++ b/modules/perception/onboard/component/lane_detection_component.cc
@@ -693,7 +693,10 @@ int LaneDetectionComponent::InternalProc(
 int LaneDetectionComponent::ConvertLaneToCameraLaneline(
     const base::LaneLine &lane_line,
     apollo::perception::camera::CameraLaneLine *camera_laneline) {
-  CHECK_NOTNULL(camera_laneline);
+  if (camera_laneline == nullptr) {
+    AERROR << "camera_laneline is not available";
+    return false;
+  }
   // fill the lane line attribute
   apollo::perception::camera::LaneLineType line_type =
       static_cast<apollo::perception::camera::LaneLineType>(lane_line.type);
@@ -768,7 +771,10 @@ int LaneDetectionComponent::MakeProtobufMsg(
     double msg_timestamp, const std::string &camera_name,
     const camera::CameraFrame &camera_frame,
     apollo::perception::PerceptionLanes *lanes_msg) {
-  CHECK_NOTNULL(lanes_msg);
+  if (lanes_msg == nullptr) {
+    AERROR << "lanes_msg is not available";
+    return false;
+  }
   auto itr = std::find(camera_names_.begin(), camera_names_.end(), camera_name);
   if (itr == camera_names_.end()) {
     AERROR << "invalid camera_name: " << camera_name;

--- a/modules/perception/onboard/component/radar_detection_component.cc
+++ b/modules/perception/onboard/component/radar_detection_component.cc
@@ -202,9 +202,15 @@ bool RadarDetectionComponent::InternalProc(
 bool RadarDetectionComponent::GetCarLocalizationSpeed(
     double timestamp, Eigen::Vector3f* car_linear_speed,
     Eigen::Vector3f* car_angular_speed) {
-  CHECK_NOTNULL(car_linear_speed);
+  if (car_linear_speed == nullptr) {
+    AERROR << "car_linear_speed is not available";
+    return false;
+  }
   (*car_linear_speed) = Eigen::Vector3f::Zero();
-  CHECK_NOTNULL(car_angular_speed);
+  if (car_linear_speed == nullptr) {
+    AERROR << "car_linear_speed is not available";
+    return false;
+  }
   (*car_angular_speed) = Eigen::Vector3f::Zero();
   std::shared_ptr<LocalizationEstimate const> loct_ptr;
   if (!localization_subscriber_.LookupNearest(timestamp, &loct_ptr)) {

--- a/modules/perception/radar/app/radar_obstacle_perception.cc
+++ b/modules/perception/radar/app/radar_obstacle_perception.cc
@@ -73,9 +73,12 @@ bool RadarObstaclePerception::Perceive(
   const std::string& sensor_name = options.sensor_name;
   PERCEPTION_PERF_BLOCK_START();
   base::FramePtr detect_frame_ptr(new base::Frame());
-  CHECK(detector_->Detect(corrected_obstacles, options.detector_options,
-                          detect_frame_ptr))
-      << "radar detect error";
+
+  if (!detector_->Detect(corrected_obstacles, options.detector_options,
+                        detect_frame_ptr)) {
+    AERROR << "radar detect error";
+    return false;
+  }
   ADEBUG << "Detected frame objects number: "
          << detect_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "detector");
@@ -87,9 +90,11 @@ bool RadarObstaclePerception::Perceive(
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "roi_filter");
 
   base::FramePtr tracker_frame_ptr = std::make_shared<base::Frame>();
-  CHECK(tracker_->Track(*detect_frame_ptr, options.track_options,
-                        tracker_frame_ptr))
-      << "radar track error";
+  if (!tracker_->Track(*detect_frame_ptr, options.track_options,
+                      tracker_frame_ptr)) {
+    AERROR << "radar track error";
+    return false;
+  }
   ADEBUG << "tracked frame objects number: "
          << tracker_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "tracker");

--- a/modules/perception/radar/lib/dummy/dummy_algorithms.cc
+++ b/modules/perception/radar/lib/dummy/dummy_algorithms.cc
@@ -77,7 +77,10 @@ bool DummyPreprocessor::Init() { return true; }
 bool DummyPreprocessor::Preprocess(const drivers::ContiRadar& raw_obstacles,
                                    const PreprocessorOptions& options,
                                    drivers::ContiRadar* corrected_obstacles) {
-  CHECK_NOTNULL(corrected_obstacles);
+  if (corrected_obstacles == nullptr) {
+    AERROR << "corrected_obstacles is not available";
+    return false;
+  }
   *corrected_obstacles = raw_obstacles;
   return true;
 }

--- a/modules/perception/radar/lib/interface/base_matcher.cc
+++ b/modules/perception/radar/lib/interface/base_matcher.cc
@@ -55,7 +55,10 @@ void BaseMatcher::IDMatch(const std::vector<RadarTrackPtr> &radar_tracks,
   for (size_t i = 0; i < num_track; ++i) {
     const auto &track_object = radar_tracks[i]->GetObsRadar();
     double track_timestamp = radar_tracks[i]->GetTimestamp();
-    CHECK_NOTNULL(track_object.get());
+    if (track_object.get() == nullptr) {
+      AERROR << "track_object is not available";
+      continue;
+    }
     int track_object_track_id = track_object->track_id;
     for (size_t j = 0; j < num_obj; ++j) {
       int object_track_id = objects[j]->track_id;

--- a/modules/perception/radar/lib/tracker/conti_ars_tracker/conti_ars_tracker.cc
+++ b/modules/perception/radar/lib/tracker/conti_ars_tracker/conti_ars_tracker.cc
@@ -148,7 +148,10 @@ void ContiArsTracker::CreateNewTracks(
 }
 
 void ContiArsTracker::CollectTrackedFrame(base::FramePtr tracked_frame) {
-  CHECK(tracked_frame != nullptr) << "tracked_frame is nullptr";
+  if (tracked_frame == nullptr) {
+    AERROR << "tracked_frame is nullptr";
+    return;
+  }
   auto &objects = tracked_frame->objects;
   const auto &radar_tracks = track_manager_->GetTracks();
   for (size_t i = 0; i < radar_tracks.size(); ++i) {

--- a/modules/perception/radar/lib/tracker/filter/adaptive_kalman_filter.cc
+++ b/modules/perception/radar/lib/tracker/filter/adaptive_kalman_filter.cc
@@ -102,8 +102,14 @@ Eigen::VectorXd AdaptiveKalmanFilter::UpdateWithObject(
 }
 void AdaptiveKalmanFilter::GetState(Eigen::Vector3d* anchor_point,
                                     Eigen::Vector3d* velocity) {
-  CHECK_NOTNULL(anchor_point);
-  CHECK_NOTNULL(velocity);
+  if (anchor_point == nullptr) {
+    AERROR << "anchor_point is not available";
+    return;
+  }
+  if (velocity == nullptr) {
+    AERROR << "velocity is not available";
+    return;
+  }
   *anchor_point = belief_anchor_point_;
   *velocity = belief_velocity_;
 }


### PR DESCRIPTION
Replaced run-time CHECK macro to AERROR and return. 
Exception: CHECK is still in Initialization functions and second-party functions. 

