### PR TITLE
cyber: update cyber docker image with python and cuda support

### DIFF
--- a/docker/build/cyber.x86_64.dockerfile
+++ b/docker/build/cyber.x86_64.dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:18.04
+ARG BASE_IMAGE=nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+# ARG BASE_IMAGE=ubuntu:18.04
+FROM ${BASE_IMAGE}
 
 LABEL version="1.0"
 
@@ -62,6 +64,7 @@ RUN bash /tmp/installers/install_protobuf.sh
 RUN bash /tmp/installers/install_bazel_packages.sh
 RUN bash /tmp/installers/install_google_styleguide.sh
 RUN bash /tmp/installers/install_osqp.sh
+RUN bash /tmp/installers/install_python_modules.sh
 
 # Add Bionic source
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted" > /etc/apt/sources.list

--- a/docker/build/installers/install_python_modules.sh
+++ b/docker/build/installers/install_python_modules.sh
@@ -28,7 +28,7 @@ apt-get -y update && \
     python-pip \
     python-psutil \
     python-scipy \
-    python-software-properties \
+    software-properties-common \
     python3-psutil
 
 pip install -r py27_requirements.txt

--- a/docker/build/installers/py27_requirements.txt
+++ b/docker/build/installers/py27_requirements.txt
@@ -2,6 +2,9 @@
 #    sudo apt-get install python-numpy python-scipy python-matplotlib
 #    sudo pip install -r py27_requirements.txt
 
+# system utils
+supervisor
+
 # Google infras.
 glog
 protobuf == 3.1
@@ -13,13 +16,13 @@ flask-cors
 requests >= 2.18
 simplejson
 
+# ROS env.
+PyYAML
+
 # Python tools
-pyproj == 1.9.6
+pyproj
 shapely
 
 # Data format
-PyYAML
 h5py
-pypcd
-pytz
 utm

--- a/docker/scripts/cyber_start.sh
+++ b/docker/scripts/cyber_start.sh
@@ -192,7 +192,7 @@ function main(){
         info "Start docker container based on local image : $IMG"
     else
         info "Start pulling docker image $IMG ..."
-        #docker pull $IMG
+        docker pull $IMG
         if [ $? -ne 0 ];then
             error "Failed to pull docker image."
             exit 1

--- a/docker/scripts/cyber_start.sh
+++ b/docker/scripts/cyber_start.sh
@@ -20,7 +20,7 @@ INCHINA="no"
 LOCAL_IMAGE="no"
 VERSION=""
 ARCH=$(uname -m)
-VERSION_X86_64="cyber-x86_64-18.04-20190613_1540"
+VERSION_X86_64="cyber-x86_64-18.04-20190930_1641"
 VERSION_AARCH64="cyber-aarch64-18.04-20190621_1606"
 VERSION_OPT=""
 
@@ -192,7 +192,7 @@ function main(){
         info "Start docker container based on local image : $IMG"
     else
         info "Start pulling docker image $IMG ..."
-        docker pull $IMG
+        #docker pull $IMG
         if [ $? -ne 0 ];then
             error "Failed to pull docker image."
             exit 1


### PR DESCRIPTION
a) install python modules so python tools could be fully supported
b) replace ubuntu 18.04 base with Nvidia cuda base image, so streamline
the process from cyber docker image to dev docker image