### PR TITLE
Cyber: remove UB from cyber base object pool test

### DIFF
--- a/cyber/base/object_pool_test.cc
+++ b/cyber/base/object_pool_test.cc
@@ -88,27 +88,10 @@ TEST(CCObjectPoolTest, construct_object) {
   std::vector<std::shared_ptr<TestNode>> vec;
 
   FOR_EACH(i, 0, capacity) {
-    auto obj = pool->GetObject();
-    vec.push_back(obj);
-    EXPECT_FALSE(obj->inited);
-    EXPECT_EQ(0, obj->value);
-  }
-  vec.clear();
-
-  FOR_EACH(i, 0, capacity) {
     auto obj = pool->ConstructObject(i);
     vec.push_back(obj);
     EXPECT_TRUE(obj->inited);
     EXPECT_EQ(i, obj->value);
-  }
-  vec.clear();
-
-  // check values after destructor
-  FOR_EACH(i, 0, capacity) {
-    auto obj = pool->GetObject();
-    vec.push_back(obj);
-    EXPECT_FALSE(obj->inited);
-    EXPECT_EQ(1, obj->value);
   }
   vec.clear();
 }


### PR DESCRIPTION
There is undefined behavior in the object pool test. I'm not sure if it is in the usage as well.

Basically, there shouldn't be any usage of an object before it is constructed. It can get very tricky. There are some CPPCon talks about these kind of issues [CppCon 2019: CJ Johnson “How to Hold a T”
](https://www.youtube.com/watch?v=WX8FsrUbLjc) and [CppCon 2019: Miro Knejp “Non-conforming C++: the Secrets the Committee Is Hiding From You”](https://youtu.be/IAdLwUXRUvg?t=1103).

In C++17 and beyond you can access [indeterminate values](https://eel.is/c++draft/basic.indet), if they are `std::byte` or `unsigned`. Access outside of the lifetime of an object is undefined as per this [example in the standard](https://eel.is/c++draft/conv.lval).

Newer compilers may optimize away parts of the code. It seems that the destruction will be optimized away in new versions of GCC. You can take a look at this [example](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAKxAEZSAbAQwDtRkBSAJgCFufSAZ1QBXYskwgA5NwDMeFsgYisAag6yAwskEF8LAhuwcADAEE5CpSszqtOvQzwAjI6Ytd5i5Wo2a8qLrEmEwAtm7mlt42dpqhmKEkAJ4RFuZBIsgEqgDyzlTqAOx85qq5%2BRAAlKogqgqEmOgQBMQimNUcxZ0AIu5lAH55VFVFPHUsDeh23aoAZkwMgpgaYz19qs6oqAzjk50884vLhb2yJRYnK%2B7uAG6oeFOaCww5LJgj%2B6q66CAootl%2BPzqLhcWjcLixIHfX6YFjoBgrIq9cx3B6qJ4MBgAFQA7qgPsUvnpfmgRACtEDwVxwZCtESfiBYfDEWsUfdHs8sQhgu8OoToX8ybTNMDPDTAXSBUyEWckddzApsqEmAoCecyqipgAqNAsXSqYhMHEAfQADi1pqpkM9UMgIII8AAvTCoWYQIaVUiqWiVK6lcoFHWoPXZAiYXTGlgYTBmi0aGbBRWYYim4IEY3W3R%2BIaqLVGCCGk3m4i%2Bs7rPCzVTNcPpqNYWPEAC0RnqYfQfPVZXRz1evL9ZjKrIHo3WZQFggQTGC6Ab2fyRi%2ByuI6eLEDeOKrYYjdZjxeqQyqpFHXZPp7P5/PHAArHwr913flc7r9XvRqpi83ZNhBhVS6sTn%2B6xDmUGLYniVT9mUFabjWkbRg2n7YK2jQdseoFcjyEFlv6wEGpgBBiCwqjYAAGgAklixoAMoAKqaJo2BUVR/ZDlInoMNIV5SKQLDSCY3GoNImj8PwXyiOIthyLQ3EEHxbGegA1iAV4mIw0gACzcbxUj8aQglSNxgggKpsk6WxpBwLAMBQNZEBIP8ppkuQlBoKEpp4AwyZ0KQjSECQ3k4oaprSNJ7GcVpcl6dIUmqDihAIKoAAeAAcABsjapepqjAMgyCbq0LAKZUMlyZ6dmMolmDIGSJDORAU7AIIAAKrCYAwVEIKgOLadJpCue5zAEAELAtW87Wdd1kX9R5XnAAAnFwfWoG5M3EDkZIdV12m6ZglXIGYxCNdI3G7VVVF6Aox2MKw7AibwjAuEZkCeqg5rDUZUiNt88acLw/C0JpQjiRI3nfAoo1tZtk1mWFUhcTxkX6Sl6WZdluWqHNAB0ELYHtNXEFWuB%2BQTUnVMJf28CVMOKcpqkcVIgOhCAsjqZjKm0JlXBzbIV6yIUhTJYUCNmVFBlCN5pn8WVtlIKd1VEGQFD1YdzWteNW0hdx02DcNEPq9Duna7NC1LStnlrRtE3bSde0HUdYty%2Bd%2BhXcwbAoHdAhOM4T2Hq9Q3Bh9X16D9HsA6ojY5LIhnA5I9BgyNatQz15n0/D1ui8jGVZTleVYzjeMK4T%2BCF6T6Ie1TUueggIRYMQlA0ypakM9xTO0CYqnp/phnGaQkvyU3XAt8zrPs5z3O8/zgvC7pXe96VFm2TLFVVfjdUNarY1J5rpsDUw/sJ5vVtTctA2zepyVXjvq3rQQW8i3LdsfTbZ0Xdp3Gu7dFOe498AvW9AfSCDugEOX9aBJGjmIEGcdX56zvqFJuadEbSEzqjHOqhWbJTZsRAuJAi7E2BLIH0Zcv4V37tXJgtd66kCUo3emjNmZcExoUdSc1aAC15p4WgbdUrTwEldIyJl56WUQMveWtUlbr1gUfKQvVtZ711onaRhsT6rRAMAc%2Bl8jYW1vko5%2B%2B0VZXUdq/F2N13Zfwet7X%2Bel/56kAd9WQ3Rfp8F4GA8OkcIESVBjAxRGsZEp3CrwjOaUs5ozyhgrBuMV6FwgETEunCyblzntTUg5DKGHhoXTDSEURazwEUkyuA8h6yEYcw1h7DimEO4YE2efdpbwHKlouqWi1GCBYEwU0E5UAEFILMDyYZiBGQgM4SKzgFBTiSNvVy8QDCvAYBMkWWBlRsE8pFfAwQsh4BuOGSKcsySSD8eQAwbVIpe0NMQJImhozbxaHgJmfj2KmKcfwCxPs/770DgAdWeOHD5u0WhMHDqaRorAhp5SASA5xPAw4RyjkDSBsdYaIJycg4JqD0bNAKkVPBcTCFekuWbZMBCiHk0haQyoVca5eUPHQopJSWFsIvhUrhJgeGd34T3WpDdMlSFhWysWnLCnVKugKrZAzhogHUkAA).