### PR TITLE
remote Eigen auto in vehicle state provider

### DIFF
--- a/modules/common/vehicle_state/vehicle_state_provider.cc
+++ b/modules/common/vehicle_state/vehicle_state_provider.cc
@@ -230,7 +230,8 @@ math::Vec2d VehicleStateProvider::EstimateFuturePosition(const double t) const {
                                          orientation.qy(), orientation.qz());
     Eigen::Vector3d pos_vec(vehicle_state_.x(), vehicle_state_.y(),
                             vehicle_state_.z());
-    auto future_pos_3d = quaternion.toRotationMatrix() * vec_distance + pos_vec;
+    const Eigen::Vector3d future_pos_3d =
+        quaternion.toRotationMatrix() * vec_distance + pos_vec;
     return math::Vec2d(future_pos_3d[0], future_pos_3d[1]);
   }
 


### PR DESCRIPTION
In gcc 5.4.0, `bazel test --config=unit_test -c opt --copt=-fpic //modules/common/vehicle_state:vehicle_state_provider_test` will fail. In general, [the eigen project doesn't recommend using auto](https://eigen.tuxfamily.org/dox/TopicPitfalls.html#TopicPitfalls_auto_keyword). I'd recommend using an explicit type here.