### PR TITLE
Perception: Fix typo in channel name.

### DIFF
--- a/modules/perception/onboard/proto/trafficlights_perception_component.proto
+++ b/modules/perception/onboard/proto/trafficlights_perception_component.proto
@@ -3,23 +3,30 @@ syntax = "proto2";
 package apollo.perception.onboard;
 
 message TrafficLight {
-    optional string tl_tf2_frame_id = 1 [default = "world"];
-    optional string tl_tf2_child_frame_id = 2 [default = "perception_localization_100hz"];
-    optional double tf2_timeout_second = 3 [default = 0.01];
-    optional string camera_names = 4 [default = "front_6mm,front_12mm"];
-    optional string camera_channel_names = 5 [default = "/apollo/sensor/camera/front_6mm,/apollop/sensor/camera/front_12mm"];
-    optional double tl_image_timestamp_offset = 6 [default = 0.0];
-    optional int32 max_process_image_fps = 7 [default = 8];
-    optional double query_tf_interval_seconds = 8 [default = 0.3];
-    optional double valid_hdmap_interval = 9 [default = 1.5];
-    optional double image_sys_ts_diff_threshold = 10 [default = 0.5];
-    optional double sync_interval_seconds = 11 [default = 0.5];
-    optional string camera_traffic_light_perception_conf_dir = 12 [default = "conf/perception/camera"];
-    optional string camera_traffic_light_perception_conf_file = 13 [default = "trafficlight.pt"];
-    optional int32 default_image_border_size = 14 [default = 100];
-    optional string traffic_light_output_channel_name = 15 [default = "/apollo/perception/traffic_light"];
-    optional string simulation_channel_name = 16 [default = "/apollo/perception/traffic_light_simulation"];
-    optional string v2x_trafficlights_input_channel_name = 17 [default = "/apollo/v2x/traffic_light"];
-    optional double v2x_sync_interval_seconds = 18 [default = 0.1];
-    optional int32 max_v2x_msg_buff_size = 19 [default = 50];
+  optional string tl_tf2_frame_id = 1 [default = "world"];
+  optional string tl_tf2_child_frame_id = 2 [default =
+      "perception_localization_100hz"];
+  optional double tf2_timeout_second = 3 [default = 0.01];
+  optional string camera_names = 4 [default = "front_6mm,front_12mm"];
+  optional string camera_channel_names = 5 [default =
+      "/apollo/sensor/camera/front_6mm,/apollo/sensor/camera/front_12mm"];
+  optional double tl_image_timestamp_offset = 6 [default = 0.0];
+  optional int32 max_process_image_fps = 7 [default = 8];
+  optional double query_tf_interval_seconds = 8 [default = 0.3];
+  optional double valid_hdmap_interval = 9 [default = 1.5];
+  optional double image_sys_ts_diff_threshold = 10 [default = 0.5];
+  optional double sync_interval_seconds = 11 [default = 0.5];
+  optional string camera_traffic_light_perception_conf_dir = 12 [default =
+      "conf/perception/camera"];
+  optional string camera_traffic_light_perception_conf_file = 13 [default =
+      "trafficlight.pt"];
+  optional int32 default_image_border_size = 14 [default = 100];
+  optional string traffic_light_output_channel_name = 15 [default =
+      "/apollo/perception/traffic_light"];
+  optional string simulation_channel_name = 16 [default =
+      "/apollo/perception/traffic_light_simulation"];
+  optional string v2x_trafficlights_input_channel_name = 17 [default =
+      "/apollo/v2x/traffic_light"];
+  optional double v2x_sync_interval_seconds = 18 [default = 0.1];
+  optional int32 max_v2x_msg_buff_size = 19 [default = 50];
 }


### PR DESCRIPTION
`/apollop/sensor/camera/front_12mm` -> `/apollo/sensor/camera/front_12mm`