### PR TITLE
Start stop encoders

### DIFF
--- a/modules/dreamview/backend/teleop/teleop.cc
+++ b/modules/dreamview/backend/teleop/teleop.cc
@@ -30,7 +30,6 @@ using ::google::protobuf::util::MessageToJsonString;
 using modules::teleop::network::ModemInfo;
 using modules::teleop::teleop::DaemonServiceCmd;
 using modules::teleop::teleop::DaemonServiceRpt;
-using apollo::planning::PadMessage;
 using apollo::cyber::Time;
 
 // modem ids

--- a/modules/dreamview/backend/teleop/teleop.cc
+++ b/modules/dreamview/backend/teleop/teleop.cc
@@ -289,7 +289,6 @@ void TeleopService::UpdateOperatorDaemonRpt(
 }
 
 void TeleopService::SendVideoStreamCmd(bool start_stop) {
-  // auto msg = std::make_shared<DaemonServiceCmd>();
   DaemonServiceCmd msg;
   if (start_stop) {
     msg.set_cmd("start");

--- a/modules/dreamview/backend/teleop/teleop.cc
+++ b/modules/dreamview/backend/teleop/teleop.cc
@@ -112,10 +112,10 @@ void TeleopService::RegisterMessageHandlers() {
         // TODO
         {
           boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
-          // teleop_status_["audio"] = !teleop_status_["audio"];
+          teleop_status_["audio"] = !teleop_status_["audio"];
 
           // turn on/off the mic based on the audio status
-          // teleop_status_["mic"] = teleop_status_["audio"];
+          teleop_status_["mic"] = teleop_status_["audio"];
         }
       });
   // Mute/Unmute local microphone

--- a/modules/dreamview/backend/teleop/teleop.cc
+++ b/modules/dreamview/backend/teleop/teleop.cc
@@ -17,20 +17,20 @@
 #include "modules/dreamview/backend/teleop/teleop.h"
 
 #include "cyber/common/log.h"
-#include "google/protobuf/util/json_util.h"
 #include "cyber/time/time.h"
+#include "google/protobuf/util/json_util.h"
 #include "modules/common/util/message_util.h"
 
 namespace apollo {
 namespace dreamview {
 
 using Json = nlohmann::json;
+using apollo::cyber::Time;
 using apollo::planning::PadMessage;
 using ::google::protobuf::util::MessageToJsonString;
 using modules::teleop::network::ModemInfo;
 using modules::teleop::teleop::DaemonServiceCmd;
 using modules::teleop::teleop::DaemonServiceRpt;
-using apollo::cyber::Time;
 
 // modem ids
 const std::string modem0_id = "0";
@@ -136,16 +136,15 @@ void TeleopService::RegisterMessageHandlers() {
         // TODO
         {
           bool sendStartVideo = false;
-          bool sendStopVideo  = false;
+          bool sendStopVideo = false;
           // create a scope for the mutex lock
           {
             boost::shared_lock<boost::shared_mutex> writer_lock(mutex_);
             // toggle depending on current state change
-            if (teleop_status_["video_starting"])  {
+            if (teleop_status_["video_starting"]) {
               teleop_status_["video_starting"] = false;
               teleop_status_["video_stopping"] = true;
-            }
-            else if (teleop_status_["video_stopping"]) {
+            } else if (teleop_status_["video_stopping"]) {
               teleop_status_["video_starting"] = true;
               teleop_status_["video_stopping"] = false;
             }
@@ -155,8 +154,7 @@ void TeleopService::RegisterMessageHandlers() {
               if (teleop_status_["video"]) {
                 teleop_status_["video_stopping"] = true;
                 teleop_status_["video_starting"] = false;
-              }
-              else {
+              } else {
                 teleop_status_["video_stopping"] = false;
                 teleop_status_["video_starting"] = true;
               }
@@ -164,7 +162,7 @@ void TeleopService::RegisterMessageHandlers() {
             AINFO << "ToggleVideo: " << teleop_status_["video_starting"];
           }
           if (sendStartVideo || sendStopVideo) {
-             SendVideoStreamCmd(sendStartVideo);
+            SendVideoStreamCmd(sendStartVideo);
           }
         }
       });
@@ -216,75 +214,72 @@ void TeleopService::UpdateModem(const std::string &modem_id,
 void TeleopService::UpdateCarDaemonRpt(
     const std::shared_ptr<DaemonServiceRpt> &daemon_rpt) {
   {
-      bool videoIsRunning = false;
-      bool voipIsRunning = false;
-      unsigned int runningEncoders = 0;
-      for (int i = 0; i < daemon_rpt->services_size(); i++) {
-          // look for voip_encoder or encoder0..1.2
-          // check 'voip_encoder' first because it contains 'encoder'
-          std::string service =  daemon_rpt->services(i);
-          if (service.find("voip_encoder") != std::string::npos) {
-              voipIsRunning = true;
-          }
-          else if (service.find("encoder") != std::string::npos) {
-              runningEncoders ++;
-          }
+    bool videoIsRunning = false;
+    bool voipIsRunning = false;
+    unsigned int runningEncoders = 0;
+    for (int i = 0; i < daemon_rpt->services_size(); i++) {
+      // look for voip_encoder or encoder0..1.2
+      // check 'voip_encoder' first because it contains 'encoder'
+      std::string service = daemon_rpt->services(i);
+      if (service.find("voip_encoder") != std::string::npos) {
+        voipIsRunning = true;
+      } else if (service.find("encoder") != std::string::npos) {
+        runningEncoders++;
       }
+    }
 
-      // all  video encoders are running.
-      videoIsRunning = runningEncoders == encoder_count;
+    // all  video encoders are running.
+    videoIsRunning = runningEncoders == encoder_count;
 
-      // we may need to write commands to start/stop the video stream
-      bool sendStartVideo = false;
-      bool sendStopVideo = false;
+    // we may need to write commands to start/stop the video stream
+    bool sendStartVideo = false;
+    bool sendStopVideo = false;
 
-      // scope for the lock
-      {
-        boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
-        teleop_status_["video"] = videoIsRunning;
-        teleop_status_["audio"] = voipIsRunning;
+    // scope for the lock
+    {
+      boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
+      teleop_status_["video"] = videoIsRunning;
+      teleop_status_["audio"] = voipIsRunning;
 
-        if  (teleop_status_["video"]) {
-          if (teleop_status_["video_starting"]) {
-            // video has started
-            teleop_status_["video_starting"] = false;
-          }
-          else if (teleop_status_["video_stopping"]) {
-            // not stopped yet
-            sendStopVideo = true;
-          }
-        }
-        // video not running
-        else {
-          if (teleop_status_["video_starting"]) {
-            // not started yet
-            sendStartVideo = true;
-          }
-          else if (teleop_status_["video_stopping"]) {
-            // video is stopped
-            teleop_status_["video_stopping"] = false;
-          }
+      if (teleop_status_["video"]) {
+        if (teleop_status_["video_starting"]) {
+          // video has started
+          teleop_status_["video_starting"] = false;
+        } else if (teleop_status_["video_stopping"]) {
+          // not stopped yet
+          sendStopVideo = true;
         }
       }
-      if (sendStartVideo || sendStopVideo) {
-        SendVideoStreamCmd(sendStartVideo);
+      // video not running
+      else {
+        if (teleop_status_["video_starting"]) {
+          // not started yet
+          sendStartVideo = true;
+        } else if (teleop_status_["video_stopping"]) {
+          // video is stopped
+          teleop_status_["video_stopping"] = false;
+        }
       }
+    }
+    if (sendStartVideo || sendStopVideo) {
+      SendVideoStreamCmd(sendStartVideo);
+    }
   }
 }
 
 void TeleopService::UpdateOperatorDaemonRpt(
     const std::shared_ptr<DaemonServiceRpt> &daemon_rpt) {
   {
-      bool voipIsRunning = false;
-      for (int i = 0; i < daemon_rpt->services_size(); i++) {
-          std::string service =  daemon_rpt->services(i);
-          if (service.find("voip_encoder") != std::string::npos) {
-              voipIsRunning = true;
-              break;
-          }
+    bool voipIsRunning = false;
+    for (int i = 0; i < daemon_rpt->services_size(); i++) {
+      std::string service = daemon_rpt->services(i);
+      if (service.find("voip_encoder") != std::string::npos) {
+        voipIsRunning = true;
+        break;
       }
-      boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
-      teleop_status_["mic"] = voipIsRunning;
+    }
+    boost::unique_lock<boost::shared_mutex> writer_lock(mutex_);
+    teleop_status_["mic"] = voipIsRunning;
   }
 }
 
@@ -292,8 +287,7 @@ void TeleopService::SendVideoStreamCmd(bool start_stop) {
   DaemonServiceCmd msg;
   if (start_stop) {
     msg.set_cmd("start");
-  }
-  else {
+  } else {
     msg.set_cmd("kill");
   }
   // we send a message to each encoder.
@@ -303,7 +297,7 @@ void TeleopService::SendVideoStreamCmd(bool start_stop) {
     msg.set_service(encoderName);
     common::util::FillHeader("dreamview", &msg);
     car_daemon_cmd_writer_->Write(msg);
-    AINFO << encoderName << " "  <<  msg.cmd();
+    AINFO << encoderName << " " << msg.cmd();
   }
 }
 

--- a/modules/dreamview/backend/teleop/teleop.h
+++ b/modules/dreamview/backend/teleop/teleop.h
@@ -44,6 +44,9 @@ class TeleopService {
   void SendStatus(WebSocketHandler::Connection *conn);
 
 #ifdef TELEOP
+
+  void SendVideoStreamCmd(bool start_stop);
+
   void UpdateModemInfo(
       const std::shared_ptr<modules::teleop::network::ModemInfo> &modem_info);
 #endif
@@ -83,7 +86,6 @@ class TeleopService {
   // planning driving actions  and feedback
   std::shared_ptr<cyber::Writer<apollo::planning::PadMessage>>
       pad_message_writer_;
-
 #endif
 
   // Store teleop status
@@ -92,6 +94,7 @@ class TeleopService {
   // Mutex to protect concurrent access to teleop_status_.
   // NOTE: Use boost until we upgrade to std version with rwlock support.
   boost::shared_mutex mutex_;
+
 };
 
 }  // namespace dreamview

--- a/modules/dreamview/backend/teleop/teleop.h
+++ b/modules/dreamview/backend/teleop/teleop.h
@@ -95,7 +95,6 @@ class TeleopService {
   // Mutex to protect concurrent access to teleop_status_.
   // NOTE: Use boost until we upgrade to std version with rwlock support.
   boost::shared_mutex mutex_;
-
 };
 
 }  // namespace dreamview

--- a/modules/dreamview/backend/teleop/teleop.h
+++ b/modules/dreamview/backend/teleop/teleop.h
@@ -45,6 +45,7 @@ class TeleopService {
 
 #ifdef TELEOP
 
+  // send a command to the car daemon to start or stop video encoders.
   void SendVideoStreamCmd(bool start_stop);
 
   void UpdateModemInfo(


### PR DESCRIPTION
This adds logic to start / stop video encoders (2 for now).

The first message to start is sent when the user toggles the switch (setting a "starting" status). During the daemon report callback, if the encoders are not all started, then more messages are sent. 

In this PR, the UI is not "aware" of the "starting" / "stopping" status. A single "stopped, starting, started, stopping" list could replace the 4 booleans value.  One thing to note is that if the video is "starting" and the user presses the switch, the backend will go to "stopping" mode. This behavior might surprise the user.

Next, the same recipe should be applicable to audio and "Pull over" (using the planner msg instead of the daemon report). These should be simpler since there's only one audio encoding node, and one pad planner message to send.
