### PR TITLE
Cyber: stabilize cyber class_loader_test

### DIFF
--- a/cyber/class_loader/BUILD
+++ b/cyber/class_loader/BUILD
@@ -43,6 +43,10 @@ cc_test(
     srcs = [
         "class_loader_test.cc",
     ],
+    data = [
+        "//cyber/class_loader/test:plugin1",
+        "//cyber/class_loader/test:plugin2",
+    ],
     deps = [
         "//cyber",
         "//cyber/class_loader/test:base",

--- a/cyber/class_loader/class_loader_test.cc
+++ b/cyber/class_loader/class_loader_test.cc
@@ -185,5 +185,7 @@ TEST(ClassLoaderTest, util_test) {
 int main(int argc, char** argv) {
   apollo::cyber::Init(argv[0]);
   testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  const int output = RUN_ALL_TESTS();
+  google::protobuf::ShutdownProtobufLibrary();
+  return output;
 }


### PR DESCRIPTION
class_loader_test has a runtime dependency on the plugins.

To reproduce
```
bazel test //cyber/class_loader/class_loader_test
```

The other change is to improve the results from valgrind. Unfortunately, there are still problems from the logger and other parts of cyber.