### PR TITLE
Camera Drivers: update ffmpeg call

### DIFF
--- a/modules/drivers/camera/usb_cam.cc
+++ b/modules/drivers/camera/usb_cam.cc
@@ -117,8 +117,8 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height) {
   avpicture_alloc(reinterpret_cast<AVPicture*>(avframe_rgb_), AV_PIX_FMT_RGB24,
                   image_width, image_height);
 #else
-  avframe_camera_ = avcodec_alloc_frame();
-  avframe_rgb_ = avcodec_alloc_frame();
+  avframe_camera_ = av_frame_alloc();
+  avframe_rgb_ = av_frame_alloc();
 
   avpicture_alloc(reinterpret_cast<AVPicture*>(avframe_rgb_), PIX_FMT_RGB24,
                   image_width, image_height);


### PR DESCRIPTION
This API call is deprecated: http://git.videolan.org/gitweb.cgi/ffmpeg.git/?p=ffmpeg.git;a=blobdiff;f=libavcodec/avcodec.h;h=e1315c2eb4b7c8c58cd4623c2961855376abe8ae;hp=05516bd38e9d9a4e11419d55d5605311022c1fca;hb=b9fb59d2ab05fdfe89d3fb0d7ecbbd91e560f57d;hpb=5b9c3b4505206143d85398c1410949319fa1180f.

This change seems to work locally, but I didn't test it very much.