### PR TITLE
[cyber_monitor] Avoid crash when unfold the a repeated field

### DIFF
--- a/cyber/tools/cyber_monitor/general_message.cc
+++ b/cyber/tools/cyber_monitor/general_message.cc
@@ -36,6 +36,12 @@ std::vector<int> SortProtobufMapByKeys(
   if (0 == size) {
     return output;
   }
+  if (field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+    for (int i = 0; i < size; ++i) {
+      output.emplace_back(i);
+    }
+    return output;
+  }
   const ::google::protobuf::Message& item =
       reflection.GetRepeatedMessage(message, field, 0);
   const ::google::protobuf::FieldDescriptor* item_fd =


### PR DESCRIPTION
When unfold a repeated field in cyber monitor, the cyber monitor will crash if that field is not `CPPTYPE_MESSAGE` type
So fix it by return a continuous index if the field type is not `CPPTYPE_MESSAGE` (Since those field don't have the concept of `key`)