### PR TITLE
Memory leak in prediction module

### DIFF
--- a/modules/prediction/common/feature_output.cc
+++ b/modules/prediction/common/feature_output.cc
@@ -72,8 +72,14 @@ void FeatureOutput::Close() {
 void FeatureOutput::Clear() {
   idx_feature_ = 0;
   idx_learning_ = 0;
+  idx_prediction_result_ = 0;
+  idx_frame_env_ = 0;
+  idx_tuning_ = 0;
   features_.Clear();
   list_data_for_learning_.Clear();
+  list_prediction_result_.Clear();
+  list_frame_env_.Clear();
+  list_data_for_tuning_.Clear();
 }
 
 bool FeatureOutput::Ready() {

--- a/modules/prediction/container/obstacles/obstacles_container.cc
+++ b/modules/prediction/container/obstacles/obstacles_container.cc
@@ -132,6 +132,7 @@ void ObstaclesContainer::Insert(const ::google::protobuf::Message& message) {
     }
     default: {
       // No data dump
+      FeatureOutput::Clear();
       break;
     }
   }


### PR DESCRIPTION
This PR fixes memory leak issue described in #10440 

In offline mode each time after dump containers are cleaned. But in online mode there is no cleanup and the data accumulates infinitely. This leads to an unlimited increase in memory consumption.

So I invoke Clear() in offline mode and add missing cleaning of containers in this method.