### PR TITLE
bugfix: std::map.erase(iter)

### DIFF
--- a/cyber/class_loader/utility/class_loader_utility.cc
+++ b/cyber/class_loader/utility/class_loader_utility.cc
@@ -129,7 +129,7 @@ void DestroyClassFactoryObjectsOfLibrary(
       class_factory_object->RemoveOwnedClassLoader(class_loader);
       // when no anybody owner,delete && erase
       if (!class_factory_object->IsOwnedByAnybody()) {
-        class_factory_map->erase(itr++);
+        itr = class_factory_map->erase(itr);
         delete class_factory_object;
       } else {
         ++itr;


### PR DESCRIPTION
more clear use of iterating over std::map containing erasing operations.