### PR TITLE
Revert "Scripts: May fix CPU drain issue on powerful machines."

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -135,12 +135,6 @@ function generate_build_targets() {
   fi
 }
 
-function jobs_count() {
-  CPU_COUNT=$(nproc)
-  CPU_FACTOR="0.7"
-  python -c "print(int(max(${CPU_COUNT} * ${CPU_FACTOR}, 1)))"
-}
-
 #=================================================
 #              Build functions
 #=================================================
@@ -157,7 +151,7 @@ function build() {
   info "Building on $MACHINE_ARCH..."
 
   MACHINE_ARCH=$(uname -m)
-  JOB_ARG="--jobs=$(jobs_count) --ram_utilization_factor 80"
+  JOB_ARG="--jobs=$(nproc) --ram_utilization_factor 80"
   if [ "$MACHINE_ARCH" == 'aarch64' ]; then
     JOB_ARG="--jobs=3"
   fi
@@ -475,7 +469,7 @@ function gen_coverage() {
 }
 
 function run_test() {
-  JOB_ARG="--jobs=$(jobs_count) --ram_utilization_factor 80"
+  JOB_ARG="--jobs=$(nproc) --ram_utilization_factor 80"
 
   generate_build_targets
   if [ "$USE_GPU" == "1" ]; then


### PR DESCRIPTION
This reverts commit 4f9f1720bad418d677990aef9727a627c579cbf9.

This is not the root cause, while make everyone compile slower. If you met the problem like browser crashing during compiling, a potential reason is that you have a too small swap partition.