### PR TITLE
Build: clean build warnings

### DIFF
--- a/modules/dreamview/backend/handlers/websocket_handler.cc
+++ b/modules/dreamview/backend/handlers/websocket_handler.cc
@@ -126,7 +126,7 @@ bool WebSocketHandler::SendData(Connection *conn, const std::string &data,
 
   // Note that while we are holding the connection lock, the connection won't be
   // closed and removed.
-  int ret;
+  int ret = 0;
   PERF_BLOCK(absl::StrCat(name_, ": Writing ", data.size(),
                           " bytes via websocket took"),
              0.1) {

--- a/modules/localization/ndt/ndt_localization.cc
+++ b/modules/localization/ndt/ndt_localization.cc
@@ -254,7 +254,7 @@ bool NDTLocalization::IsServiceStarted() { return is_service_started_; }
 
 void NDTLocalization::FillLocalizationMsgHeader(
     LocalizationEstimate* localization) {
-  DCHECK_NOTNULL(localization);
+  CHECK_NOTNULL(localization);
 
   auto* header = localization->mutable_header();
   double timestamp = apollo::common::time::Clock::NowInSeconds();

--- a/modules/localization/ndt/ndt_localization.cc
+++ b/modules/localization/ndt/ndt_localization.cc
@@ -254,8 +254,6 @@ bool NDTLocalization::IsServiceStarted() { return is_service_started_; }
 
 void NDTLocalization::FillLocalizationMsgHeader(
     LocalizationEstimate* localization) {
-  CHECK_NOTNULL(localization);
-
   auto* header = localization->mutable_header();
   double timestamp = apollo::common::time::Clock::NowInSeconds();
   header->set_module_name(module_name_);

--- a/modules/localization/rtk/rtk_localization.cc
+++ b/modules/localization/rtk/rtk_localization.cc
@@ -188,8 +188,6 @@ void RTKLocalization::PrepareLocalizationMsg(
 
 void RTKLocalization::FillLocalizationMsgHeader(
     LocalizationEstimate *localization) {
-  CHECK_NOTNULL(localization);
-
   auto *header = localization->mutable_header();
   double timestamp = apollo::common::time::Clock::NowInSeconds();
   header->set_module_name(module_name_);

--- a/modules/localization/rtk/rtk_localization.cc
+++ b/modules/localization/rtk/rtk_localization.cc
@@ -399,7 +399,6 @@ bool RTKLocalization::InterpolateIMU(const CorrectedImu &imu1,
                                      const CorrectedImu &imu2,
                                      const double timestamp_sec,
                                      CorrectedImu *imu_msg) {
-  CHECK_NOTNULL(imu_msg);
   if (!(imu1.header().has_timestamp_sec() &&
         imu2.header().has_timestamp_sec())) {
     AERROR << "imu1 and imu2 has no header or no timestamp_sec in header";

--- a/modules/localization/rtk/rtk_localization.cc
+++ b/modules/localization/rtk/rtk_localization.cc
@@ -188,7 +188,7 @@ void RTKLocalization::PrepareLocalizationMsg(
 
 void RTKLocalization::FillLocalizationMsgHeader(
     LocalizationEstimate *localization) {
-  DCHECK_NOTNULL(localization);
+  CHECK_NOTNULL(localization);
 
   auto *header = localization->mutable_header();
   double timestamp = apollo::common::time::Clock::NowInSeconds();
@@ -401,7 +401,7 @@ bool RTKLocalization::InterpolateIMU(const CorrectedImu &imu1,
                                      const CorrectedImu &imu2,
                                      const double timestamp_sec,
                                      CorrectedImu *imu_msg) {
-  DCHECK_NOTNULL(imu_msg);
+  CHECK_NOTNULL(imu_msg);
   if (!(imu1.header().has_timestamp_sec() &&
         imu2.header().has_timestamp_sec())) {
     AERROR << "imu1 and imu2 has no header or no timestamp_sec in header";

--- a/modules/localization/rtk/rtk_localization_component.cc
+++ b/modules/localization/rtk/rtk_localization_component.cc
@@ -65,20 +65,20 @@ bool RTKLocalizationComponent::InitIO() {
   corrected_imu_listener_ = node_->CreateReader<localization::CorrectedImu>(
       imu_topic_, std::bind(&RTKLocalization::ImuCallback, localization_.get(),
                             std::placeholders::_1));
-  CHECK_NOTNULL(corrected_imu_listener_);
+  CHECK(corrected_imu_listener_);
 
   gps_status_listener_ = node_->CreateReader<drivers::gnss::InsStat>(
       gps_status_topic_, std::bind(&RTKLocalization::GpsStatusCallback,
                                    localization_.get(), std::placeholders::_1));
-  CHECK_NOTNULL(gps_status_listener_);
+  CHECK(gps_status_listener_);
 
   localization_talker_ =
       node_->CreateWriter<LocalizationEstimate>(localization_topic_);
-  CHECK_NOTNULL(localization_talker_);
+  CHECK(localization_talker_);
 
   localization_status_talker_ =
       node_->CreateWriter<LocalizationStatus>(localization_status_topic_);
-  CHECK_NOTNULL(localization_status_talker_);
+  CHECK(localization_status_talker_);
   return true;
 }
 

--- a/modules/localization/rtk/rtk_localization_component.cc
+++ b/modules/localization/rtk/rtk_localization_component.cc
@@ -65,20 +65,20 @@ bool RTKLocalizationComponent::InitIO() {
   corrected_imu_listener_ = node_->CreateReader<localization::CorrectedImu>(
       imu_topic_, std::bind(&RTKLocalization::ImuCallback, localization_.get(),
                             std::placeholders::_1));
-  DCHECK_NOTNULL(corrected_imu_listener_);
+  CHECK_NOTNULL(corrected_imu_listener_);
 
   gps_status_listener_ = node_->CreateReader<drivers::gnss::InsStat>(
       gps_status_topic_, std::bind(&RTKLocalization::GpsStatusCallback,
                                    localization_.get(), std::placeholders::_1));
-  DCHECK_NOTNULL(gps_status_listener_);
+  CHECK_NOTNULL(gps_status_listener_);
 
   localization_talker_ =
       node_->CreateWriter<LocalizationEstimate>(localization_topic_);
-  DCHECK_NOTNULL(localization_talker_);
+  CHECK_NOTNULL(localization_talker_);
 
   localization_status_talker_ =
       node_->CreateWriter<LocalizationStatus>(localization_status_topic_);
-  DCHECK_NOTNULL(localization_status_talker_);
+  CHECK_NOTNULL(localization_status_talker_);
   return true;
 }
 

--- a/modules/planning/common/path/path_data.cc
+++ b/modules/planning/common/path/path_data.cc
@@ -119,8 +119,7 @@ common::PathPoint PathData::GetPathPointWithPathS(const double s) const {
 
 bool PathData::GetPathPointWithRefS(const double ref_s,
                                     common::PathPoint *const path_point) const {
-  CHECK_NOTNULL(reference_line_);
-  CHECK_NOTNULL(path_point);
+  CHECK(reference_line_);
   DCHECK_EQ(discretized_path_.size(), frenet_path_.size());
   if (ref_s < 0) {
     AERROR << "ref_s[" << ref_s << "] should be > 0";
@@ -177,7 +176,6 @@ std::string PathData::DebugString() const {
 
 bool PathData::SLToXY(const FrenetFramePath &frenet_path,
                       DiscretizedPath *const discretized_path) {
-  CHECK_NOTNULL(discretized_path);
   std::vector<common::PathPoint> path_points;
   for (const common::FrenetFramePoint &frenet_point : frenet_path) {
     const common::SLPoint sl_point =
@@ -216,8 +214,7 @@ bool PathData::SLToXY(const FrenetFramePath &frenet_path,
 
 bool PathData::XYToSL(const DiscretizedPath &discretized_path,
                       FrenetFramePath *const frenet_path) {
-  CHECK_NOTNULL(frenet_path);
-  CHECK_NOTNULL(reference_line_);
+  CHECK(reference_line_);
   std::vector<common::FrenetFramePoint> frenet_frame_points;
   const double max_len = reference_line_->Length();
   for (const auto &path_point : discretized_path) {
@@ -244,7 +241,7 @@ bool PathData::XYToSL(const DiscretizedPath &discretized_path,
 }
 
 bool PathData::LeftTrimWithRefS(const common::FrenetFramePoint &frenet_point) {
-  CHECK_NOTNULL(reference_line_);
+  CHECK(reference_line_);
   std::vector<common::FrenetFramePoint> frenet_frame_points;
   frenet_frame_points.emplace_back(frenet_point);
 

--- a/modules/planning/common/path/path_data.cc
+++ b/modules/planning/common/path/path_data.cc
@@ -119,8 +119,8 @@ common::PathPoint PathData::GetPathPointWithPathS(const double s) const {
 
 bool PathData::GetPathPointWithRefS(const double ref_s,
                                     common::PathPoint *const path_point) const {
-  DCHECK_NOTNULL(reference_line_);
-  DCHECK_NOTNULL(path_point);
+  CHECK_NOTNULL(reference_line_);
+  CHECK_NOTNULL(path_point);
   DCHECK_EQ(discretized_path_.size(), frenet_path_.size());
   if (ref_s < 0) {
     AERROR << "ref_s[" << ref_s << "] should be > 0";
@@ -177,7 +177,7 @@ std::string PathData::DebugString() const {
 
 bool PathData::SLToXY(const FrenetFramePath &frenet_path,
                       DiscretizedPath *const discretized_path) {
-  DCHECK_NOTNULL(discretized_path);
+  CHECK_NOTNULL(discretized_path);
   std::vector<common::PathPoint> path_points;
   for (const common::FrenetFramePoint &frenet_point : frenet_path) {
     const common::SLPoint sl_point =

--- a/modules/planning/navi/decider/navi_path_decider_test.cc
+++ b/modules/planning/navi/decider/navi_path_decider_test.cc
@@ -51,14 +51,11 @@ class NaviPathDeciderTest : public ::testing::Test {
   }
 
   static void InitPlannigConfig(PlanningConfig* const plannig_config) {
-    CHECK_NOTNULL(plannig_config);
     auto* navi_planner_config =
         plannig_config->mutable_navigation_planning_config()
             ->mutable_planner_navi_config();
-    CHECK_NOTNULL(navi_planner_config);
     auto* navi_path_decider_config =
         navi_planner_config->mutable_navi_path_decider_config();
-    CHECK_NOTNULL(navi_path_decider_config);
     navi_path_decider_config->set_min_path_length(5.0);
     navi_path_decider_config->set_min_look_forward_time(2.0);
     navi_path_decider_config->set_max_keep_lane_distance(0.4);
@@ -69,9 +66,7 @@ class NaviPathDeciderTest : public ::testing::Test {
     navi_path_decider_config->clear_move_dest_lane_config_talbe();
     auto* move_dest_lane_cfg_table =
         navi_path_decider_config->mutable_move_dest_lane_config_talbe();
-    CHECK_NOTNULL(move_dest_lane_cfg_table);
     auto* move_shift_config = move_dest_lane_cfg_table->add_lateral_shift();
-    CHECK_NOTNULL(move_shift_config);
     move_shift_config->set_max_speed(34);
     move_shift_config->set_max_move_dest_lane_shift_y(0.45);
   }

--- a/modules/planning/navi/decider/navi_path_decider_test.cc
+++ b/modules/planning/navi/decider/navi_path_decider_test.cc
@@ -42,7 +42,6 @@ class NaviPathDeciderTest : public ::testing::Test {
   static void GeneratePathData(
       double s, double init_y, double kappa,
       std::vector<common::PathPoint>* const path_points) {
-    CHECK_NOTNULL(path_points);
     for (double x = 0.0, y = init_y; x < s; ++x) {
       path_points->clear();
       path_points->push_back(

--- a/modules/planning/navi/decider/navi_path_decider_test.cc
+++ b/modules/planning/navi/decider/navi_path_decider_test.cc
@@ -42,7 +42,7 @@ class NaviPathDeciderTest : public ::testing::Test {
   static void GeneratePathData(
       double s, double init_y, double kappa,
       std::vector<common::PathPoint>* const path_points) {
-    DCHECK_NOTNULL(path_points);
+    CHECK_NOTNULL(path_points);
     for (double x = 0.0, y = init_y; x < s; ++x) {
       path_points->clear();
       path_points->push_back(
@@ -51,14 +51,14 @@ class NaviPathDeciderTest : public ::testing::Test {
   }
 
   static void InitPlannigConfig(PlanningConfig* const plannig_config) {
-    DCHECK_NOTNULL(plannig_config);
+    CHECK_NOTNULL(plannig_config);
     auto* navi_planner_config =
         plannig_config->mutable_navigation_planning_config()
             ->mutable_planner_navi_config();
-    DCHECK_NOTNULL(navi_planner_config);
+    CHECK_NOTNULL(navi_planner_config);
     auto* navi_path_decider_config =
         navi_planner_config->mutable_navi_path_decider_config();
-    DCHECK_NOTNULL(navi_path_decider_config);
+    CHECK_NOTNULL(navi_path_decider_config);
     navi_path_decider_config->set_min_path_length(5.0);
     navi_path_decider_config->set_min_look_forward_time(2.0);
     navi_path_decider_config->set_max_keep_lane_distance(0.4);
@@ -69,9 +69,9 @@ class NaviPathDeciderTest : public ::testing::Test {
     navi_path_decider_config->clear_move_dest_lane_config_talbe();
     auto* move_dest_lane_cfg_table =
         navi_path_decider_config->mutable_move_dest_lane_config_talbe();
-    DCHECK_NOTNULL(move_dest_lane_cfg_table);
+    CHECK_NOTNULL(move_dest_lane_cfg_table);
     auto* move_shift_config = move_dest_lane_cfg_table->add_lateral_shift();
-    DCHECK_NOTNULL(move_shift_config);
+    CHECK_NOTNULL(move_shift_config);
     move_shift_config->set_max_speed(34);
     move_shift_config->set_max_move_dest_lane_shift_y(0.45);
   }
@@ -162,8 +162,8 @@ TEST_F(NaviPathDeciderTest, KeepLane) {
   LocalView local_view;
   navi_path_decider.frame_ =
       new Frame(1, local_view, plan_start_point, vehicle_state, nullptr);
-  DCHECK_NOTNULL(navi_path_decider.reference_line_info_);
-  DCHECK_NOTNULL(navi_path_decider.frame_);
+  CHECK_NOTNULL(navi_path_decider.reference_line_info_);
+  CHECK_NOTNULL(navi_path_decider.frame_);
   GeneratePathData(kMaxS, 0.19, 0.03, &path_points);
   dest_y = path_points[0].y();
   expect_y = path_points[0].y();

--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -398,7 +398,6 @@ std::string NaviPlanning::GetCurrentLaneId() {
 
 void NaviPlanning::GetLeftNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  CHECK_NOTNULL(lane_info_group);
   auto& ref_line_info_group = *frame_->mutable_reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {
@@ -426,7 +425,6 @@ void NaviPlanning::GetLeftNeighborLanesInfo(
 
 void NaviPlanning::GetRightNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  CHECK_NOTNULL(lane_info_group);
   auto& ref_line_info_group = *frame_->mutable_reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {
@@ -473,7 +471,6 @@ Status NaviPlanning::Plan(
     const double current_time_stamp,
     const std::vector<TrajectoryPoint>& stitching_trajectory,
     ADCTrajectory* const trajectory_pb) {
-  CHECK_NOTNULL(trajectory_pb);
   auto* ptr_debug = trajectory_pb->mutable_debug();
   if (FLAGS_enable_record_debug) {
     ptr_debug->mutable_planning_data()->mutable_init_point()->CopyFrom(

--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -398,7 +398,7 @@ std::string NaviPlanning::GetCurrentLaneId() {
 
 void NaviPlanning::GetLeftNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  DCHECK_NOTNULL(lane_info_group);
+  CHECK_NOTNULL(lane_info_group);
   auto& ref_line_info_group = *frame_->mutable_reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {
@@ -426,7 +426,7 @@ void NaviPlanning::GetLeftNeighborLanesInfo(
 
 void NaviPlanning::GetRightNeighborLanesInfo(
     std::vector<std::pair<std::string, double>>* const lane_info_group) {
-  DCHECK_NOTNULL(lane_info_group);
+  CHECK_NOTNULL(lane_info_group);
   auto& ref_line_info_group = *frame_->mutable_reference_line_info();
   const auto& vehicle_state = frame_->vehicle_state();
   for (auto& ref_line_info : ref_line_info_group) {

--- a/modules/planning/planner/public_road/public_road_planner.cc
+++ b/modules/planning/planner/public_road/public_road_planner.cc
@@ -33,7 +33,7 @@ Status PublicRoadPlanner::Init(const PlanningConfig& config) {
 Status PublicRoadPlanner::Plan(const TrajectoryPoint& planning_start_point,
                                Frame* frame,
                                ADCTrajectory* ptr_computed_trajectory) {
-  DCHECK_NOTNULL(frame);
+  CHECK_NOTNULL(frame);
   scenario_manager_.Update(planning_start_point, *frame);
   scenario_ = scenario_manager_.mutable_scenario();
   auto result = scenario_->Process(planning_start_point, frame);

--- a/modules/planning/planner/public_road/public_road_planner.cc
+++ b/modules/planning/planner/public_road/public_road_planner.cc
@@ -33,7 +33,6 @@ Status PublicRoadPlanner::Init(const PlanningConfig& config) {
 Status PublicRoadPlanner::Plan(const TrajectoryPoint& planning_start_point,
                                Frame* frame,
                                ADCTrajectory* ptr_computed_trajectory) {
-  CHECK_NOTNULL(frame);
   scenario_manager_.Update(planning_start_point, *frame);
   scenario_ = scenario_manager_.mutable_scenario();
   auto result = scenario_->Process(planning_start_point, frame);

--- a/modules/planning/proto/planning_internal.proto
+++ b/modules/planning/proto/planning_internal.proto
@@ -12,7 +12,6 @@ import "modules/map/relative_map/proto/navigation.proto";
 import "modules/routing/proto/routing.proto";
 import "modules/perception/proto/traffic_light_detection.proto";
 import "modules/planning/proto/sl_boundary.proto";
-import "modules/planning/proto/st_drivable_boundary.proto";
 import "modules/planning/proto/decision.proto";
 import "modules/planning/proto/planning_config.proto";
 

--- a/modules/planning/proto/planning_status.proto
+++ b/modules/planning/proto/planning_status.proto
@@ -3,7 +3,6 @@ syntax = "proto2";
 package apollo.planning;
 
 import "modules/common/proto/geometry.proto";
-import "modules/common/proto/pnc_point.proto";
 import "modules/planning/proto/planning_config.proto";
 import "modules/routing/proto/routing.proto";
 

--- a/modules/planning/proto/st_drivable_boundary.proto
+++ b/modules/planning/proto/st_drivable_boundary.proto
@@ -2,8 +2,6 @@ syntax = "proto2";
 
 package apollo.planning;
 
-import "modules/common/proto/pnc_point.proto";
-
 message STDrivableBoundaryInstance {
   optional double t = 1;
   optional double s_lower = 2;

--- a/modules/planning/reference_line/reference_line.cc
+++ b/modules/planning/reference_line/reference_line.cc
@@ -392,7 +392,7 @@ bool ReferenceLine::SLToXY(const SLPoint& sl_point,
 
 bool ReferenceLine::XYToSL(const common::math::Vec2d& xy_point,
                            SLPoint* const sl_point) const {
-  DCHECK_NOTNULL(sl_point);
+  CHECK_NOTNULL(sl_point);
   double s = 0.0;
   double l = 0.0;
   if (!map_path_.GetProjection(xy_point, &s, &l)) {

--- a/modules/planning/reference_line/reference_line.cc
+++ b/modules/planning/reference_line/reference_line.cc
@@ -377,7 +377,6 @@ ReferencePoint ReferenceLine::GetReferencePoint(const double x,
 
 bool ReferenceLine::SLToXY(const SLPoint& sl_point,
                            common::math::Vec2d* const xy_point) const {
-  CHECK_NOTNULL(xy_point);
   if (map_path_.num_points() < 2) {
     AERROR << "The reference line has too few points.";
     return false;
@@ -392,7 +391,6 @@ bool ReferenceLine::SLToXY(const SLPoint& sl_point,
 
 bool ReferenceLine::XYToSL(const common::math::Vec2d& xy_point,
                            SLPoint* const sl_point) const {
-  CHECK_NOTNULL(sl_point);
   double s = 0.0;
   double l = 0.0;
   if (!map_path_.GetProjection(xy_point, &s, &l)) {

--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -1787,7 +1787,8 @@ bool PathBoundsDecider::CheckLaneBoundaryType(
   }
 
   const auto waypoint = ref_point.lane_waypoints().front();
-  hdmap::LaneBoundaryType::Type lane_boundary_type;
+  hdmap::LaneBoundaryType::Type lane_boundary_type =
+      hdmap::LaneBoundaryType::UNKNOWN;
   if (lane_borrow_info == LaneBorrowInfo::LEFT_BORROW) {
     lane_boundary_type = hdmap::LeftBoundaryType(waypoint);
   } else if (lane_borrow_info == LaneBorrowInfo::RIGHT_BORROW) {

--- a/modules/planning/tasks/deciders/path_decider/path_decider.cc
+++ b/modules/planning/tasks/deciders/path_decider/path_decider.cc
@@ -66,7 +66,7 @@ Status PathDecider::Process(const ReferenceLineInfo *reference_line_info,
 bool PathDecider::MakeObjectDecision(const PathData &path_data,
                                      const std::string &blocking_obstacle_id,
                                      PathDecision *const path_decision) {
-  DCHECK_NOTNULL(path_decision);
+  CHECK_NOTNULL(path_decision);
   if (!MakeStaticObstacleDecision(path_data, blocking_obstacle_id,
                                   path_decision)) {
     AERROR << "Failed to make decisions for static obstacles";
@@ -82,7 +82,7 @@ bool PathDecider::MakeStaticObstacleDecision(
     const PathData &path_data, const std::string &blocking_obstacle_id,
     PathDecision *const path_decision) {
   // Sanity checks and get important values.
-  DCHECK_NOTNULL(path_decision);
+  CHECK_NOTNULL(path_decision);
   const auto &frenet_path = path_data.frenet_frame_path();
   if (frenet_path.empty()) {
     AERROR << "Path is empty.";

--- a/modules/planning/tasks/deciders/path_decider/path_decider.cc
+++ b/modules/planning/tasks/deciders/path_decider/path_decider.cc
@@ -45,8 +45,6 @@ Status PathDecider::Execute(Frame *frame,
 Status PathDecider::Process(const ReferenceLineInfo *reference_line_info,
                             const PathData &path_data,
                             PathDecision *const path_decision) {
-  CHECK_NOTNULL(path_decision);
-
   // skip path_decider if reused path
   if (FLAGS_enable_skip_path_tasks && reference_line_info->path_reusable()) {
     return Status::OK();
@@ -66,7 +64,6 @@ Status PathDecider::Process(const ReferenceLineInfo *reference_line_info,
 bool PathDecider::MakeObjectDecision(const PathData &path_data,
                                      const std::string &blocking_obstacle_id,
                                      PathDecision *const path_decision) {
-  CHECK_NOTNULL(path_decision);
   if (!MakeStaticObstacleDecision(path_data, blocking_obstacle_id,
                                   path_decision)) {
     AERROR << "Failed to make decisions for static obstacles";
@@ -82,7 +79,7 @@ bool PathDecider::MakeStaticObstacleDecision(
     const PathData &path_data, const std::string &blocking_obstacle_id,
     PathDecision *const path_decision) {
   // Sanity checks and get important values.
-  CHECK_NOTNULL(path_decision);
+  CHECK(path_decision);
   const auto &frenet_path = path_data.frenet_frame_path();
   if (frenet_path.empty()) {
     AERROR << "Path is empty.";

--- a/modules/planning/tasks/deciders/path_lane_borrow_decider/path_lane_borrow_decider.cc
+++ b/modules/planning/tasks/deciders/path_lane_borrow_decider/path_lane_borrow_decider.cc
@@ -282,7 +282,8 @@ void PathLaneBorrowDecider::CheckLaneBorrow(
     }
 
     const auto waypoint = ref_point.lane_waypoints().front();
-    hdmap::LaneBoundaryType::Type lane_boundary_type;
+    hdmap::LaneBoundaryType::Type lane_boundary_type =
+        hdmap::LaneBoundaryType::UNKNOWN;
 
     if (*left_neighbor_lane_borrowable) {
       lane_boundary_type = hdmap::LeftBoundaryType(waypoint);

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
@@ -191,8 +191,8 @@ bool STBoundaryMapper::GetOverlapBoundaryPoints(
     std::vector<STPoint>* upper_points,
     std::vector<STPoint>* lower_points) const {
   // Sanity checks.
-  DCHECK_NOTNULL(upper_points);
-  DCHECK_NOTNULL(lower_points);
+  CHECK_NOTNULL(upper_points);
+  CHECK_NOTNULL(lower_points);
   DCHECK(upper_points->empty());
   DCHECK(lower_points->empty());
   DCHECK_GT(path_points.size(), 0);

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
@@ -191,8 +191,6 @@ bool STBoundaryMapper::GetOverlapBoundaryPoints(
     std::vector<STPoint>* upper_points,
     std::vector<STPoint>* lower_points) const {
   // Sanity checks.
-  CHECK_NOTNULL(upper_points);
-  CHECK_NOTNULL(lower_points);
   DCHECK(upper_points->empty());
   DCHECK(lower_points->empty());
   DCHECK_GT(path_points.size(), 0);

--- a/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
+++ b/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
@@ -337,8 +337,6 @@ void SpeedDecider::AppendIgnoreDecision(Obstacle* obstacle) const {
 bool SpeedDecider::CreateStopDecision(const Obstacle& obstacle,
                                       ObjectDecisionType* const stop_decision,
                                       double stop_distance) const {
-  CHECK_NOTNULL(stop_decision);
-
   const auto& boundary = obstacle.path_st_boundary();
 
   // TODO(all): this is a bug! Cannot mix reference s and path s!
@@ -379,8 +377,6 @@ bool SpeedDecider::CreateStopDecision(const Obstacle& obstacle,
 
 bool SpeedDecider::CreateFollowDecision(
     const Obstacle& obstacle, ObjectDecisionType* const follow_decision) const {
-  CHECK_NOTNULL(follow_decision);
-
   const double follow_speed = init_point_.v();
   const double follow_distance_s =
       -StGapEstimator::EstimateProperFollowingGap(follow_speed);
@@ -415,8 +411,6 @@ bool SpeedDecider::CreateFollowDecision(
 
 bool SpeedDecider::CreateYieldDecision(
     const Obstacle& obstacle, ObjectDecisionType* const yield_decision) const {
-  CHECK_NOTNULL(yield_decision);
-
   PerceptionObstacle::Type obstacle_type = obstacle.Perception().type();
   double yield_distance = StGapEstimator::EstimateProperYieldingGap();
 
@@ -452,8 +446,6 @@ bool SpeedDecider::CreateYieldDecision(
 bool SpeedDecider::CreateOvertakeDecision(
     const Obstacle& obstacle,
     ObjectDecisionType* const overtake_decision) const {
-  CHECK_NOTNULL(overtake_decision);
-
   const auto& velocity = obstacle.Perception().velocity();
   const double obstacle_speed =
       common::math::Vec2d::CreateUnitVec2d(init_point_.path_point().theta())

--- a/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
+++ b/modules/planning/tasks/deciders/speed_decider/speed_decider.cc
@@ -337,7 +337,7 @@ void SpeedDecider::AppendIgnoreDecision(Obstacle* obstacle) const {
 bool SpeedDecider::CreateStopDecision(const Obstacle& obstacle,
                                       ObjectDecisionType* const stop_decision,
                                       double stop_distance) const {
-  DCHECK_NOTNULL(stop_decision);
+  CHECK_NOTNULL(stop_decision);
 
   const auto& boundary = obstacle.path_st_boundary();
 
@@ -379,7 +379,7 @@ bool SpeedDecider::CreateStopDecision(const Obstacle& obstacle,
 
 bool SpeedDecider::CreateFollowDecision(
     const Obstacle& obstacle, ObjectDecisionType* const follow_decision) const {
-  DCHECK_NOTNULL(follow_decision);
+  CHECK_NOTNULL(follow_decision);
 
   const double follow_speed = init_point_.v();
   const double follow_distance_s =
@@ -415,7 +415,7 @@ bool SpeedDecider::CreateFollowDecision(
 
 bool SpeedDecider::CreateYieldDecision(
     const Obstacle& obstacle, ObjectDecisionType* const yield_decision) const {
-  DCHECK_NOTNULL(yield_decision);
+  CHECK_NOTNULL(yield_decision);
 
   PerceptionObstacle::Type obstacle_type = obstacle.Perception().type();
   double yield_distance = StGapEstimator::EstimateProperYieldingGap();
@@ -452,7 +452,7 @@ bool SpeedDecider::CreateYieldDecision(
 bool SpeedDecider::CreateOvertakeDecision(
     const Obstacle& obstacle,
     ObjectDecisionType* const overtake_decision) const {
-  DCHECK_NOTNULL(overtake_decision);
+  CHECK_NOTNULL(overtake_decision);
 
   const auto& velocity = obstacle.Perception().velocity();
   const double obstacle_speed =

--- a/modules/planning/tasks/deciders/st_bounds_decider/st_obstacles_processor.cc
+++ b/modules/planning/tasks/deciders/st_bounds_decider/st_obstacles_processor.cc
@@ -177,7 +177,7 @@ Status STObstaclesProcessor::MapObstaclesToSTBoundaries(
     } else {
       // Obstacle is dynamic.
       if (boundary.bottom_left_point().s() - adc_path_init_s_ <
-          kSIgnoreThreshold &&
+              kSIgnoreThreshold &&
           boundary.bottom_left_point().t() > kTIgnoreThreshold) {
         // Ignore obstacles that are behind.
         // TODO(jiacheng): don't ignore if ADC is in dangerous segments.

--- a/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
+++ b/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
@@ -199,10 +199,10 @@ bool DpRoadGraph::GenerateMinCostPath(
 }
 
 void DpRoadGraph::UpdateNode(const std::shared_ptr<RoadGraphMessage> &msg) {
-  DCHECK_NOTNULL(msg);
-  DCHECK_NOTNULL(msg->trajectory_cost);
-  DCHECK_NOTNULL(msg->front);
-  DCHECK_NOTNULL(msg->cur_node);
+  CHECK_NOTNULL(msg);
+  CHECK_NOTNULL(msg->trajectory_cost);
+  CHECK_NOTNULL(msg->front);
+  CHECK_NOTNULL(msg->cur_node);
   for (const auto &prev_dp_node : msg->prev_nodes) {
     const auto &prev_sl_point = prev_dp_node.sl_point;
     const auto &cur_point = msg->cur_node->sl_point;


### PR DESCRIPTION
for DCHEKC_NOTNULL WARNING, use CHECK_NOTNULL don't need to change logic for now:
// You may see warnings in release mode if you don't use the return
// value of DCHECK_NOTNULL. Please just use DCHECK for such cases.