### PR TITLE
canbus: added option to select socket CAN interface (native, virtual or slcan)

### DIFF
--- a/modules/canbus/conf/canbus_conf.pb.txt
+++ b/modules/canbus/conf/canbus_conf.pb.txt
@@ -8,6 +8,7 @@ can_card_parameter {
   brand: ESD_CAN
   type: PCI_CARD
   channel_id: CHANNEL_ID_ZERO
+  interface: NATIVE
 }
 
 enable_debug_mode: false

--- a/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
+++ b/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
@@ -76,9 +76,9 @@ ErrorCode SocketCanClientRaw::Start() {
 
   // init config and state
   int ret;
-  
+
   // 1. for non virtual busses, set receive message_id filter, ie white list
-  if(interface_ != CANCardParameter::VIRTUAL) {
+  if (interface_ != CANCardParameter::VIRTUAL) {
     struct can_filter filter[2048];
     for (int i = 0; i < 2048; ++i) {
       filter[i].can_id = 0x000 + i;
@@ -107,10 +107,10 @@ ErrorCode SocketCanClientRaw::Start() {
     interface_prefix = "vcan";
   } else if (interface_ == CANCardParameter::SLCAN) {
     interface_prefix = "slcan";
-  } else { //default: CANCardParameter::NATIVE
+  } else {  // default: CANCardParameter::NATIVE
     interface_prefix = "can";
   }
-  
+
   const std::string can_name = absl::StrCat(interface_prefix, port_);
   std::strncpy(ifr.ifr_name, can_name.c_str(), IFNAMSIZ);
   if (ioctl(dev_handler_, SIOCGIFINDEX, &ifr) < 0) {

--- a/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
+++ b/modules/drivers/canbus/can_client/socket/socket_can_client_raw.cc
@@ -40,6 +40,7 @@ bool SocketCanClientRaw::Init(const CANCardParameter &parameter) {
   }
 
   port_ = parameter.channel_id();
+  interface_ = parameter.interface();
   return true;
 }
 
@@ -74,18 +75,22 @@ ErrorCode SocketCanClientRaw::Start() {
   }
 
   // init config and state
-  // 1. set receive message_id filter, ie white list
-  struct can_filter filter[2048];
-  for (int i = 0; i < 2048; ++i) {
-    filter[i].can_id = 0x000 + i;
-    filter[i].can_mask = CAN_SFF_MASK;
-  }
+  int ret;
+  
+  // 1. for non virtual busses, set receive message_id filter, ie white list
+  if(interface_ != CANCardParameter::VIRTUAL) {
+    struct can_filter filter[2048];
+    for (int i = 0; i < 2048; ++i) {
+      filter[i].can_id = 0x000 + i;
+      filter[i].can_mask = CAN_SFF_MASK;
+    }
 
-  int ret = setsockopt(dev_handler_, SOL_CAN_RAW, CAN_RAW_FILTER, &filter,
-                       sizeof(filter));
-  if (ret < 0) {
-    AERROR << "add receive msg id filter error code: " << ret;
-    return ErrorCode::CAN_CLIENT_ERROR_BASE;
+    ret = setsockopt(dev_handler_, SOL_CAN_RAW, CAN_RAW_FILTER, &filter,
+                         sizeof(filter));
+    if (ret < 0) {
+      AERROR << "add receive msg id filter error code: " << ret;
+      return ErrorCode::CAN_CLIENT_ERROR_BASE;
+    }
   }
 
   // 2. enable reception of can frames.
@@ -97,7 +102,16 @@ ErrorCode SocketCanClientRaw::Start() {
     return ErrorCode::CAN_CLIENT_ERROR_BASE;
   }
 
-  const std::string can_name = absl::StrCat("can", port_);
+  std::string interface_prefix;
+  if (interface_ == CANCardParameter::VIRTUAL) {
+    interface_prefix = "vcan";
+  } else if (interface_ == CANCardParameter::SLCAN) {
+    interface_prefix = "slcan";
+  } else { //default: CANCardParameter::NATIVE
+    interface_prefix = "can";
+  }
+  
+  const std::string can_name = absl::StrCat(interface_prefix, port_);
   std::strncpy(ifr.ifr_name, can_name.c_str(), IFNAMSIZ);
   if (ioctl(dev_handler_, SIOCGIFINDEX, &ifr) < 0) {
     AERROR << "ioctl error";

--- a/modules/drivers/canbus/can_client/socket/socket_can_client_raw.h
+++ b/modules/drivers/canbus/can_client/socket/socket_can_client_raw.h
@@ -112,6 +112,7 @@ class SocketCanClientRaw : public CanClient {
  private:
   int dev_handler_ = 0;
   CANCardParameter::CANChannelId port_;
+  CANCardParameter::CANInterface interface_;
   can_frame send_frames_[MAX_CAN_SEND_FRAME_LEN];
   can_frame recv_frames_[MAX_CAN_RECV_FRAME_LEN];
 };

--- a/modules/drivers/canbus/proto/can_card_parameter.proto
+++ b/modules/drivers/canbus/proto/can_card_parameter.proto
@@ -22,7 +22,14 @@ message CANCardParameter {
     CHANNEL_ID_THREE = 3;
   }
 
+  enum CANInterface {
+    NATIVE = 0;
+    VIRTUAL = 1;
+    SLCAN = 2;
+  }
+
   optional CANCardBrand brand = 1;
   optional CANCardType type = 2;
   optional CANChannelId channel_id = 3;
+  optional CANInterface interface = 4;
 }


### PR DESCRIPTION
Added support for virtual and serial CAN interfaces when using the socket CAN client. Tested with our virtual CAN bus based drive by wire simulator. 

closes #10546 