### PR TITLE
Cyber: io_poller regularized test results

### DIFF
--- a/cyber/io/poller.cc
+++ b/cyber/io/poller.cc
@@ -60,7 +60,7 @@ bool Poller::Register(const PollRequest& req) {
     return false;
   }
 
-  PollCtrlParam ctrl_param;
+  PollCtrlParam ctrl_param{};
   ctrl_param.fd = req.fd;
   ctrl_param.event.data.fd = req.fd;
   ctrl_param.event.events = req.events;
@@ -142,7 +142,7 @@ bool Poller::Init() {
   };
   requests_[request->fd] = request;
 
-  PollCtrlParam ctrl_param;
+  PollCtrlParam ctrl_param{};
   ctrl_param.operation = EPOLL_CTL_ADD;
   ctrl_param.fd = pipe_fd_[0];
   ctrl_param.event.data.fd = pipe_fd_[0];

--- a/cyber/io/poller_test.cc
+++ b/cyber/io/poller_test.cc
@@ -51,7 +51,7 @@ TEST(PollerTest, operation) {
   PollResponse response(123);
   request.callback = [&response](const PollResponse& rsp) { response = rsp; };
   EXPECT_TRUE(poller->Register(request));
-  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   EXPECT_EQ(response.events, 0);
 
   // timeout_ms is 50


### PR DESCRIPTION
I got a few random errors from this test. The valgrind uninitialized values passed to system call may be false positives, but I figure it cannot hurt. The timeout seems to make the results more stable.

Test
```
bazel test -c dbg //cyber/io:poller_test
sudo apt update && sudo apt install valgrind
valgrind bazel-bin/cyber/io/poller_test
```