### PR TITLE
async_logger bug fixes

### DIFF
--- a/cyber/init.cc
+++ b/cyber/init.cc
@@ -69,9 +69,7 @@ void InitLogger(const char* binary_name) {
 }
 
 void StopLogger() {
-  if (async_logger != nullptr) {
-    async_logger->Stop();
-  }
+  delete async_logger;
 }
 
 }  // namespace

--- a/cyber/logger/async_logger.cc
+++ b/cyber/logger/async_logger.cc
@@ -22,15 +22,13 @@
 #include <unordered_map>
 
 #include "cyber/base/macros.h"
-#include "cyber/logger/log_file_object.h"
 #include "cyber/logger/logger_util.h"
 
 namespace apollo {
 namespace cyber {
 namespace logger {
 
-static std::unordered_map<std::string, LogFileObject*> moduleLoggerMap;
-static std::unordered_map<char, int> log_level_map = {
+static const std::unordered_map<char, int> log_level_map = {
     {'F', 3}, {'E', 2}, {'W', 1}, {'I', 0}};
 
 AsyncLogger::AsyncLogger(google::base::Logger* wrapped) : wrapped_(wrapped) {
@@ -38,12 +36,7 @@ AsyncLogger::AsyncLogger(google::base::Logger* wrapped) : wrapped_(wrapped) {
   flushing_buf_.reset(new std::deque<Msg>());
 }
 
-AsyncLogger::~AsyncLogger() {
-  for (auto& logger : moduleLoggerMap) {
-    delete logger.second;
-  }
-  moduleLoggerMap.clear();
-}
+AsyncLogger::~AsyncLogger() { Stop(); }
 
 void AsyncLogger::Start() {
   CHECK_EQ(state_.load(std::memory_order_acquire), INITTED);
@@ -53,7 +46,6 @@ void AsyncLogger::Start() {
 }
 
 void AsyncLogger::Stop() {
-  CHECK_EQ(state_.load(std::memory_order_acquire), RUNNING);
   state_.store(STOPPED, std::memory_order_release);
   if (log_thread_.joinable()) {
     log_thread_.join();
@@ -67,22 +59,27 @@ void AsyncLogger::Stop() {
 
 void AsyncLogger::Write(bool force_flush, time_t timestamp, const char* message,
                         int message_len) {
-  (void)force_flush;
   if (cyber_unlikely(state_.load(std::memory_order_acquire) != RUNNING)) {
     // std::cout << "Async Logger not running!" << std::endl;
     return;
   }
-  auto msg_str = std::string(message, message_len);
-  while (flag_.test_and_set(std::memory_order_acquire)) {
-    cpu_relax();
+  if (message_len > 0) {
+    auto msg_str = std::string(message, message_len);
+    while (flag_.test_and_set(std::memory_order_acquire)) {
+      cpu_relax();
+    }
+    active_buf_->emplace_back(timestamp, std::move(msg_str),
+                              log_level_map.at(message[0]));
+    flag_.clear(std::memory_order_release);
   }
-  active_buf_->emplace_back(timestamp, std::move(msg_str),
-                            log_level_map[message[0]]);
-  flag_.clear(std::memory_order_release);
+
+  if (force_flush && timestamp == 0 && message && message_len == 0) {
+    Stop();
+  }
 }
 
 void AsyncLogger::Flush() {
-  for (auto& module_logger : moduleLoggerMap) {
+  for (auto& module_logger : module_logger_map_) {
     module_logger.second->Flush();
   }
 }
@@ -109,23 +106,19 @@ void AsyncLogger::FlushBuffer(const std::unique_ptr<std::deque<Msg>>& buffer) {
     auto& msg = buffer->front();
     FindModuleName(&(msg.message), &module_name);
 
-    LogFileObject* fileobject = nullptr;
-    if (moduleLoggerMap.find(module_name) != moduleLoggerMap.end()) {
-      fileobject = moduleLoggerMap[module_name];
-    } else {
+    if (module_logger_map_.find(module_name) == module_logger_map_.end()) {
       std::string file_name = module_name + ".log.INFO.";
       if (!FLAGS_log_dir.empty()) {
         file_name = FLAGS_log_dir + "/" + file_name;
       }
-      fileobject = new LogFileObject(google::INFO, file_name.c_str());
-      fileobject->SetSymlinkBasename(module_name.c_str());
-      moduleLoggerMap[module_name] = fileobject;
+      module_logger_map_[module_name].reset(
+          new LogFileObject(google::INFO, file_name.c_str()));
+      module_logger_map_[module_name]->SetSymlinkBasename(module_name.c_str());
     }
-    if (fileobject) {
-      const bool force_flush = msg.level > 0;
-      fileobject->Write(force_flush, msg.ts, msg.message.data(),
+    const bool force_flush = msg.level > 0;
+    module_logger_map_.find(module_name)
+        ->second->Write(force_flush, msg.ts, msg.message.data(),
                         static_cast<int>(msg.message.size()));
-    }
     buffer->pop_front();
   }
   Flush();

--- a/cyber/logger/async_logger.h
+++ b/cyber/logger/async_logger.h
@@ -27,11 +27,14 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "cyber/common/macros.h"
 #include "glog/logging.h"
+
+#include "cyber/logger/log_file_object.h"
 
 namespace apollo {
 namespace cyber {
@@ -185,6 +188,8 @@ class AsyncLogger : public google::base::Logger {
   enum State { INITTED, RUNNING, STOPPED };
   std::atomic<State> state_ = {INITTED};
   std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+  std::unordered_map<std::string, std::unique_ptr<LogFileObject>>
+      module_logger_map_;
 
   DISALLOW_COPY_AND_ASSIGN(AsyncLogger);
 };

--- a/cyber/logger/async_logger_test.cc
+++ b/cyber/logger/async_logger_test.cc
@@ -58,14 +58,13 @@ TEST(AsyncLoggerTest, SetLoggerToGlog) {
   google::SetLogDestination(google::ERROR, "");
   google::SetLogDestination(google::WARNING, "");
   google::SetLogDestination(google::FATAL, "");
-  AsyncLogger* logger = new AsyncLogger(google::base::GetLogger(google::INFO));
-  google::base::SetLogger(FLAGS_minloglevel, logger);
-  logger->Start();
+  AsyncLogger logger(google::base::GetLogger(google::INFO));
+  google::base::SetLogger(FLAGS_minloglevel, &logger);
+  logger.Start();
   ALOG_MODULE("AsyncLoggerTest2", INFO) << "test set async logger to glog";
   ALOG_MODULE("AsyncLoggerTest2", WARN) << "test set async logger to glog";
   ALOG_MODULE("AsyncLoggerTest2", ERROR) << "test set async logger to glog";
-  logger->Stop();
-  logger = nullptr;
+  logger.Stop();
   google::ShutdownGoogleLogging();
 }
 


### PR DESCRIPTION
# Description
There is potential for an index out of bounds on a fatal message. It seems that glog writes a zero length message if logtostderr is set: https://github.com/google/glog/blob/58d7f873dcde8cf0fe6f37817643a7ff4e49e6d4/src/logging.cc#L1626.

Also, there's a memory leak for the logger object. Glog does not delete it.

# Test
To test the index out of bounds, you can replace the `[]` operator with `at`. Then, call `ACHECK(false)`. You should see an exception out of bounds.

To test the memory leak, you look
```
valgrind --leak-check=full --show-leak-kinds=all mainboard modules/planning/dag/planning.dag
```
before and after the changes.