### PR TITLE
CHECK to ACHECK

### DIFF
--- a/cyber/common/global_data.cc
+++ b/cyber/common/global_data.cc
@@ -55,7 +55,7 @@ char* program_path() {
 
 GlobalData::GlobalData() {
   InitHostInfo();
-  CHECK(InitConfig());
+  ACHECK(InitConfig());
   process_id_ = getpid();
   char* prog_path = program_path();
   if (prog_path) {

--- a/cyber/logger/async_logger.cc
+++ b/cyber/logger/async_logger.cc
@@ -52,8 +52,8 @@ void AsyncLogger::Stop() {
   }
 
   FlushBuffer(active_buf_);
-  CHECK(active_buf_->empty());
-  CHECK(flushing_buf_->empty());
+  ACHECK(active_buf_->empty());
+  ACHECK(flushing_buf_->empty());
   // std::cout << "Async Logger Stop!" << std::endl;
 }
 

--- a/cyber/py_wrapper/py_cyber.cc
+++ b/cyber/py_wrapper/py_cyber.cc
@@ -520,7 +520,7 @@ PyObject *cyber_PyNode_create_reader(PyObject *self, PyObject *args) {
 
   PyReader *reader = reinterpret_cast<PyReader *>((node->create_reader(
       (std::string const &)channel_name, (std::string const &)type_name)));
-  CHECK(reader) << "PyReader is NULL!";
+  ACHECK(reader) << "PyReader is NULL!";
 
   PyObject *pyobj_reader =
       PyCapsule_New(reader, "apollo_cyber_pyreader", nullptr);

--- a/cyber/py_wrapper/py_record.cc
+++ b/cyber/py_wrapper/py_record.cc
@@ -112,7 +112,7 @@ PyObject *cyber_PyRecordReader_ReadMessage(PyObject *self, PyObject *args) {
 #else
       Py_BuildValue("s#", result.data.c_str(), result.data.length());
 #endif
-  CHECK(bld_data) << "Py_BuildValue returns NULL.";
+  ACHECK(bld_data) << "Py_BuildValue returns NULL.";
   PyDict_SetItemString(pyobj_bag_message, "data", bld_data);
   Py_DECREF(bld_data);
 

--- a/modules/common/configs/vehicle_config_helper.cc
+++ b/modules/common/configs/vehicle_config_helper.cc
@@ -34,7 +34,7 @@ void VehicleConfigHelper::Init() { Init(FLAGS_vehicle_config_path); }
 
 void VehicleConfigHelper::Init(const std::string &config_file) {
   VehicleConfig params;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &params))
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &params))
       << "Unable to parse vehicle config file " << config_file;
   Init(params);
 }

--- a/modules/common/filters/digital_filter.cc
+++ b/modules/common/filters/digital_filter.cc
@@ -97,8 +97,8 @@ double DigitalFilter::Compute(const std::deque<double> &values,
                               const std::vector<double> &coefficients,
                               const std::size_t coeff_start,
                               const std::size_t coeff_end) {
-  CHECK(coeff_start <= coeff_end && coeff_end < coefficients.size());
-  CHECK((coeff_end - coeff_start + 1) == values.size());
+  ACHECK(coeff_start <= coeff_end && coeff_end < coefficients.size());
+  ACHECK((coeff_end - coeff_start + 1) == values.size());
 
   double sum = 0.0;
   auto i = coeff_start;

--- a/modules/common/filters/mean_filter.cc
+++ b/modules/common/filters/mean_filter.cc
@@ -52,7 +52,7 @@ double MF::GetMax() const {
 }
 
 double MF::Update(const double measurement) {
-  CHECK(initialized_);
+  ACHECK(initialized_);
   CHECK_LE(values_.size(), window_size_);
   CHECK_LE(min_candidates_.size(), window_size_);
   CHECK_LE(max_candidates_.size(), window_size_);

--- a/modules/common/math/aabox2d.cc
+++ b/modules/common/math/aabox2d.cc
@@ -44,7 +44,7 @@ AABox2d::AABox2d(const Vec2d &one_corner, const Vec2d &opposite_corner)
               std::abs(one_corner.y() - opposite_corner.y())) {}
 
 AABox2d::AABox2d(const std::vector<Vec2d> &points) {
-  CHECK(!points.empty());
+  ACHECK(!points.empty());
   double min_x = points[0].x();
   double max_x = points[0].x();
   double min_y = points[0].y();

--- a/modules/common/math/aaboxkdtree2d.h
+++ b/modules/common/math/aaboxkdtree2d.h
@@ -336,7 +336,7 @@ class AABoxKDTree2dNode {
     mid_x_ = (min_x_ + max_x_) / 2.0;
     mid_y_ = (min_y_ + max_y_) / 2.0;
     ACHECK(!std::isinf(max_x_) && !std::isinf(max_y_) && !std::isinf(min_x_) &&
-          !std::isinf(min_y_))
+           !std::isinf(min_y_))
         << "the provided object box size is infinity";
   }
 

--- a/modules/common/math/aaboxkdtree2d.h
+++ b/modules/common/math/aaboxkdtree2d.h
@@ -70,7 +70,7 @@ class AABoxKDTree2dNode {
   AABoxKDTree2dNode(const std::vector<ObjectPtr> &objects,
                     const AABoxKDTreeParams &params, int depth)
       : depth_(depth) {
-    CHECK(!objects.empty());
+    ACHECK(!objects.empty());
 
     ComputeBoundary(objects);
     ComputePartition();
@@ -335,7 +335,7 @@ class AABoxKDTree2dNode {
     }
     mid_x_ = (min_x_ + max_x_) / 2.0;
     mid_y_ = (min_y_ + max_y_) / 2.0;
-    CHECK(!std::isinf(max_x_) && !std::isinf(max_y_) && !std::isinf(min_x_) &&
+    ACHECK(!std::isinf(max_x_) && !std::isinf(max_y_) && !std::isinf(min_x_) &&
           !std::isinf(min_y_))
         << "the provided object box size is infinity";
   }

--- a/modules/common/math/box2d.cc
+++ b/modules/common/math/box2d.cc
@@ -266,7 +266,7 @@ double Box2d::DistanceTo(const LineSegment2d &line_segment) const {
         return 0.0;
     }
   }
-  CHECK(0) << "unimplemented state: " << gx1 << " " << gy1 << " " << gx2 << " "
+  ACHECK(0) << "unimplemented state: " << gx1 << " " << gy1 << " " << gx2 << " "
            << gy2;
   return 0.0;
 }

--- a/modules/common/math/box2d.cc
+++ b/modules/common/math/box2d.cc
@@ -267,7 +267,7 @@ double Box2d::DistanceTo(const LineSegment2d &line_segment) const {
     }
   }
   ACHECK(0) << "unimplemented state: " << gx1 << " " << gy1 << " " << gx2 << " "
-           << gy2;
+            << gy2;
   return 0.0;
 }
 

--- a/modules/common/math/cartesian_frenet_conversion.cc
+++ b/modules/common/math/cartesian_frenet_conversion.cc
@@ -90,7 +90,7 @@ void CartesianFrenetConverter::frenet_to_cartesian(
     const std::array<double, 3>& d_condition, double* const ptr_x,
     double* const ptr_y, double* const ptr_theta, double* const ptr_kappa,
     double* const ptr_v, double* const ptr_a) {
-  CHECK(std::abs(rs - s_condition[0]) < 1.0e-6)
+  ACHECK(std::abs(rs - s_condition[0]) < 1.0e-6)
       << "The reference point s and s_condition[0] don't match";
 
   const double cos_theta_r = std::cos(rtheta);

--- a/modules/common/math/hermite_spline.h
+++ b/modules/common/math/hermite_spline.h
@@ -56,7 +56,7 @@ inline HermiteSpline<T, N>::HermiteSpline(std::array<T, (N + 1) / 2> x0,
                                           std::array<T, (N + 1) / 2> x1,
                                           const double z0, const double z1)
     : x0_(std::move(x0)), x1_(std::move(x1)), z0_(z0), delta_z_(z1 - z0) {
-  CHECK(N == 3 || N == 5)
+  ACHECK(N == 3 || N == 5)
       << "Error: currently we only support cubic and quintic hermite splines!";
 }
 

--- a/modules/common/math/kalman_filter.h
+++ b/modules/common/math/kalman_filter.h
@@ -254,7 +254,7 @@ class KalmanFilter {
 template <typename T, unsigned int XN, unsigned int ZN, unsigned int UN>
 inline void KalmanFilter<T, XN, ZN, UN>::Predict(
     const Eigen::Matrix<T, UN, 1> &u) {
-  CHECK(is_initialized_);
+  ACHECK(is_initialized_);
 
   x_ = F_ * x_ + B_ * u;
 
@@ -264,7 +264,7 @@ inline void KalmanFilter<T, XN, ZN, UN>::Predict(
 template <typename T, unsigned int XN, unsigned int ZN, unsigned int UN>
 inline void KalmanFilter<T, XN, ZN, UN>::Correct(
     const Eigen::Matrix<T, ZN, 1> &z) {
-  CHECK(is_initialized_);
+  ACHECK(is_initialized_);
   y_ = z - H_ * x_;
 
   S_ = static_cast<Eigen::Matrix<T, ZN, ZN>>(H_ * P_ * H_.transpose() + R_);

--- a/modules/common/math/polygon2d.cc
+++ b/modules/common/math/polygon2d.cc
@@ -335,7 +335,7 @@ bool Polygon2d::ComputeOverlap(const Polygon2d &other_polygon,
                                Polygon2d *const overlap_polygon) const {
   CHECK_GE(points_.size(), 3);
   CHECK_NOTNULL(overlap_polygon);
-  CHECK(is_convex_ && other_polygon.is_convex());
+  ACHECK(is_convex_ && other_polygon.is_convex());
   std::vector<Vec2d> points = other_polygon.points();
   for (int i = 0; i < num_points_; ++i) {
     if (!ClipConvexHull(line_segments_[i], &points)) {
@@ -523,7 +523,7 @@ Box2d Polygon2d::MinAreaBoundingBox() const {
   if (!is_convex_) {
     Polygon2d convex_polygon;
     ComputeConvexHull(points_, &convex_polygon);
-    CHECK(convex_polygon.is_convex());
+    ACHECK(convex_polygon.is_convex());
     return convex_polygon.MinAreaBoundingBox();
   }
   double min_area = std::numeric_limits<double>::infinity();
@@ -581,7 +581,7 @@ Polygon2d Polygon2d::ExpandByDistance(const double distance) const {
   if (!is_convex_) {
     Polygon2d convex_polygon;
     ComputeConvexHull(points_, &convex_polygon);
-    CHECK(convex_polygon.is_convex());
+    ACHECK(convex_polygon.is_convex());
     return convex_polygon.ExpandByDistance(distance);
   }
   const double kMinAngle = 0.1;
@@ -603,7 +603,7 @@ Polygon2d Polygon2d::ExpandByDistance(const double distance) const {
     }
   }
   Polygon2d new_polygon;
-  CHECK(ComputeConvexHull(points, &new_polygon));
+  ACHECK(ComputeConvexHull(points, &new_polygon));
   return new_polygon;
 }
 

--- a/modules/common/util/json_util.cc
+++ b/modules/common/util/json_util.cc
@@ -39,7 +39,7 @@ nlohmann::json JsonUtil::ProtoToTypedJson(
   static const auto kJsonOption = JsonOption();
   std::string json_string;
   const auto status = MessageToJsonString(proto, &json_string, kJsonOption);
-  CHECK(status.ok()) << "Cannot convert proto to json:" << proto.DebugString();
+  ACHECK(status.ok()) << "Cannot convert proto to json:" << proto.DebugString();
 
   Json json_obj;
   json_obj["type"] = json_type;

--- a/modules/common/vehicle_model/vehicle_model.cc
+++ b/modules/common/vehicle_model/vehicle_model.cc
@@ -85,13 +85,13 @@ VehicleState VehicleModel::Predict(const double predicted_time_horizon,
   VehicleModelConfig vehicle_model_config;
 
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_vehicle_model_config_filename,
-                                        &vehicle_model_config))
+                                         &vehicle_model_config))
       << "Failed to load vehicle model config file "
       << FLAGS_vehicle_model_config_filename;
 
   // Some models not supported for now
   ACHECK(vehicle_model_config.model_type() !=
-        VehicleModelConfig::COM_CENTERED_DYNAMIC_BICYCLE_MODEL);
+         VehicleModelConfig::COM_CENTERED_DYNAMIC_BICYCLE_MODEL);
   ACHECK(vehicle_model_config.model_type() != VehicleModelConfig::MLP_MODEL);
 
   VehicleState predicted_vehicle_state;

--- a/modules/common/vehicle_model/vehicle_model.cc
+++ b/modules/common/vehicle_model/vehicle_model.cc
@@ -84,15 +84,15 @@ VehicleState VehicleModel::Predict(const double predicted_time_horizon,
                                    const VehicleState& cur_vehicle_state) {
   VehicleModelConfig vehicle_model_config;
 
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_vehicle_model_config_filename,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_vehicle_model_config_filename,
                                         &vehicle_model_config))
       << "Failed to load vehicle model config file "
       << FLAGS_vehicle_model_config_filename;
 
   // Some models not supported for now
-  CHECK(vehicle_model_config.model_type() !=
+  ACHECK(vehicle_model_config.model_type() !=
         VehicleModelConfig::COM_CENTERED_DYNAMIC_BICYCLE_MODEL);
-  CHECK(vehicle_model_config.model_type() != VehicleModelConfig::MLP_MODEL);
+  ACHECK(vehicle_model_config.model_type() != VehicleModelConfig::MLP_MODEL);
 
   VehicleState predicted_vehicle_state;
   if (vehicle_model_config.model_type() ==

--- a/modules/common/vehicle_model/vehicle_model_test.cc
+++ b/modules/common/vehicle_model/vehicle_model_test.cc
@@ -32,18 +32,18 @@ class VehicleModelTest : public ::testing::Test {
   virtual void SetUp() {
     std::string localization_pre_file =
         "modules/common/testdata/localization_pre.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(localization_pre_file,
+    ACHECK(cyber::common::GetProtoFromFile(localization_pre_file,
                                           &localization_pre_));
     std::string localization_post_file =
         "modules/common/testdata/localization_post.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(localization_post_file,
+    ACHECK(cyber::common::GetProtoFromFile(localization_post_file,
                                           &localization_post_));
     const std::string chassis_pre_file =
         "modules/common/testdata/chassis_pre.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(chassis_pre_file, &chassis_pre_));
+    ACHECK(cyber::common::GetProtoFromFile(chassis_pre_file, &chassis_pre_));
     const std::string chassis_post_file =
         "modules/common/testdata/chassis_post.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(chassis_post_file, &chassis_post_));
+    ACHECK(cyber::common::GetProtoFromFile(chassis_post_file, &chassis_post_));
   }
 
  protected:

--- a/modules/common/vehicle_model/vehicle_model_test.cc
+++ b/modules/common/vehicle_model/vehicle_model_test.cc
@@ -33,11 +33,11 @@ class VehicleModelTest : public ::testing::Test {
     std::string localization_pre_file =
         "modules/common/testdata/localization_pre.pb.txt";
     ACHECK(cyber::common::GetProtoFromFile(localization_pre_file,
-                                          &localization_pre_));
+                                           &localization_pre_));
     std::string localization_post_file =
         "modules/common/testdata/localization_post.pb.txt";
     ACHECK(cyber::common::GetProtoFromFile(localization_post_file,
-                                          &localization_post_));
+                                           &localization_post_));
     const std::string chassis_pre_file =
         "modules/common/testdata/chassis_pre.pb.txt";
     ACHECK(cyber::common::GetProtoFromFile(chassis_pre_file, &chassis_pre_));

--- a/modules/common/vehicle_state/vehicle_state_provider_test.cc
+++ b/modules/common/vehicle_state/vehicle_state_provider_test.cc
@@ -38,7 +38,7 @@ class VehicleStateProviderTest : public ::testing::Test {
   virtual void SetUp() {
     std::string localization_file =
         "modules/localization/testdata/3_localization_result_1.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(localization_file, &localization_));
+    ACHECK(cyber::common::GetProtoFromFile(localization_file, &localization_));
     chassis_.set_speed_mps(3.0);
     chassis_.set_gear_location(canbus::Chassis::GEAR_DRIVE);
     FLAGS_enable_map_reference_unify = false;

--- a/modules/control/common/interpolation_1d_test.cc
+++ b/modules/control/common/interpolation_1d_test.cc
@@ -34,7 +34,7 @@ class Interpolation1DTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
   }
 
  protected:

--- a/modules/control/common/interpolation_2d_test.cc
+++ b/modules/control/common/interpolation_2d_test.cc
@@ -32,7 +32,7 @@ class Interpolation2DTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
   }
 
  protected:

--- a/modules/control/common/leadlag_controller_test.cc
+++ b/modules/control/common/leadlag_controller_test.cc
@@ -32,7 +32,7 @@ class LeadlagControllerTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
     lon_controller_conf_ = control_conf_.lon_controller_conf();
   }
 

--- a/modules/control/common/mrac_controller_test.cc
+++ b/modules/control/common/mrac_controller_test.cc
@@ -36,7 +36,7 @@ class MracControllerTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
     lat_controller_conf_ = control_conf_.lat_controller_conf();
     steering_latency_param_.set_dead_time(0.0);
     steering_latency_param_.set_rise_time(0.0);

--- a/modules/control/common/pid_BC_controller_test.cc
+++ b/modules/control/common/pid_BC_controller_test.cc
@@ -31,7 +31,7 @@ class PidBCControllerTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
     lon_controller_conf_ = control_conf_.lon_controller_conf();
   }
 

--- a/modules/control/common/pid_IC_controller_test.cc
+++ b/modules/control/common/pid_IC_controller_test.cc
@@ -31,7 +31,7 @@ class PidICControllerTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
     lon_controller_conf_ = control_conf_.lon_controller_conf();
   }
 

--- a/modules/control/common/pid_controller_test.cc
+++ b/modules/control/common/pid_controller_test.cc
@@ -32,7 +32,7 @@ class PidControllerTest : public ::testing::Test {
   virtual void SetUp() {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf_));
     lon_controller_conf_ = control_conf_.lon_controller_conf();
   }
 

--- a/modules/control/control_component.cc
+++ b/modules/control/control_component.cc
@@ -43,7 +43,7 @@ bool ControlComponent::Init() {
 
   AINFO << "Control init, starting ...";
 
-  CHECK(
+  ACHECK(
       cyber::common::GetProtoFromFile(FLAGS_control_conf_file, &control_conf_))
       << "Unable to load control conf file: " + FLAGS_control_conf_file;
 
@@ -67,7 +67,7 @@ bool ControlComponent::Init() {
 
   chassis_reader_ =
       node_->CreateReader<Chassis>(chassis_reader_config, nullptr);
-  CHECK(chassis_reader_ != nullptr);
+  ACHECK(chassis_reader_ != nullptr);
 
   cyber::ReaderConfig planning_reader_config;
   planning_reader_config.channel_name = FLAGS_planning_trajectory_topic;
@@ -75,7 +75,7 @@ bool ControlComponent::Init() {
 
   trajectory_reader_ =
       node_->CreateReader<ADCTrajectory>(planning_reader_config, nullptr);
-  CHECK(trajectory_reader_ != nullptr);
+  ACHECK(trajectory_reader_ != nullptr);
 
   cyber::ReaderConfig localization_reader_config;
   localization_reader_config.channel_name = FLAGS_localization_topic;
@@ -84,7 +84,7 @@ bool ControlComponent::Init() {
 
   localization_reader_ = node_->CreateReader<LocalizationEstimate>(
       localization_reader_config, nullptr);
-  CHECK(localization_reader_ != nullptr);
+  ACHECK(localization_reader_ != nullptr);
 
   cyber::ReaderConfig pad_msg_reader_config;
   pad_msg_reader_config.channel_name = FLAGS_pad_topic;
@@ -92,16 +92,16 @@ bool ControlComponent::Init() {
 
   pad_msg_reader_ =
       node_->CreateReader<PadMessage>(pad_msg_reader_config, nullptr);
-  CHECK(pad_msg_reader_ != nullptr);
+  ACHECK(pad_msg_reader_ != nullptr);
 
   if (!FLAGS_use_control_submodules) {
     control_cmd_writer_ =
         node_->CreateWriter<ControlCommand>(FLAGS_control_command_topic);
-    CHECK(control_cmd_writer_ != nullptr);
+    ACHECK(control_cmd_writer_ != nullptr);
   } else {
     local_view_writer_ =
         node_->CreateWriter<LocalView>(FLAGS_control_local_view_topic);
-    CHECK(local_view_writer_ != nullptr);
+    ACHECK(local_view_writer_ != nullptr);
   }
 
   // set initial vehicle state by cmd

--- a/modules/control/control_component_test.cc
+++ b/modules/control/control_component_test.cc
@@ -180,7 +180,7 @@ bool ControlComponentTest::FeedTestData() {
 }
 
 bool ControlComponentTest::RunControl(const std::string& test_case_name) {
-  CHECK(FeedTestData()) << "Failed to feed test data";
+  ACHECK(FeedTestData()) << "Failed to feed test data";
 
   control_component_.reset(new ControlComponent());
   control_component_->Initialize(component_config_);

--- a/modules/control/controller/controller_agent.cc
+++ b/modules/control/controller/controller_agent.cc
@@ -79,7 +79,7 @@ Status ControllerAgent::InitializeConf(const ControlConf *control_conf) {
 
 Status ControllerAgent::Init(const ControlConf *control_conf) {
   RegisterControllers(control_conf);
-  CHECK(InitializeConf(control_conf).ok()) << "Failed to initialize config.";
+  ACHECK(InitializeConf(control_conf).ok()) << "Failed to initialize config.";
   for (auto &controller : controller_list_) {
     if (controller == nullptr) {
       return Status(ErrorCode::CONTROL_INIT_ERROR, "Controller is null.");

--- a/modules/control/controller/lat_controller.cc
+++ b/modules/control/controller/lat_controller.cc
@@ -285,11 +285,11 @@ void LatController::LoadLatGainScheduler(
   }
 
   lat_err_interpolation_.reset(new Interpolation1D);
-  CHECK(lat_err_interpolation_->Init(xy1))
+  ACHECK(lat_err_interpolation_->Init(xy1))
       << "Fail to load lateral error gain scheduler";
 
   heading_err_interpolation_.reset(new Interpolation1D);
-  CHECK(heading_err_interpolation_->Init(xy2))
+  ACHECK(heading_err_interpolation_->Init(xy2))
       << "Fail to load heading error gain scheduler";
 }
 

--- a/modules/control/controller/lat_controller_test.cc
+++ b/modules/control/controller/lat_controller_test.cc
@@ -44,7 +44,7 @@ class LatControllerTest : public ::testing::Test, LatController {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
     ControlConf control_conf;
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf));
     lateral_conf_ = control_conf.lat_controller_conf();
 
     timestamp_ = Clock::NowInSeconds();
@@ -62,7 +62,7 @@ class LatControllerTest : public ::testing::Test, LatController {
  protected:
   LocalizationPb LoadLocalizaionPb(const std::string &filename) {
     LocalizationPb localization_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &localization_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &localization_pb))
         << "Failed to open file " << filename;
     localization_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return localization_pb;
@@ -70,7 +70,7 @@ class LatControllerTest : public ::testing::Test, LatController {
 
   ChassisPb LoadChassisPb(const std::string &filename) {
     ChassisPb chassis_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
         << "Failed to open file " << filename;
     chassis_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return chassis_pb;
@@ -78,7 +78,7 @@ class LatControllerTest : public ::testing::Test, LatController {
 
   PlanningTrajectoryPb LoadPlanningTrajectoryPb(const std::string &filename) {
     PlanningTrajectoryPb planning_trajectory_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &planning_trajectory_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &planning_trajectory_pb))
         << "Failed to open file " << filename;
     planning_trajectory_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return planning_trajectory_pb;

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -147,7 +147,7 @@ void LonController::LoadControlCalibrationTable(
                                   calibration.command()));
   }
   control_interpolation_.reset(new Interpolation2D);
-  CHECK(control_interpolation_->Init(xyz))
+  ACHECK(control_interpolation_->Init(xyz))
       << "Fail to load control calibration table";
 }
 

--- a/modules/control/controller/lon_controller_test.cc
+++ b/modules/control/controller/lon_controller_test.cc
@@ -50,7 +50,7 @@ class LonControllerTest : public ::testing::Test, LonController {
     std::string control_conf_file =
         "/apollo/modules/control/testdata/conf/control_conf.pb.txt";
 
-    CHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf));
+    ACHECK(cyber::common::GetProtoFromFile(control_conf_file, &control_conf));
     longitudinal_conf_ = control_conf.lon_controller_conf();
 
     timestamp_ = Clock::NowInSeconds();
@@ -72,7 +72,7 @@ class LonControllerTest : public ::testing::Test, LonController {
  protected:
   LocalizationPb LoadLocalizationPb(const std::string &filename) {
     LocalizationPb localization;
-    CHECK(cyber::common::GetProtoFromFile(filename, &localization))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &localization))
         << "Failed to open file " << filename;
     localization.mutable_header()->set_timestamp_sec(timestamp_);
     return localization;
@@ -80,7 +80,7 @@ class LonControllerTest : public ::testing::Test, LonController {
 
   ChassisPb LoadChassisPb(const std::string &filename) {
     ChassisPb chassis_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
         << "Failed to open file " << filename;
     chassis_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return chassis_pb;
@@ -88,7 +88,7 @@ class LonControllerTest : public ::testing::Test, LonController {
 
   TrajectoryPb LoadPlanningTrajectoryPb(const std::string &filename) {
     TrajectoryPb trajectory_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &trajectory_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &trajectory_pb))
         << "Failed to open file " << filename;
 
     trajectory_pb.mutable_header()->set_timestamp_sec(timestamp_);

--- a/modules/control/controller/mpc_controller.cc
+++ b/modules/control/controller/mpc_controller.cc
@@ -282,19 +282,19 @@ void MPCController::LoadMPCGainScheduler(
   }
 
   lat_err_interpolation_.reset(new Interpolation1D);
-  CHECK(lat_err_interpolation_->Init(xy1))
+  ACHECK(lat_err_interpolation_->Init(xy1))
       << "Fail to load lateral error gain scheduler for MPC controller";
 
   heading_err_interpolation_.reset(new Interpolation1D);
-  CHECK(heading_err_interpolation_->Init(xy2))
+  ACHECK(heading_err_interpolation_->Init(xy2))
       << "Fail to load heading error gain scheduler for MPC controller";
 
   feedforwardterm_interpolation_.reset(new Interpolation1D);
-  CHECK(feedforwardterm_interpolation_->Init(xy2))
+  ACHECK(feedforwardterm_interpolation_->Init(xy2))
       << "Fail to load feed forward term gain scheduler for MPC controller";
 
   steer_weight_interpolation_.reset(new Interpolation1D);
-  CHECK(steer_weight_interpolation_->Init(xy2))
+  ACHECK(steer_weight_interpolation_->Init(xy2))
       << "Fail to load steer weight gain scheduler for MPC controller";
 }
 
@@ -559,7 +559,7 @@ void MPCController::LoadControlCalibrationTable(
                                   calibration.command()));
   }
   control_interpolation_.reset(new Interpolation2D);
-  CHECK(control_interpolation_->Init(xyz))
+  ACHECK(control_interpolation_->Init(xyz))
       << "Fail to load control calibration table";
 }
 

--- a/modules/control/controller/mpc_controller_test.cc
+++ b/modules/control/controller/mpc_controller_test.cc
@@ -46,7 +46,7 @@ class MPCControllerTest : public ::testing::Test, MPCController {
         "control_conf.pb.txt ";
     ControlConf control_conf;
     ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_conf_file,
-                                          &control_conf));
+                                           &control_conf));
     mpc_conf_ = control_conf.mpc_controller_conf();
 
     timestamp_ = Clock::NowInSeconds();

--- a/modules/control/controller/mpc_controller_test.cc
+++ b/modules/control/controller/mpc_controller_test.cc
@@ -45,7 +45,7 @@ class MPCControllerTest : public ::testing::Test, MPCController {
         "/apollo/modules//control/testdata/mpc_controller_test/"
         "control_conf.pb.txt ";
     ControlConf control_conf;
-    CHECK(cyber::common::GetProtoFromFile(FLAGS_control_conf_file,
+    ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_conf_file,
                                           &control_conf));
     mpc_conf_ = control_conf.mpc_controller_conf();
 
@@ -64,7 +64,7 @@ class MPCControllerTest : public ::testing::Test, MPCController {
  protected:
   LocalizationPb LoadLocalizaionPb(const std::string &filename) {
     LocalizationPb localization_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &localization_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &localization_pb))
         << "Failed to open file " << filename;
     localization_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return localization_pb;
@@ -72,7 +72,7 @@ class MPCControllerTest : public ::testing::Test, MPCController {
 
   ChassisPb LoadChassisPb(const std::string &filename) {
     ChassisPb chassis_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &chassis_pb))
         << "Failed to open file " << filename;
     chassis_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return chassis_pb;
@@ -80,7 +80,7 @@ class MPCControllerTest : public ::testing::Test, MPCController {
 
   PlanningTrajectoryPb LoadPlanningTrajectoryPb(const std::string &filename) {
     PlanningTrajectoryPb planning_trajectory_pb;
-    CHECK(cyber::common::GetProtoFromFile(filename, &planning_trajectory_pb))
+    ACHECK(cyber::common::GetProtoFromFile(filename, &planning_trajectory_pb))
         << "Failed to open file " << filename;
     planning_trajectory_pb.mutable_header()->set_timestamp_sec(timestamp_);
     return planning_trajectory_pb;

--- a/modules/control/submodules/lat_lon_controller_submodule.cc
+++ b/modules/control/submodules/lat_lon_controller_submodule.cc
@@ -42,7 +42,7 @@ std::string LatLonControllerSubmodule::Name() const {
 
 bool LatLonControllerSubmodule::Init() {
   // lateral controller initialization
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_lateral_controller_conf_file,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_lateral_controller_conf_file,
                                         &lateral_controller_conf_))
       << "Unable to load lateral controller conf file: "
       << FLAGS_lateral_controller_conf_file;
@@ -53,7 +53,7 @@ bool LatLonControllerSubmodule::Init() {
     return false;
   }
   // longitudinal controller
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_longitudinal_controller_conf_file,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_longitudinal_controller_conf_file,
                                         &longitudinal_controller_conf_))
       << "Unable to load longitudinal controller conf file: " +
              FLAGS_longitudinal_controller_conf_file;
@@ -67,7 +67,7 @@ bool LatLonControllerSubmodule::Init() {
   control_core_writer_ =
       node_->CreateWriter<ControlCommand>(FLAGS_control_core_command_topic);
 
-  CHECK(control_core_writer_ != nullptr);
+  ACHECK(control_core_writer_ != nullptr);
 
   return true;
 }

--- a/modules/control/submodules/lat_lon_controller_submodule.cc
+++ b/modules/control/submodules/lat_lon_controller_submodule.cc
@@ -43,7 +43,7 @@ std::string LatLonControllerSubmodule::Name() const {
 bool LatLonControllerSubmodule::Init() {
   // lateral controller initialization
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_lateral_controller_conf_file,
-                                        &lateral_controller_conf_))
+                                         &lateral_controller_conf_))
       << "Unable to load lateral controller conf file: "
       << FLAGS_lateral_controller_conf_file;
 
@@ -53,8 +53,8 @@ bool LatLonControllerSubmodule::Init() {
     return false;
   }
   // longitudinal controller
-  ACHECK(cyber::common::GetProtoFromFile(FLAGS_longitudinal_controller_conf_file,
-                                        &longitudinal_controller_conf_))
+  ACHECK(cyber::common::GetProtoFromFile(
+      FLAGS_longitudinal_controller_conf_file, &longitudinal_controller_conf_))
       << "Unable to load longitudinal controller conf file: " +
              FLAGS_longitudinal_controller_conf_file;
 

--- a/modules/control/submodules/mpc_controller_submodule.cc
+++ b/modules/control/submodules/mpc_controller_submodule.cc
@@ -45,7 +45,7 @@ std::string MPCControllerSubmodule::Name() const {
 
 bool MPCControllerSubmodule::Init() {
   // TODO(SHU): separate common_control conf from controller conf
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_mpc_controller_conf_file,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_mpc_controller_conf_file,
                                         &mpc_controller_conf_))
       << "Unable to load control conf file: " << FLAGS_mpc_controller_conf_file;
 
@@ -57,7 +57,7 @@ bool MPCControllerSubmodule::Init() {
 
   control_core_writer_ =
       node_->CreateWriter<ControlCommand>(FLAGS_control_core_command_topic);
-  CHECK(control_core_writer_ != nullptr);
+  ACHECK(control_core_writer_ != nullptr);
   return true;
 }
 

--- a/modules/control/submodules/mpc_controller_submodule.cc
+++ b/modules/control/submodules/mpc_controller_submodule.cc
@@ -46,7 +46,7 @@ std::string MPCControllerSubmodule::Name() const {
 bool MPCControllerSubmodule::Init() {
   // TODO(SHU): separate common_control conf from controller conf
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_mpc_controller_conf_file,
-                                        &mpc_controller_conf_))
+                                         &mpc_controller_conf_))
       << "Unable to load control conf file: " << FLAGS_mpc_controller_conf_file;
 
   if (!mpc_controller_.Init(&mpc_controller_conf_).ok()) {

--- a/modules/control/submodules/postprocessor_submodule.cc
+++ b/modules/control/submodules/postprocessor_submodule.cc
@@ -39,14 +39,14 @@ std::string PostprocessorSubmodule::Name() const {
 }
 
 bool PostprocessorSubmodule::Init() {
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
                                         &control_common_conf_))
       << "Unable to load control common conf file: "
       << FLAGS_control_common_conf_file;
 
   postprocessor_writer_ =
       node_->CreateWriter<ControlCommand>(FLAGS_control_command_topic);
-  CHECK(postprocessor_writer_ != nullptr);
+  ACHECK(postprocessor_writer_ != nullptr);
   return true;
 }
 

--- a/modules/control/submodules/postprocessor_submodule.cc
+++ b/modules/control/submodules/postprocessor_submodule.cc
@@ -40,7 +40,7 @@ std::string PostprocessorSubmodule::Name() const {
 
 bool PostprocessorSubmodule::Init() {
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
-                                        &control_common_conf_))
+                                         &control_common_conf_))
       << "Unable to load control common conf file: "
       << FLAGS_control_common_conf_file;
 

--- a/modules/control/submodules/preprocessor_submodule.cc
+++ b/modules/control/submodules/preprocessor_submodule.cc
@@ -49,7 +49,7 @@ std::string PreprocessorSubmodule::Name() const {
 }
 
 bool PreprocessorSubmodule::Init() {
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
                                         &control_common_conf_))
       << "Unable to load control common conf file: "
       << FLAGS_control_common_conf_file;
@@ -58,7 +58,7 @@ bool PreprocessorSubmodule::Init() {
   preprocessor_writer_ =
       node_->CreateWriter<Preprocessor>(FLAGS_control_preprocessor_topic);
 
-  CHECK(preprocessor_writer_ != nullptr);
+  ACHECK(preprocessor_writer_ != nullptr);
   return true;
 }
 

--- a/modules/control/submodules/preprocessor_submodule.cc
+++ b/modules/control/submodules/preprocessor_submodule.cc
@@ -50,7 +50,7 @@ std::string PreprocessorSubmodule::Name() const {
 
 bool PreprocessorSubmodule::Init() {
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_control_common_conf_file,
-                                        &control_common_conf_))
+                                         &control_common_conf_))
       << "Unable to load control common conf file: "
       << FLAGS_control_common_conf_file;
 

--- a/modules/data/tools/smart_recorder/smart_recorder.cc
+++ b/modules/data/tools/smart_recorder/smart_recorder.cc
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
         << ". config file: " << FLAGS_smart_recorder_config_filename
         << ". program name: " << argv[0];
   SmartRecordTrigger trigger_conf;
-  CHECK(GetProtoFromFile(FLAGS_smart_recorder_config_filename, &trigger_conf))
+  ACHECK(GetProtoFromFile(FLAGS_smart_recorder_config_filename, &trigger_conf))
       << "Failed to load triggers config file "
       << FLAGS_smart_recorder_config_filename;
   auto processor = std::unique_ptr<RecordProcessor>(new RealtimeRecordProcessor(

--- a/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
+++ b/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
@@ -120,7 +120,7 @@ void DataCollectionMonitor::LoadConfiguration() {
   }
 
   ACHECK(cyber::common::GetProtoFromFile(data_collection_config_path,
-                                        &data_collection_table_))
+                                         &data_collection_table_))
       << "Unable to parse data collection configuration from file "
       << data_collection_config_path;
 

--- a/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
+++ b/modules/dreamview/backend/data_collection_monitor/data_collection_monitor.cc
@@ -119,7 +119,7 @@ void DataCollectionMonitor::LoadConfiguration() {
     data_collection_config_path = FLAGS_default_data_collection_config_path;
   }
 
-  CHECK(cyber::common::GetProtoFromFile(data_collection_config_path,
+  ACHECK(cyber::common::GetProtoFromFile(data_collection_config_path,
                                         &data_collection_table_))
       << "Unable to parse data collection configuration from file "
       << data_collection_config_path;

--- a/modules/dreamview/backend/hmi/hmi.cc
+++ b/modules/dreamview/backend/hmi/hmi.cc
@@ -97,7 +97,7 @@ void HMI::RegisterMessageHandlers() {
         // Extra works for current Dreamview.
         if (hmi_action == HMIAction::CHANGE_MAP) {
           // Reload simulation map after changing map.
-          CHECK(map_service_->ReloadMap(true))
+          ACHECK(map_service_->ReloadMap(true))
               << "Failed to load new simulation map: " << value;
         } else if (hmi_action == HMIAction::CHANGE_VEHICLE) {
           // Reload lidar params for point cloud service.

--- a/modules/dreamview/backend/hmi/hmi_worker.cc
+++ b/modules/dreamview/backend/hmi/hmi_worker.cc
@@ -113,7 +113,7 @@ void SetGlobalFlag(std::string_view flag_name, const ValueType& value,
     *flag = value;
     // Overwrite global flagfile.
     std::ofstream fout(kGlobalFlagfile, std::ios_base::app);
-    CHECK(fout) << "Fail to open global flagfile " << kGlobalFlagfile;
+    ACHECK(fout) << "Fail to open global flagfile " << kGlobalFlagfile;
     fout << "\n--" << flag_name << "=" << value << std::endl;
   }
 }
@@ -157,7 +157,7 @@ HMIConfig HMIWorker::LoadConfig() {
   // Get available modes, maps and vehicles by listing data directory.
   *config.mutable_modes() =
       ListFilesAsDict(FLAGS_hmi_modes_config_path, ".pb.txt");
-  CHECK(!config.modes().empty())
+  ACHECK(!config.modes().empty())
       << "No modes config loaded from " << FLAGS_hmi_modes_config_path;
 
   *config.mutable_maps() = ListDirAsDict(FLAGS_maps_data_path);
@@ -168,14 +168,14 @@ HMIConfig HMIWorker::LoadConfig() {
 
 HMIMode HMIWorker::LoadMode(const std::string& mode_config_path) {
   HMIMode mode;
-  CHECK(cyber::common::GetProtoFromFile(mode_config_path, &mode))
+  ACHECK(cyber::common::GetProtoFromFile(mode_config_path, &mode))
       << "Unable to parse HMIMode from file " << mode_config_path;
   // Translate cyber_modules to regular modules.
   for (const auto& iter : mode.cyber_modules()) {
     const std::string& module_name = iter.first;
     const CyberModule& cyber_module = iter.second;
     // Each cyber module should have at least one dag file.
-    CHECK(!cyber_module.dag_files().empty())
+    ACHECK(!cyber_module.dag_files().empty())
         << "None dag file is provided for " << module_name << " module in "
         << mode_config_path;
 
@@ -464,7 +464,7 @@ void HMIWorker::ChangeVehicle(const std::string& vehicle_name) {
   }
   ResetMode();
 
-  CHECK(VehicleManager::Instance()->UseVehicle(*vehicle_dir));
+  ACHECK(VehicleManager::Instance()->UseVehicle(*vehicle_dir));
 }
 
 void HMIWorker::ChangeMode(const std::string& mode_name) {

--- a/modules/dreamview/backend/hmi/vehicle_manager.cc
+++ b/modules/dreamview/backend/hmi/vehicle_manager.cc
@@ -32,7 +32,7 @@ namespace dreamview {
 using cyber::common::GetProtoFromFile;
 
 VehicleManager::VehicleManager() {
-  CHECK(GetProtoFromFile(FLAGS_vehicle_data_config_filename, &vehicle_data_))
+  ACHECK(GetProtoFromFile(FLAGS_vehicle_data_config_filename, &vehicle_data_))
       << "Unable to parse VehicleData config file "
       << FLAGS_vehicle_data_config_filename;
 }

--- a/modules/drivers/gnss/stream/raw_stream.cc
+++ b/modules/drivers/gnss/stream/raw_stream.cc
@@ -59,7 +59,7 @@ std::string getLocalTimeFileStr(const std::string &gpsbin_folder) {
   std::strftime(local_time_char, sizeof(local_time_char), "%Y%m%d_%H%M%S",
                 &time_tm);
   std::string local_time_str = local_time_char;
-  CHECK(cyber::common::EnsureDirectory(gpsbin_folder))
+  ACHECK(cyber::common::EnsureDirectory(gpsbin_folder))
       << "gbsbin folder : " << gpsbin_folder << " create fail";
   std::string local_time_file_str =
       gpsbin_folder + "/" + local_time_str + ".bin";

--- a/modules/localization/msf/local_map/base_map/base_map.cc
+++ b/modules/localization/msf/local_map/base_map/base_map.cc
@@ -44,8 +44,8 @@ BaseMap::~BaseMap() {
 }
 
 void BaseMap::InitMapNodeCaches(int cacheL1_size, int cahceL2_size) {
-  CHECK(map_node_cache_lvl1_ == nullptr);
-  CHECK(map_node_cache_lvl2_ == nullptr);
+  ACHECK(map_node_cache_lvl1_ == nullptr);
+  ACHECK(map_node_cache_lvl2_ == nullptr);
   map_node_cache_lvl1_ =
       new MapNodeCacheL1<MapNodeIndex, BaseMapNode>(cacheL1_size);
   map_node_cache_lvl2_ =
@@ -175,7 +175,7 @@ void BaseMap::LoadMapNodes(std::set<MapNodeIndex>* map_ids) {
   }
   lock2.unlock();
 
-  CHECK(map_ids->empty());
+  ACHECK(map_ids->empty());
 }
 
 void BaseMap::PreloadMapNodes(std::set<MapNodeIndex>* map_ids) {

--- a/modules/localization/msf/msf_localization.cc
+++ b/modules/localization/msf/msf_localization.cc
@@ -136,8 +136,8 @@ void MSFLocalization::InitParams() {
     double uncertainty_z = 0.0;
     AINFO << "Ant imu lever arm file: " << FLAGS_ant_imu_leverarm_file;
     ACHECK(LoadGnssAntennaExtrinsic(FLAGS_ant_imu_leverarm_file, &offset_x,
-                                   &offset_y, &offset_z, &uncertainty_x,
-                                   &uncertainty_y, &uncertainty_z));
+                                    &offset_y, &offset_z, &uncertainty_x,
+                                    &uncertainty_y, &uncertainty_z));
     localization_param_.ant_imu_leverarm_file = FLAGS_ant_imu_leverarm_file;
 
     localization_param_.imu_to_ant_offset.offset_x = offset_x;

--- a/modules/localization/msf/msf_localization.cc
+++ b/modules/localization/msf/msf_localization.cc
@@ -135,7 +135,7 @@ void MSFLocalization::InitParams() {
     double uncertainty_y = 0.0;
     double uncertainty_z = 0.0;
     AINFO << "Ant imu lever arm file: " << FLAGS_ant_imu_leverarm_file;
-    CHECK(LoadGnssAntennaExtrinsic(FLAGS_ant_imu_leverarm_file, &offset_x,
+    ACHECK(LoadGnssAntennaExtrinsic(FLAGS_ant_imu_leverarm_file, &offset_x,
                                    &offset_y, &offset_z, &uncertainty_x,
                                    &uncertainty_y, &uncertainty_z));
     localization_param_.ant_imu_leverarm_file = FLAGS_ant_imu_leverarm_file;

--- a/modules/localization/rtk/rtk_localization_component.cc
+++ b/modules/localization/rtk/rtk_localization_component.cc
@@ -65,20 +65,20 @@ bool RTKLocalizationComponent::InitIO() {
   corrected_imu_listener_ = node_->CreateReader<localization::CorrectedImu>(
       imu_topic_, std::bind(&RTKLocalization::ImuCallback, localization_.get(),
                             std::placeholders::_1));
-  CHECK(corrected_imu_listener_);
+  ACHECK(corrected_imu_listener_);
 
   gps_status_listener_ = node_->CreateReader<drivers::gnss::InsStat>(
       gps_status_topic_, std::bind(&RTKLocalization::GpsStatusCallback,
                                    localization_.get(), std::placeholders::_1));
-  CHECK(gps_status_listener_);
+  ACHECK(gps_status_listener_);
 
   localization_talker_ =
       node_->CreateWriter<LocalizationEstimate>(localization_topic_);
-  CHECK(localization_talker_);
+  ACHECK(localization_talker_);
 
   localization_status_talker_ =
       node_->CreateWriter<LocalizationStatus>(localization_status_topic_);
-  CHECK(localization_status_talker_);
+  ACHECK(localization_status_talker_);
   return true;
 }
 

--- a/modules/localization/rtk/rtk_localization_test.cc
+++ b/modules/localization/rtk/rtk_localization_test.cc
@@ -33,7 +33,7 @@ class RTKLocalizationTest : public ::testing::Test {
  protected:
   template <class T>
   void load_data(const std::string &filename, T *data) {
-    CHECK(cyber::common::GetProtoFromFile(filename, data))
+    ACHECK(cyber::common::GetProtoFromFile(filename, data))
         << "Failed to open file " << filename;
   }
 

--- a/modules/map/hdmap/adapter/opendrive_adapter.cc
+++ b/modules/map/hdmap/adapter/opendrive_adapter.cc
@@ -36,7 +36,7 @@ bool OpendriveAdapter::LoadData(const std::string& filename,
 
   // root node
   const tinyxml2::XMLElement* root_node = document.RootElement();
-  CHECK(root_node != nullptr);
+  ACHECK(root_node != nullptr);
   // header
   PbHeader* map_header = pb_map->mutable_header();
   Status status = HeaderXmlParser::Parse(*root_node, map_header);

--- a/modules/map/hdmap/adapter/xml_parser/lanes_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/lanes_xml_parser.cc
@@ -200,7 +200,7 @@ Status LanesXmlParser::ParseLane(const tinyxml2::XMLElement& xml_node,
   const tinyxml2::XMLElement* sub_node = xml_node.FirstChildElement("border");
   if (sub_node) {
     PbLaneBoundary* lane_boundary = lane->mutable_right_boundary();
-    CHECK(lane_boundary != nullptr);
+    ACHECK(lane_boundary != nullptr);
     success =
         UtilXmlParser::ParseCurve(*sub_node, lane_boundary->mutable_curve());
     if (!success.ok()) {

--- a/modules/map/hdmap/adapter/xml_parser/objects_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/objects_xml_parser.cc
@@ -77,7 +77,7 @@ Status ObjectsXmlParser::ParseClearAreas(
       PbClearArea clear_area;
       clear_area.mutable_id()->set_id(object_id);
       PbPolygon* polygon = clear_area.mutable_polygon();
-      CHECK(polygon != nullptr);
+      ACHECK(polygon != nullptr);
       const tinyxml2::XMLElement* outline_node =
           sub_node->FirstChildElement("outline");
       if (outline_node == nullptr) {
@@ -155,7 +155,7 @@ Status ObjectsXmlParser::ParseStopLines(
       StopLineInternal stop_line;
       stop_line.id = object_id;
       PbCurveSegment* curve_segment = stop_line.curve.add_segment();
-      CHECK(curve_segment != nullptr);
+      ACHECK(curve_segment != nullptr);
       const auto sub_node = object_node->FirstChildElement("geometry");
       if (sub_node == nullptr) {
         std::string err_msg = "Error parse stopline geometry";

--- a/modules/map/hdmap/adapter/xml_parser/roads_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/roads_xml_parser.cc
@@ -22,7 +22,7 @@ limitations under the License.
 
 namespace {
 bool IsRoadBelongToJunction(const std::string& road_id) {
-  CHECK(!road_id.empty());
+  ACHECK(!road_id.empty());
   return road_id != "-1";
 }
 }  // namespace

--- a/modules/map/hdmap/adapter/xml_parser/signals_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/signals_xml_parser.cc
@@ -119,7 +119,7 @@ Status SignalsXmlParser::ParseTrafficLights(
           std::string stop_line_id;
           int checker = UtilXmlParser::QueryStringAttribute(*sub_node, "id",
                                                             &stop_line_id);
-          CHECK(checker == tinyxml2::XML_SUCCESS);
+          ACHECK(checker == tinyxml2::XML_SUCCESS);
           trafficlight_internal.stop_line_ids.insert(stop_line_id);
           sub_node = sub_node->NextSiblingElement("objectReference");
         }
@@ -258,7 +258,7 @@ Status SignalsXmlParser::ParseStopSigns(
           std::string stop_line_id;
           int checker = UtilXmlParser::QueryStringAttribute(*sub_node, "id",
                                                             &stop_line_id);
-          CHECK(checker == tinyxml2::XML_SUCCESS);
+          ACHECK(checker == tinyxml2::XML_SUCCESS);
           stop_sign_internal.stop_line_ids.insert(stop_line_id);
 
           sub_node = sub_node->NextSiblingElement("objectReference");
@@ -319,7 +319,7 @@ Status SignalsXmlParser::ParseYieldSigns(
           std::string stop_line_id;
           int checker = UtilXmlParser::QueryStringAttribute(*sub_node, "id",
                                                             &stop_line_id);
-          CHECK(checker == tinyxml2::XML_SUCCESS);
+          ACHECK(checker == tinyxml2::XML_SUCCESS);
           yield_sign_internal.stop_line_ids.insert(stop_line_id);
 
           sub_node = sub_node->NextSiblingElement("objectReference");

--- a/modules/map/hdmap/adapter/xml_parser/util_xml_parser.cc
+++ b/modules/map/hdmap/adapter/xml_parser/util_xml_parser.cc
@@ -148,7 +148,7 @@ Status UtilXmlParser::ParsePoint(const tinyxml2::XMLElement& xml_node,
   CHECK_NOTNULL(pt);
 
   const auto sub_node = xml_node.FirstChildElement("centerPoint");
-  CHECK(sub_node != nullptr);
+  ACHECK(sub_node != nullptr);
   int checker = tinyxml2::XML_SUCCESS;
   double ptx = 0.0;
   double pty = 0.0;

--- a/modules/map/hdmap/hdmap_common.cc
+++ b/modules/map/hdmap/hdmap_common.cc
@@ -80,7 +80,7 @@ void PointsFromCurve(const Curve &input_curve, std::vector<Vec2d> *points) {
   for (const auto &curve : input_curve.segment()) {
     if (curve.has_line_segment()) {
       for (const auto &point : curve.line_segment().point()) {
-        CHECK(IsPointValid(point))
+        ACHECK(IsPointValid(point))
             << "invalid map point: " << point.DebugString();
         points->emplace_back(point.x(), point.y());
       }
@@ -95,7 +95,7 @@ apollo::common::math::Polygon2d ConvertToPolygon2d(const Polygon &polygon) {
   std::vector<Vec2d> points;
   points.reserve(polygon.point_size());
   for (const auto &point : polygon.point()) {
-    CHECK(IsPointValid(point)) << "invalid map point:" << point.DebugString();
+    ACHECK(IsPointValid(point)) << "invalid map point:" << point.DebugString();
     points.emplace_back(point.x(), point.y());
   }
   RemoveDuplicates(&points);
@@ -147,7 +147,7 @@ void LaneInfo::Init() {
 
   accumulated_s_.push_back(s);
   total_length_ = s;
-  CHECK(!unit_directions_.empty());
+  ACHECK(!unit_directions_.empty());
   unit_directions_.push_back(unit_directions_.back());
   for (const auto &direction : unit_directions_) {
     headings_.push_back(direction.Angle());
@@ -155,7 +155,7 @@ void LaneInfo::Init() {
   for (const auto &overlap_id : lane_.overlap_id()) {
     overlap_ids_.emplace_back(overlap_id.id());
   }
-  CHECK(!segments_.empty());
+  ACHECK(!segments_.empty());
 
   sampled_left_width_.clear();
   sampled_right_width_.clear();
@@ -568,7 +568,7 @@ void SignalInfo::Init() {
   for (const auto &stop_line : signal_.stop_line()) {
     SegmentsFromCurve(stop_line, &segments_);
   }
-  CHECK(!segments_.empty());
+  ACHECK(!segments_.empty());
   std::vector<Vec2d> points;
   for (const auto &segment : segments_) {
     points.emplace_back(segment.start());
@@ -595,7 +595,7 @@ void StopSignInfo::init() {
   for (const auto &stop_line : stop_sign_.stop_line()) {
     SegmentsFromCurve(stop_line, &segments_);
   }
-  CHECK(!segments_.empty());
+  ACHECK(!segments_.empty());
 
   for (const auto &overlap_id : stop_sign_.overlap_id()) {
     overlap_ids_.emplace_back(overlap_id);
@@ -641,7 +641,7 @@ void YieldSignInfo::Init() {
     SegmentsFromCurve(stop_line, &segments_);
   }
   // segments_from_curve(yield_sign_.stop_line(), &segments_);
-  CHECK(!segments_.empty());
+  ACHECK(!segments_.empty());
 }
 
 ClearAreaInfo::ClearAreaInfo(const ClearArea &clear_area)
@@ -663,7 +663,7 @@ void SpeedBumpInfo::Init() {
   for (const auto &stop_line : speed_bump_.position()) {
     SegmentsFromCurve(stop_line, &segments_);
   }
-  CHECK(!segments_.empty());
+  ACHECK(!segments_.empty());
 }
 
 OverlapInfo::OverlapInfo(const Overlap &overlap) : overlap_(overlap) {}

--- a/modules/map/hdmap/hdmap_impl.cc
+++ b/modules/map/hdmap/hdmap_impl.cc
@@ -503,7 +503,7 @@ int HDMapImpl::GetNearestLane(const Vec2d& point,
   }
   const Id& lane_id = segment_object->object()->id();
   *nearest_lane = GetLaneById(lane_id);
-  CHECK(*nearest_lane);
+  ACHECK(*nearest_lane);
   const int id = segment_object->id();
   const auto& segment = (*nearest_lane)->segments()[id];
   Vec2d nearest_pt;

--- a/modules/map/hdmap/hdmap_impl_test.cc
+++ b/modules/map/hdmap/hdmap_impl_test.cc
@@ -422,11 +422,11 @@ TEST_F(HDMapImplTestSuite, GetLocalMap) {
       std::chrono::steady_clock::now().time_since_epoch().count());
   const std::string output_bin_file =
       absl::StrCat(FLAGS_output_dir, "/base_map_", time_since_epoch, " .bin");
-  CHECK(cyber::common::SetProtoToBinaryFile(local_map, output_bin_file))
+  ACHECK(cyber::common::SetProtoToBinaryFile(local_map, output_bin_file))
       << "failed to output binary format base map";
 
   local_map.Clear();
-  CHECK(cyber::common::GetProtoFromFile(output_bin_file, &local_map))
+  ACHECK(cyber::common::GetProtoFromFile(output_bin_file, &local_map))
       << "failed to load map";
   cyber::common::DeleteFile(output_bin_file);
 }

--- a/modules/map/hdmap/hdmap_util.cc
+++ b/modules/map/hdmap/hdmap_util.cc
@@ -39,7 +39,7 @@ std::string FindFirstExist(const std::string& dir, const std::string& files) {
   }
   AERROR << "No existing file found in " << dir << "/" << files
          << ". Fallback to first candidate as default result.";
-  CHECK(!candidates.empty()) << "Please specify at least one map.";
+  ACHECK(!candidates.empty()) << "Please specify at least one map.";
   return absl::StrCat(FLAGS_map_dir, "/", candidates[0]);
 }
 

--- a/modules/map/pnc_map/pnc_map.cc
+++ b/modules/map/pnc_map/pnc_map.cc
@@ -66,7 +66,7 @@ const hdmap::HDMap *PncMap::hdmap() const { return hdmap_; }
 LaneWaypoint PncMap::ToLaneWaypoint(
     const routing::LaneWaypoint &waypoint) const {
   auto lane = hdmap_->GetLaneById(hdmap::MakeMapId(waypoint.id()));
-  CHECK(lane) << "Invalid lane id: " << waypoint.id();
+  ACHECK(lane) << "Invalid lane id: " << waypoint.id();
   return LaneWaypoint(lane, waypoint.s());
 }
 
@@ -80,7 +80,7 @@ double PncMap::LookForwardDistance(double velocity) {
 
 LaneSegment PncMap::ToLaneSegment(const routing::LaneSegment &segment) const {
   auto lane = hdmap_->GetLaneById(hdmap::MakeMapId(segment.id()));
-  CHECK(lane) << "Invalid lane id: " << segment.id();
+  ACHECK(lane) << "Invalid lane id: " << segment.id();
   return LaneSegment(lane, segment.start_s(), segment.end_s());
 }
 

--- a/modules/map/pnc_map/pnc_map_test.cc
+++ b/modules/map/pnc_map/pnc_map_test.cc
@@ -44,12 +44,12 @@ class PncMapTest : public ::testing::Test {
     AINFO << "map file: " << FLAGS_test_map_file;
     if (hdmap_.LoadMapFromFile(FLAGS_test_map_file) != 0) {
       AERROR << "Failed to load map: " << FLAGS_test_map_file;
-      CHECK(false);
+      ACHECK(false);
     }
     pnc_map_.reset(new PncMap(&hdmap_));
     if (!cyber::common::GetProtoFromFile(FLAGS_test_routing_file, &routing_)) {
       AERROR << "Failed to load routing: " << FLAGS_test_routing_file;
-      CHECK(false);
+      ACHECK(false);
     }
     pnc_map_->UpdateRoutingResponse(routing_);
   }

--- a/modules/map/pnc_map/route_segments_test.cc
+++ b/modules/map/pnc_map/route_segments_test.cc
@@ -38,7 +38,7 @@ class RouteSegmentsTest : public ::testing::Test {
     AINFO << "map file: " << FLAGS_test_map_file;
     if (hdmap_.LoadMapFromFile(FLAGS_test_map_file) != 0) {
       AERROR << "Failed to load map: " << FLAGS_test_map_file;
-      CHECK(false);
+      ACHECK(false);
     }
   }
 

--- a/modules/map/relative_map/tools/navigator.cc
+++ b/modules/map/relative_map/tools/navigator.cc
@@ -203,13 +203,13 @@ bool GetNavigationPathFromFile(const std::string& filename,
 
 void CheckConfig(
     const apollo::relative_map::NavigatorConfig& navigator_config) {
-  CHECK(navigator_config.has_sample_param());
+  ACHECK(navigator_config.has_sample_param());
   const auto& sample_param = navigator_config.sample_param();
-  CHECK(sample_param.has_straight_sample_interval());
-  CHECK(sample_param.has_small_kappa_sample_interval());
-  CHECK(sample_param.has_middle_kappa_sample_interval());
-  CHECK(sample_param.has_large_kappa_sample_interval());
-  CHECK(sample_param.has_small_kappa());
-  CHECK(sample_param.has_middle_kappa());
-  CHECK(sample_param.has_large_kappa());
+  ACHECK(sample_param.has_straight_sample_interval());
+  ACHECK(sample_param.has_small_kappa_sample_interval());
+  ACHECK(sample_param.has_middle_kappa_sample_interval());
+  ACHECK(sample_param.has_large_kappa_sample_interval());
+  ACHECK(sample_param.has_small_kappa());
+  ACHECK(sample_param.has_middle_kappa());
+  ACHECK(sample_param.has_large_kappa());
 }

--- a/modules/map/tools/bin_map_generator.cc
+++ b/modules/map/tools/bin_map_generator.cc
@@ -35,15 +35,15 @@ int main(int argc, char **argv) {
 
   const auto map_filename = FLAGS_map_dir + "/base_map.txt";
   apollo::hdmap::Map pb_map;
-  CHECK(apollo::cyber::common::GetProtoFromFile(map_filename, &pb_map))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(map_filename, &pb_map))
       << "fail to load data from : " << map_filename;
 
   const std::string output_bin_file = FLAGS_output_dir + "/base_map.bin";
-  CHECK(apollo::cyber::common::SetProtoToBinaryFile(pb_map, output_bin_file))
+  ACHECK(apollo::cyber::common::SetProtoToBinaryFile(pb_map, output_bin_file))
       << "failed to output binary format base map";
 
   pb_map.Clear();
-  CHECK(apollo::cyber::common::GetProtoFromFile(output_bin_file, &pb_map))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(output_bin_file, &pb_map))
       << "failed to load map,transform map failed";
 
   AINFO << "transform map into .bin map success";

--- a/modules/map/tools/map_tool.cc
+++ b/modules/map/tools/map_tool.cc
@@ -66,8 +66,8 @@ static void ShiftMap(Map* map_pb) {
 static void OutputMap(const Map& map_pb) {
   const std::string txt_file = FLAGS_output_dir + "/base_map.txt";
   const std::string bin_file = FLAGS_output_dir + "/base_map.bin";
-  CHECK(apollo::cyber::common::SetProtoToASCIIFile(map_pb, txt_file));
-  CHECK(apollo::cyber::common::SetProtoToBinaryFile(map_pb, bin_file));
+  ACHECK(apollo::cyber::common::SetProtoToASCIIFile(map_pb, txt_file));
+  ACHECK(apollo::cyber::common::SetProtoToBinaryFile(map_pb, bin_file));
 }
 
 int main(int32_t argc, char** argv) {
@@ -79,7 +79,7 @@ int main(int32_t argc, char** argv) {
 
   Map map_pb;
   const auto map_file = apollo::hdmap::BaseMapFile();
-  CHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map_pb))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map_pb))
       << "Fail to open:" << map_file;
   ShiftMap(&map_pb);
   OutputMap(map_pb);

--- a/modules/map/tools/map_xysl.cc
+++ b/modules/map/tools/map_xysl.cc
@@ -366,7 +366,8 @@ int main(int argc, char *argv[]) {
   if (!FLAGS_dump_bin_map.empty()) {
     apollo::hdmap::Map map;
     ACHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map));
-    ACHECK(apollo::cyber::common::SetProtoToBinaryFile(map, FLAGS_dump_bin_map));
+    ACHECK(
+        apollo::cyber::common::SetProtoToBinaryFile(map, FLAGS_dump_bin_map));
     valid_arg = true;
   }
   if (!valid_arg) {

--- a/modules/map/tools/map_xysl.cc
+++ b/modules/map/tools/map_xysl.cc
@@ -359,14 +359,14 @@ int main(int argc, char *argv[]) {
   }
   if (!FLAGS_dump_txt_map.empty()) {
     apollo::hdmap::Map map;
-    CHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map));
-    CHECK(apollo::cyber::common::SetProtoToASCIIFile(map, FLAGS_dump_txt_map));
+    ACHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map));
+    ACHECK(apollo::cyber::common::SetProtoToASCIIFile(map, FLAGS_dump_txt_map));
     valid_arg = true;
   }
   if (!FLAGS_dump_bin_map.empty()) {
     apollo::hdmap::Map map;
-    CHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map));
-    CHECK(apollo::cyber::common::SetProtoToBinaryFile(map, FLAGS_dump_bin_map));
+    ACHECK(apollo::cyber::common::GetProtoFromFile(map_file, &map));
+    ACHECK(apollo::cyber::common::SetProtoToBinaryFile(map, FLAGS_dump_bin_map));
     valid_arg = true;
   }
   if (!valid_arg) {

--- a/modules/map/tools/proto_map_generator.cc
+++ b/modules/map/tools/proto_map_generator.cc
@@ -35,20 +35,20 @@ int main(int argc, char **argv) {
 
   const auto map_filename = FLAGS_map_dir + "/base_map.xml";
   apollo::hdmap::Map pb_map;
-  CHECK(
+  ACHECK(
       apollo::hdmap::adapter::OpendriveAdapter::LoadData(map_filename, &pb_map))
       << "fail to load data from : " << map_filename;
 
   const std::string output_ascii_file = FLAGS_output_dir + "/base_map.txt";
-  CHECK(apollo::cyber::common::SetProtoToASCIIFile(pb_map, output_ascii_file))
+  ACHECK(apollo::cyber::common::SetProtoToASCIIFile(pb_map, output_ascii_file))
       << "failed to output ASCII format base map";
 
   const std::string output_bin_file = FLAGS_output_dir + "/base_map.bin";
-  CHECK(apollo::cyber::common::SetProtoToBinaryFile(pb_map, output_bin_file))
+  ACHECK(apollo::cyber::common::SetProtoToBinaryFile(pb_map, output_bin_file))
       << "failed to output binary format base map";
 
   pb_map.Clear();
-  CHECK(apollo::cyber::common::GetProtoFromFile(output_bin_file, &pb_map))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(output_bin_file, &pb_map))
       << "failed to load map";
 
   AINFO << "load map success";

--- a/modules/map/tools/refresh_default_end_way_point.cc
+++ b/modules/map/tools/refresh_default_end_way_point.cc
@@ -36,15 +36,15 @@ namespace hdmap {
 apollo::common::PointENU SLToXYZ(const std::string& lane_id, const double s,
                                  const double l) {
   const auto lane_info = HDMapUtil::BaseMap().GetLaneById(MakeMapId(lane_id));
-  CHECK(lane_info);
+  ACHECK(lane_info);
   return lane_info->GetSmoothPoint(s);
 }
 
 void XYZToSL(const apollo::common::PointENU& point, std::string* lane_id,
              double* s, double* l) {
-  CHECK(lane_id);
-  CHECK(s);
-  CHECK(l);
+  ACHECK(lane_id);
+  ACHECK(s);
+  ACHECK(l);
   LaneInfoConstPtr lane = nullptr;
 
   CHECK_EQ(HDMapUtil::BaseMap().GetNearestLane(point, &lane, s, l), 0);
@@ -61,7 +61,7 @@ double XYZDistance(const apollo::common::PointENU& p1,
 
 void RefreshDefaultEndPoint() {
   apollo::routing::POI old_poi;
-  CHECK(cyber::common::GetProtoFromASCIIFile(EndWayPointFile(), &old_poi));
+  ACHECK(cyber::common::GetProtoFromASCIIFile(EndWayPointFile(), &old_poi));
 
   apollo::routing::POI new_poi;
   for (const auto& old_landmark : old_poi.landmark()) {
@@ -101,7 +101,7 @@ void RefreshDefaultEndPoint() {
             << XYZDistance(old_xyz, new_xyz);
     }
   }
-  CHECK(cyber::common::SetProtoToASCIIFile(new_poi, EndWayPointFile()));
+  ACHECK(cyber::common::SetProtoToASCIIFile(new_poi, EndWayPointFile()));
 }
 
 }  // namespace hdmap

--- a/modules/map/tools/sim_map_generator.cc
+++ b/modules/map/tools/sim_map_generator.cc
@@ -113,9 +113,9 @@ int main(int32_t argc, char** argv) {
   Map map_pb;
   const auto map_file = apollo::hdmap::BaseMapFile();
   if (absl::EndsWith(map_file, ".xml")) {
-    CHECK(OpendriveAdapter::LoadData(map_file, &map_pb));
+    ACHECK(OpendriveAdapter::LoadData(map_file, &map_pb));
   } else {
-    CHECK(GetProtoFromFile(map_file, &map_pb)) << "Fail to open: " << map_file;
+    ACHECK(GetProtoFromFile(map_file, &map_pb)) << "Fail to open: " << map_file;
   }
 
   DownsampleMap(&map_pb);

--- a/modules/perception/base/blob.cc
+++ b/modules/perception/base/blob.cc
@@ -127,19 +127,19 @@ Blob<Dtype>::Blob(const std::vector<int>& shape,
 
 template <typename Dtype>
 const int* Blob<Dtype>::gpu_shape() const {
-  CHECK(shape_data_);
+  ACHECK(shape_data_);
   return (const int*)shape_data_->gpu_data();
 }
 
 template <typename Dtype>
 const Dtype* Blob<Dtype>::cpu_data() const {
-  CHECK(data_);
+  ACHECK(data_);
   return (const Dtype*)data_->cpu_data();
 }
 
 template <typename Dtype>
 void Blob<Dtype>::set_cpu_data(Dtype* data) {
-  CHECK(data);
+  ACHECK(data);
   // Make sure CPU and GPU sizes remain equal
   size_t size = count_ * sizeof(Dtype);
   if (data_->size() != size) {
@@ -150,13 +150,13 @@ void Blob<Dtype>::set_cpu_data(Dtype* data) {
 
 template <typename Dtype>
 const Dtype* Blob<Dtype>::gpu_data() const {
-  CHECK(data_);
+  ACHECK(data_);
   return (const Dtype*)data_->gpu_data();
 }
 
 template <typename Dtype>
 void Blob<Dtype>::set_gpu_data(Dtype* data) {
-  CHECK(data);
+  ACHECK(data);
   // Make sure CPU and GPU sizes remain equal
   size_t size = count_ * sizeof(Dtype);
   if (data_->size() != size) {
@@ -167,13 +167,13 @@ void Blob<Dtype>::set_gpu_data(Dtype* data) {
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_cpu_data() {
-  CHECK(data_);
+  ACHECK(data_);
   return static_cast<Dtype*>(data_->mutable_cpu_data());
 }
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_gpu_data() {
-  CHECK(data_);
+  ACHECK(data_);
   return static_cast<Dtype*>(data_->mutable_gpu_data());
 }
 

--- a/modules/perception/base/blob.h
+++ b/modules/perception/base/blob.h
@@ -274,7 +274,7 @@ class Blob {
   }
 
   inline const std::shared_ptr<SyncedMemory>& data() const {
-    CHECK(data_);
+    ACHECK(data_);
     return data_;
   }
 

--- a/modules/perception/base/syncedmem.cc
+++ b/modules/perception/base/syncedmem.cc
@@ -177,7 +177,7 @@ const void* SyncedMemory::cpu_data() {
 
 void SyncedMemory::set_cpu_data(void* data) {
   check_device();
-  CHECK(data);
+  ACHECK(data);
   if (own_cpu_data_) {
     PerceptionFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);
   }
@@ -200,7 +200,7 @@ const void* SyncedMemory::gpu_data() {
 void SyncedMemory::set_gpu_data(void* data) {
   check_device();
 #ifndef PERCEPTION_CPU_ONLY
-  CHECK(data);
+  ACHECK(data);
   if (own_gpu_data_) {
     BASE_CUDA_CHECK(cudaFree(gpu_ptr_));
   }

--- a/modules/perception/base/syncedmem.h
+++ b/modules/perception/base/syncedmem.h
@@ -77,7 +77,7 @@ inline void PerceptionMallocHost(void** ptr, size_t size, bool use_cuda) {
   }
 #endif
   *ptr = malloc(size);
-  CHECK(*ptr) << "host allocation of size " << size << " failed";
+  ACHECK(*ptr) << "host allocation of size " << size << " failed";
 }
 
 inline void PerceptionFreeHost(void* ptr, bool use_cuda) {

--- a/modules/perception/camera/app/lane_camera_perception.cc
+++ b/modules/perception/camera/app/lane_camera_perception.cc
@@ -50,9 +50,9 @@ bool LaneCameraPerception::Init(const CameraPerceptionInitOptions &options) {
   std::string config_file =
       GetAbsolutePath(options.root_dir, options.conf_file);
   config_file = GetAbsolutePath(work_root, config_file);
-  CHECK(cyber::common::GetProtoFromFile(config_file, &perception_param_))
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &perception_param_))
       << "Read config failed: " << config_file;
-  CHECK(inference::CudaUtil::set_device_id(perception_param_.gpu_id()));
+  ACHECK(inference::CudaUtil::set_device_id(perception_param_.gpu_id()));
 
   lane_calibration_working_sensor_name_ =
       options.lane_calibration_working_sensor_name;
@@ -76,7 +76,7 @@ void LaneCameraPerception::InitLane(
   for (int i = 0; i < perception_param.lane_param_size(); ++i) {
     // Initialize lane detector
     const auto &lane_param = perception_param.lane_param(i);
-    CHECK(lane_param.has_lane_detector_param())
+    ACHECK(lane_param.has_lane_detector_param())
         << "Failed to include lane_detector_param.";
     LaneDetectorInitOptions lane_detector_init_options;
     const auto &lane_detector_param = lane_param.lane_detector_param();
@@ -95,8 +95,8 @@ void LaneCameraPerception::InitLane(
     AINFO << "lane_detector_name: " << lane_detector_plugin_param.name();
     lane_detector_.reset(BaseLaneDetectorRegisterer::GetInstanceByName(
         lane_detector_plugin_param.name()));
-    CHECK(lane_detector_ != nullptr);
-    CHECK(lane_detector_->Init(lane_detector_init_options))
+    ACHECK(lane_detector_ != nullptr);
+    ACHECK(lane_detector_->Init(lane_detector_init_options))
         << "Failed to init: " << lane_detector_plugin_param.name();
     AINFO << "Detector: " << lane_detector_->Name();
 
@@ -115,8 +115,8 @@ void LaneCameraPerception::InitLane(
     lane_postprocessor_.reset(
         BaseLanePostprocessorRegisterer::GetInstanceByName(
             lane_postprocessor_param.name()));
-    CHECK(lane_postprocessor_ != nullptr);
-    CHECK(lane_postprocessor_->Init(postprocessor_init_options))
+    ACHECK(lane_postprocessor_ != nullptr);
+    ACHECK(lane_postprocessor_->Init(postprocessor_init_options))
         << "Failed to init: " << lane_postprocessor_param.name();
     AINFO << "lane_postprocessor: " << lane_postprocessor_->Name();
 
@@ -141,7 +141,7 @@ void LaneCameraPerception::InitCalibrationService(
     const std::string &work_root, const base::BaseCameraModelPtr model,
     const app::PerceptionParam &perception_param) {
   // Init calibration service
-  CHECK(perception_param.has_calibration_service_param())
+  ACHECK(perception_param.has_calibration_service_param())
       << "Failed to include calibration_service_param";
   {
     auto calibration_service_param =
@@ -159,8 +159,8 @@ void LaneCameraPerception::InitCalibrationService(
     calibration_service_.reset(
         BaseCalibrationServiceRegisterer::GetInstanceByName(
             calibration_service_param.plugin_param().name()));
-    CHECK(calibration_service_ != nullptr);
-    CHECK(calibration_service_->Init(calibration_service_init_options))
+    ACHECK(calibration_service_ != nullptr);
+    ACHECK(calibration_service_->Init(calibration_service_init_options))
         << "Failed to init " << calibration_service_param.plugin_param().name();
     AINFO << "Calibration service: " << calibration_service_->Name();
   }

--- a/modules/perception/camera/app/obstacle_camera_perception.cc
+++ b/modules/perception/camera/app/obstacle_camera_perception.cc
@@ -44,12 +44,12 @@ bool ObstacleCameraPerception::Init(
   std::string config_file =
       GetAbsolutePath(options.root_dir, options.conf_file);
   config_file = GetAbsolutePath(work_root, config_file);
-  CHECK(cyber::common::GetProtoFromFile(config_file, &perception_param_))
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &perception_param_))
       << "Read config failed: " << config_file;
-  CHECK(inference::CudaUtil::set_device_id(perception_param_.gpu_id()));
+  ACHECK(inference::CudaUtil::set_device_id(perception_param_.gpu_id()));
 
   // Init detector
-  CHECK(perception_param_.detector_param_size() > 0)
+  ACHECK(perception_param_.detector_param_size() > 0)
       << "Failed to init detector.";
   // Init detector
   base::BaseCameraModelPtr model;
@@ -73,14 +73,14 @@ bool ObstacleCameraPerception::Init(
     name_detector_map_.insert(
         std::pair<std::string, std::shared_ptr<BaseObstacleDetector>>(
             detector_param.camera_name(), detector_ptr));
-    CHECK(name_detector_map_.at(detector_param.camera_name()) != nullptr);
-    CHECK(name_detector_map_.at(detector_param.camera_name())
+    ACHECK(name_detector_map_.at(detector_param.camera_name()) != nullptr);
+    ACHECK(name_detector_map_.at(detector_param.camera_name())
               ->Init(detector_init_options))
         << "Failed to init: " << plugin_param.name();
   }
 
   // Init tracker
-  CHECK(perception_param_.has_tracker_param()) << "Failed to init tracker.";
+  ACHECK(perception_param_.has_tracker_param()) << "Failed to init tracker.";
   {
     ObstacleTrackerInitOptions tracker_init_options;
     tracker_init_options.image_width = static_cast<float>(model->get_width());
@@ -92,13 +92,13 @@ bool ObstacleCameraPerception::Init(
     tracker_init_options.conf_file = plugin_param.config_file();
     tracker_.reset(
         BaseObstacleTrackerRegisterer::GetInstanceByName(plugin_param.name()));
-    CHECK(tracker_ != nullptr);
-    CHECK(tracker_->Init(tracker_init_options))
+    ACHECK(tracker_ != nullptr);
+    ACHECK(tracker_->Init(tracker_init_options))
         << "Failed to init: " << plugin_param.name();
   }
 
   // Init transformer
-  CHECK(perception_param_.has_transformer_param())
+  ACHECK(perception_param_.has_transformer_param())
       << "Failed to init transformer.";
   {
     ObstacleTransformerInitOptions transformer_init_options;
@@ -108,13 +108,13 @@ bool ObstacleCameraPerception::Init(
     transformer_init_options.conf_file = plugin_param.config_file();
     transformer_.reset(BaseObstacleTransformerRegisterer::GetInstanceByName(
         plugin_param.name()));
-    CHECK(transformer_ != nullptr);
-    CHECK(transformer_->Init(transformer_init_options))
+    ACHECK(transformer_ != nullptr);
+    ACHECK(transformer_->Init(transformer_init_options))
         << "Failed to init: " << plugin_param.name();
   }
 
   // Init obstacle postprocessor
-  CHECK(perception_param_.has_postprocessor_param())
+  ACHECK(perception_param_.has_postprocessor_param())
       << "Failed to init obstacle postprocessor.";
   {
     ObstaclePostprocessorInitOptions obstacle_postprocessor_init_options;
@@ -125,8 +125,8 @@ bool ObstacleCameraPerception::Init(
     obstacle_postprocessor_.reset(
         BaseObstaclePostprocessorRegisterer::GetInstanceByName(
             plugin_param.name()));
-    CHECK(obstacle_postprocessor_ != nullptr);
-    CHECK(obstacle_postprocessor_->Init(obstacle_postprocessor_init_options))
+    ACHECK(obstacle_postprocessor_ != nullptr);
+    ACHECK(obstacle_postprocessor_->Init(obstacle_postprocessor_init_options))
         << "Failed to init: " << plugin_param.name();
   }
 
@@ -141,8 +141,8 @@ bool ObstacleCameraPerception::Init(
     init_options.conf_file = plugin_param.config_file();
     extractor_.reset(
         BaseFeatureExtractorRegisterer::GetInstanceByName(plugin_param.name()));
-    CHECK(extractor_ != nullptr);
-    CHECK(extractor_->Init(init_options))
+    ACHECK(extractor_ != nullptr);
+    ACHECK(extractor_->Init(init_options))
         << "Failed to init: " << plugin_param.name();
   }
 
@@ -175,7 +175,7 @@ bool ObstacleCameraPerception::Init(
         perception_param_.object_template_param().plugin_param();
     init_options.root_dir = GetAbsolutePath(work_root, plugin_param.root_dir());
     init_options.conf_file = plugin_param.config_file();
-    CHECK(ObjectTemplateManager::Instance()->Init(init_options));
+    ACHECK(ObjectTemplateManager::Instance()->Init(init_options));
   }
   return true;
 }
@@ -189,7 +189,7 @@ void ObstacleCameraPerception::InitLane(
   for (int i = 0; i < perception_param.lane_param_size(); ++i) {
     // Initialize lane detector
     const auto &lane_param = perception_param.lane_param(i);
-    CHECK(lane_param.has_lane_detector_param())
+    ACHECK(lane_param.has_lane_detector_param())
         << "Failed to include lane_detector_param.";
     LaneDetectorInitOptions lane_detector_init_options;
     const auto &lane_detector_param = lane_param.lane_detector_param();
@@ -206,8 +206,8 @@ void ObstacleCameraPerception::InitLane(
     AINFO << "lane_detector_name: " << lane_detector_plugin_param.name();
     lane_detector_.reset(BaseLaneDetectorRegisterer::GetInstanceByName(
         lane_detector_plugin_param.name()));
-    CHECK(lane_detector_ != nullptr);
-    CHECK(lane_detector_->Init(lane_detector_init_options))
+    ACHECK(lane_detector_ != nullptr);
+    ACHECK(lane_detector_->Init(lane_detector_init_options))
         << "Failed to init: " << lane_detector_plugin_param.name();
     AINFO << "Detector: " << lane_detector_->Name();
 
@@ -226,8 +226,8 @@ void ObstacleCameraPerception::InitLane(
     lane_postprocessor_.reset(
         BaseLanePostprocessorRegisterer::GetInstanceByName(
             lane_postprocessor_param.name()));
-    CHECK(lane_postprocessor_ != nullptr);
-    CHECK(lane_postprocessor_->Init(postprocessor_init_options))
+    ACHECK(lane_postprocessor_ != nullptr);
+    ACHECK(lane_postprocessor_->Init(postprocessor_init_options))
         << "Failed to init: " << lane_postprocessor_param.name();
     AINFO << "lane_postprocessor: " << lane_postprocessor_->Name();
 
@@ -252,7 +252,7 @@ void ObstacleCameraPerception::InitCalibrationService(
     const std::string &work_root, const base::BaseCameraModelPtr model,
     const app::PerceptionParam &perception_param) {
   // Init calibration service
-  CHECK(perception_param.has_calibration_service_param())
+  ACHECK(perception_param.has_calibration_service_param())
       << "Failed to include calibration_service_param.";
   {
     auto calibration_service_param =
@@ -270,8 +270,8 @@ void ObstacleCameraPerception::InitCalibrationService(
     calibration_service_.reset(
         BaseCalibrationServiceRegisterer::GetInstanceByName(
             calibration_service_param.plugin_param().name()));
-    CHECK(calibration_service_ != nullptr);
-    CHECK(calibration_service_->Init(calibration_service_init_options))
+    ACHECK(calibration_service_ != nullptr);
+    ACHECK(calibration_service_->Init(calibration_service_init_options))
         << "Failed to init: "
         << calibration_service_param.plugin_param().name();
     AINFO << "calibration_service: " << calibration_service_->Name();

--- a/modules/perception/camera/app/obstacle_camera_perception.cc
+++ b/modules/perception/camera/app/obstacle_camera_perception.cc
@@ -75,7 +75,7 @@ bool ObstacleCameraPerception::Init(
             detector_param.camera_name(), detector_ptr));
     ACHECK(name_detector_map_.at(detector_param.camera_name()) != nullptr);
     ACHECK(name_detector_map_.at(detector_param.camera_name())
-              ->Init(detector_init_options))
+               ->Init(detector_init_options))
         << "Failed to init: " << plugin_param.name();
   }
 

--- a/modules/perception/camera/app/traffic_light_camera_perception.cc
+++ b/modules/perception/camera/app/traffic_light_camera_perception.cc
@@ -51,7 +51,7 @@ bool TrafficLightCameraPerception::Init(
   init_options.gpu_id = tl_param_.gpu_id();
   detector_.reset(BaseTrafficLightDetectorRegisterer::GetInstanceByName(
       plugin_param.name()));
-  CHECK(detector_ != nullptr);
+  ACHECK(detector_ != nullptr);
   if (!detector_->Init(init_options)) {
     AERROR << "tl detector init failed";
     return false;
@@ -63,7 +63,7 @@ bool TrafficLightCameraPerception::Init(
   init_options.gpu_id = tl_param_.gpu_id();
   recognizer_.reset(BaseTrafficLightDetectorRegisterer::GetInstanceByName(
       plugin_param.name()));
-  CHECK(recognizer_ != nullptr);
+  ACHECK(recognizer_ != nullptr);
   if (!recognizer_->Init(init_options)) {
     AERROR << "tl recognizer init failed";
     return false;
@@ -76,7 +76,7 @@ bool TrafficLightCameraPerception::Init(
   tracker_init_options.conf_file = tracker_plugin_param.config_file();
   tracker_.reset(BaseTrafficLightTrackerRegisterer::GetInstanceByName(
       tracker_plugin_param.name()));
-  CHECK(tracker_ != nullptr);
+  ACHECK(tracker_ != nullptr);
   AINFO << tracker_init_options.root_dir << " "
         << tracker_init_options.conf_file;
   if (!tracker_->Init(tracker_init_options)) {

--- a/modules/perception/camera/common/camera_ground_plane.cc
+++ b/modules/perception/camera/common/camera_ground_plane.cc
@@ -266,8 +266,8 @@ bool CameraGroundPlaneDetector::DetetGround(float pitch, float camera_height,
       GetGround3FromPitchHeight(k_mat, baseline_, ph[0], ph[1], &ground3);
       FillGroundModel(ground3);
     } else {
-      CHECK(fabs(pitch) < params_.max_tilt_angle);
-      CHECK(camera_height < params_.max_camera_ground_height);
+      ACHECK(fabs(pitch) < params_.max_tilt_angle);
+      ACHECK(camera_height < params_.max_camera_ground_height);
       CHECK_GT(camera_height, 0.f);
       GetGround3FromPitchHeight(k_mat, baseline_, pitch, camera_height,
                                 &ground3);

--- a/modules/perception/camera/common/object_template_manager.cc
+++ b/modules/perception/camera/common/object_template_manager.cc
@@ -64,20 +64,20 @@ bool ObjectTemplateManager::Init(
     return false;
   }
 
-  CHECK(proto.has_max_dim_change_ratio());
+  ACHECK(proto.has_max_dim_change_ratio());
 
-  CHECK(proto.has_unknown());
-  CHECK(proto.has_unknown_movable());
-  CHECK(proto.has_unknown_unmovable());
-  CHECK(proto.has_car());
-  CHECK(proto.has_van());
-  CHECK(proto.has_truck());
-  CHECK(proto.has_bus());
-  CHECK(proto.has_cyclist());
-  CHECK(proto.has_motorcyclist());
-  CHECK(proto.has_tricyclist());
-  CHECK(proto.has_pedestrian());
-  CHECK(proto.has_trafficcone());
+  ACHECK(proto.has_unknown());
+  ACHECK(proto.has_unknown_movable());
+  ACHECK(proto.has_unknown_unmovable());
+  ACHECK(proto.has_car());
+  ACHECK(proto.has_van());
+  ACHECK(proto.has_truck());
+  ACHECK(proto.has_bus());
+  ACHECK(proto.has_cyclist());
+  ACHECK(proto.has_motorcyclist());
+  ACHECK(proto.has_tricyclist());
+  ACHECK(proto.has_pedestrian());
+  ACHECK(proto.has_trafficcone());
 
   CHECK_LE(proto.car().dim_size(), 3);
   CHECK_LE(proto.van().dim_size(), 3);
@@ -89,18 +89,18 @@ bool ObjectTemplateManager::Init(
   CHECK_LE(proto.pedestrian().dim_size(), 3);
   CHECK_LE(proto.trafficcone().dim_size(), 3);
 
-  CHECK(proto.unknown().has_speed_limit());
-  CHECK(proto.unknown_movable().has_speed_limit());
-  CHECK(proto.unknown_unmovable().has_speed_limit());
-  CHECK(proto.car().has_speed_limit());
-  CHECK(proto.van().has_speed_limit());
-  CHECK(proto.truck().has_speed_limit());
-  CHECK(proto.bus().has_speed_limit());
-  CHECK(proto.cyclist().has_speed_limit());
-  CHECK(proto.motorcyclist().has_speed_limit());
-  CHECK(proto.tricyclist().has_speed_limit());
-  CHECK(proto.pedestrian().has_speed_limit());
-  CHECK(proto.trafficcone().has_speed_limit());
+  ACHECK(proto.unknown().has_speed_limit());
+  ACHECK(proto.unknown_movable().has_speed_limit());
+  ACHECK(proto.unknown_unmovable().has_speed_limit());
+  ACHECK(proto.car().has_speed_limit());
+  ACHECK(proto.van().has_speed_limit());
+  ACHECK(proto.truck().has_speed_limit());
+  ACHECK(proto.bus().has_speed_limit());
+  ACHECK(proto.cyclist().has_speed_limit());
+  ACHECK(proto.motorcyclist().has_speed_limit());
+  ACHECK(proto.tricyclist().has_speed_limit());
+  ACHECK(proto.pedestrian().has_speed_limit());
+  ACHECK(proto.trafficcone().has_speed_limit());
 
   max_dim_change_ratio_ = proto.max_dim_change_ratio();
 
@@ -221,8 +221,8 @@ void ObjectTemplateManager::LoadVehMinMidMaxTemplates(
 // util for tmplt search
 float ObjectTemplateManager::Get3dDimensionSimilarity(const float *hwl1,
                                                       const float *hwl2) {
-  CHECK(hwl1 != nullptr);
-  CHECK(hwl2 != nullptr);
+  ACHECK(hwl1 != nullptr);
+  ACHECK(hwl2 != nullptr);
 
   float max_h = std::max(hwl1[0], hwl2[0]);
   float min_h = hwl1[0] + hwl2[0] - max_h;
@@ -241,8 +241,8 @@ float ObjectTemplateManager::Get3dDimensionSimilarity(const float *hwl1,
 // for general visual obj
 float ObjectTemplateManager::VehObjHwlBySearchTemplates(float *hwl, int *index,
                                                         bool *is_flip) {
-  CHECK(inited_);
-  CHECK(hwl != nullptr);
+  ACHECK(inited_);
+  ACHECK(hwl != nullptr);
 
   float hwl_flip[3] = {hwl[0], hwl[2], hwl[1]};
   float score_best = -FLT_MAX;

--- a/modules/perception/camera/common/object_template_manager.h
+++ b/modules/perception/camera/common/object_template_manager.h
@@ -53,47 +53,47 @@ class ObjectTemplateManager {
   float VehObjHwlBySearchTemplates(float *hwl, int *index = nullptr,
                                    bool *is_flip = nullptr);
   const int NrDimPerTmplt() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return nr_dim_per_tmplt_;
   }
   const std::vector<float> &VehHwl() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return veh_hwl_;
   }
   const std::map<TemplateIndex, int> &LookUpTableMinVolumeIndex() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return look_up_table_min_volume_index_;
   }
   const std::map<base::ObjectSubType, float> &TypeSpeedLimit() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return type_speed_limit_;
   }
   const std::vector<base::ObjectSubType> &TypeRefinedByTemplate() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return type_refined_by_template_;
   }
   const std::vector<base::ObjectSubType> &TypeRefinedByRef() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return type_refined_by_ref_;
   }
   const std::vector<base::ObjectSubType> &TypeCanBeRef() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return type_can_be_ref_;
   }
   const TemplateMap &MinTemplateHWL() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return min_template_hwl_;
   }
   const TemplateMap &MidTemplateHWL() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return mid_template_hwl_;
   }
   const TemplateMap &MaxTemplateHWL() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return max_template_hwl_;
   }
   const std::vector<TemplateMap> &TemplateHWL() {
-    CHECK(inited_);
+    ACHECK(inited_);
     return template_hwl_;
   }
 

--- a/modules/perception/camera/common/twod_threed_util.h
+++ b/modules/perception/camera/common/twod_threed_util.h
@@ -251,7 +251,7 @@ bool CheckXY(const T &x, const T &y, int width, int height) {
 template <typename T>
 void UpdateOffsetZ(T x_start, T z_start, T x_end, T z_end,
                    const std::pair<T, T> &range, T *z_offset) {
-  CHECK(range.first < range.second);
+  ACHECK(range.first < range.second);
   if (x_start > x_end) {
     std::swap(x_start, x_end);
     std::swap(z_start, z_end);
@@ -283,7 +283,7 @@ void GetDxDzForCenterFromGroundLineSeg(const LineSegment2D<T> &ls,
   const T Z_UNSTABLE_RATIO = static_cast<T>(0.3f);
 
   dx_dz[0] = dx_dz[1] = (T)0;
-  CHECK(ls.pt_start[0] < ls.pt_end[0]);
+  ACHECK(ls.pt_start[0] < ls.pt_end[0]);
   if (!CheckXY(ls.pt_start[0], ls.pt_start[1], width, height) ||
       !CheckXY(ls.pt_end[0], ls.pt_end[1], width, height)) {
     return;

--- a/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
+++ b/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
@@ -31,7 +31,7 @@ bool OnlineCalibrationService::Init(
   sensor_name_ = options.calibrator_working_sensor_name;
   // Init k_matrix
   auto &name_intrinsic_map = options.name_intrinsic_map;
-  CHECK(name_intrinsic_map.find(master_sensor_name_) !=
+  ACHECK(name_intrinsic_map.find(master_sensor_name_) !=
         name_intrinsic_map.end());
   CameraStatus camera_status;
   name_camera_status_map_.clear();
@@ -59,8 +59,8 @@ bool OnlineCalibrationService::Init(
       name_camera_status_map_[master_sensor_name_].k_matrix[5]);
   calibrator_.reset(
       BaseCalibratorRegisterer::GetInstanceByName(options.calibrator_method));
-  CHECK(calibrator_ != nullptr);
-  CHECK(calibrator_->Init(calibrator_init_options))
+  ACHECK(calibrator_ != nullptr);
+  ACHECK(calibrator_->Init(calibrator_init_options))
       << "Failed to init " << options.calibrator_method;
   return true;
 }
@@ -75,7 +75,7 @@ bool OnlineCalibrationService::QueryDepthOnGroundPlane(int x, int y,
   if (!is_service_ready_) {
     return false;
   }
-  CHECK(depth != nullptr);
+  ACHECK(depth != nullptr);
   double pixel[2] = {static_cast<double>(x), static_cast<double>(y)};
   double point[3] = {0};
 
@@ -97,7 +97,7 @@ bool OnlineCalibrationService::QueryPoint3dOnGroundPlane(
   if (!is_service_ready_) {
     return false;
   }
-  CHECK(point3d != nullptr);
+  ACHECK(point3d != nullptr);
   double pixel[2] = {static_cast<double>(x), static_cast<double>(y)};
   double point[3] = {0};
   auto iter = name_camera_status_map_.find(sensor_name_);
@@ -189,7 +189,7 @@ void OnlineCalibrationService::Update(CameraFrame *frame) {
         << " meter.";
   AINFO << "pitch_angle: " << iter->second.pitch_angle * 180.0 / M_PI
         << " degree.";
-  // CHECK(BuildIndex());
+  // ACHECK(BuildIndex());
   is_service_ready_ = true;
 }
 
@@ -205,8 +205,8 @@ void OnlineCalibrationService::SetCameraHeightAndPitch(
     auto iter_ground_height = name_camera_ground_height_map.find(iter->first);
     auto iter_pitch_angle_diff =
         name_camera_pitch_angle_diff_map.find(iter->first);
-    CHECK(iter_ground_height != name_camera_ground_height_map.end());
-    CHECK(iter_pitch_angle_diff != name_camera_pitch_angle_diff_map.end());
+    ACHECK(iter_ground_height != name_camera_ground_height_map.end());
+    ACHECK(iter_pitch_angle_diff != name_camera_pitch_angle_diff_map.end());
     // set camera status
     name_camera_status_map_[iter->first].camera_ground_height =
         iter_ground_height->second;

--- a/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
+++ b/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
@@ -32,7 +32,7 @@ bool OnlineCalibrationService::Init(
   // Init k_matrix
   auto &name_intrinsic_map = options.name_intrinsic_map;
   ACHECK(name_intrinsic_map.find(master_sensor_name_) !=
-        name_intrinsic_map.end());
+         name_intrinsic_map.end());
   CameraStatus camera_status;
   name_camera_status_map_.clear();
   for (auto iter = name_intrinsic_map.begin(); iter != name_intrinsic_map.end();

--- a/modules/perception/camera/lib/feature_extractor/tfe/external_feature_extractor.cc
+++ b/modules/perception/camera/lib/feature_extractor/tfe/external_feature_extractor.cc
@@ -33,7 +33,7 @@ using cyber::common::GetAbsolutePath;
 bool ExternalFeatureExtractor::Init(
     const FeatureExtractorInitOptions &options) {
   std::string efx_config = GetAbsolutePath(options.root_dir, options.conf_file);
-  CHECK(cyber::common::GetProtoFromFile(efx_config, &param_))
+  ACHECK(cyber::common::GetProtoFromFile(efx_config, &param_))
       << "Read config failed: " << efx_config;
   AINFO << "Load config Success: " << param_.ShortDebugString();
   std::string proto_file =
@@ -51,14 +51,14 @@ bool ExternalFeatureExtractor::Init(
   inference_.reset(inference::CreateInferenceByName(
       model_type, proto_file, weight_file, output_names, input_names,
       options.root_dir));
-  CHECK(nullptr != inference_) << "Failed to init CNNAdapter";
+  ACHECK(nullptr != inference_) << "Failed to init CNNAdapter";
   gpu_id_ = GlobalConfig::Instance()->track_feature_gpu_id;
   inference_->set_gpu_id(gpu_id_);
   std::vector<int> shape = {1, height_, width_, 3};
   std::map<std::string, std::vector<int>> shape_map{
       {param_.input_blob(), shape}};
 
-  CHECK(inference_->Init(shape_map));
+  ACHECK(inference_->Init(shape_map));
   inference_->Infer();
   InitFeatureExtractor(options.root_dir);
   image_.reset(new base::Image8U(height_, width_, base::Color::BGR));

--- a/modules/perception/camera/lib/feature_extractor/tfe/project_feature.cc
+++ b/modules/perception/camera/lib/feature_extractor/tfe/project_feature.cc
@@ -32,7 +32,7 @@ using cyber::common::GetAbsolutePath;
 
 bool ProjectFeature::Init(const FeatureExtractorInitOptions &options) {
   std::string efx_config = GetAbsolutePath(options.root_dir, options.conf_file);
-  CHECK(cyber::common::GetProtoFromFile(efx_config, &param_))
+  ACHECK(cyber::common::GetProtoFromFile(efx_config, &param_))
       << "Read config failed: " << efx_config;
   AINFO << "Load config Success: " << param_.ShortDebugString();
   std::string proto_file =
@@ -48,7 +48,7 @@ bool ProjectFeature::Init(const FeatureExtractorInitOptions &options) {
   inference_.reset(inference::CreateInferenceByName(
       model_type, proto_file, weight_file, output_names, input_names,
       options.root_dir));
-  CHECK(nullptr != inference_) << "Failed to init CNNAdapter";
+  ACHECK(nullptr != inference_) << "Failed to init CNNAdapter";
   gpu_id_ = GlobalConfig::Instance()->track_feature_gpu_id;
   inference_->set_gpu_id(gpu_id_);
   inference_->set_max_batch_size(100);
@@ -56,7 +56,7 @@ bool ProjectFeature::Init(const FeatureExtractorInitOptions &options) {
   std::map<std::string, std::vector<int>> shape_map{
       {param_.input_blob(), shape}};
 
-  CHECK(inference_->Init(shape_map));
+  ACHECK(inference_->Init(shape_map));
   inference_->Infer();
   return true;
 }

--- a/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
@@ -61,8 +61,8 @@ bool DarkSCNNLaneDetector::Init(const LaneDetectorInitOptions &options) {
     input_height_ = static_cast<uint16_t>(base_camera_model_->get_height());
     input_width_ = static_cast<uint16_t>(base_camera_model_->get_width());
   }
-  CHECK(input_width_ > 0) << "input width should be more than 0";
-  CHECK(input_height_ > 0) << "input height should be more than 0";
+  ACHECK(input_width_ > 0) << "input width should be more than 0";
+  ACHECK(input_height_ > 0) << "input height should be more than 0";
 
   AINFO << "input_height: " << input_height_;
   AINFO << "input_width: " << input_width_;
@@ -122,11 +122,11 @@ bool DarkSCNNLaneDetector::Init(const LaneDetectorInitOptions &options) {
   cnnadapter_lane_.reset(
       inference::CreateInferenceByName(model_type, proto_file, weight_file,
                                        net_outputs_, net_inputs_, model_root));
-  CHECK(cnnadapter_lane_ != nullptr);
+  ACHECK(cnnadapter_lane_ != nullptr);
 
   cnnadapter_lane_->set_gpu_id(options.gpu_id);
-  CHECK(resize_width_ > 0) << "resize width should be more than 0";
-  CHECK(resize_height_ > 0) << "resize height should be more than 0";
+  ACHECK(resize_width_ > 0) << "resize width should be more than 0";
+  ACHECK(resize_height_ > 0) << "resize height should be more than 0";
   std::vector<int> shape = {1, 3, resize_height_, resize_width_};
   std::map<std::string, std::vector<int>> input_reshape{
       {net_inputs_[0], shape}};

--- a/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
@@ -55,8 +55,8 @@ bool DenselineLaneDetector::Init(const LaneDetectorInitOptions &options) {
     input_height_ = static_cast<uint16_t>(base_camera_model_->get_height());
     input_width_ = static_cast<uint16_t>(base_camera_model_->get_width());
   }
-  CHECK(input_width_ > 0) << "input width should be more than 0";
-  CHECK(input_height_ > 0) << "input height should be more than 0";
+  ACHECK(input_width_ > 0) << "input width should be more than 0";
+  ACHECK(input_height_ > 0) << "input height should be more than 0";
 
   AINFO << "input_height: " << input_height_;
   AINFO << "input_width: " << input_width_;
@@ -111,13 +111,13 @@ bool DenselineLaneDetector::Init(const LaneDetectorInitOptions &options) {
   rt_net_.reset(inference::CreateInferenceByName(model_type, proto_file,
                                                  weight_file, net_outputs_,
                                                  net_inputs_, model_root));
-  CHECK(rt_net_ != nullptr);
+  ACHECK(rt_net_ != nullptr);
   rt_net_->set_gpu_id(options.gpu_id);
 
   resize_height_ = static_cast<uint16_t>(crop_height_ * image_scale_);
   resize_width_ = static_cast<uint16_t>(crop_width_ * image_scale_);
-  CHECK(resize_width_ > 0) << "resize width should be more than 0";
-  CHECK(resize_height_ > 0) << "resize height should be more than 0";
+  ACHECK(resize_width_ > 0) << "resize width should be more than 0";
+  ACHECK(resize_height_ > 0) << "resize height should be more than 0";
 
   std::vector<int> shape = {1, 3, resize_height_, resize_width_};
 

--- a/modules/perception/camera/lib/motion/plane_motion.cc
+++ b/modules/perception/camera/lib/motion/plane_motion.cc
@@ -63,8 +63,8 @@ void PlaneMotion::generate_motion_matrix(base::VehicleStatus *vehicledata) {
 
     motion_2d.block(0, 0, 2, 2) = rot2d.toRotationMatrix().transpose();
     motion_2d.block(0, 2, 2, 1) = -rot2d.toRotationMatrix().transpose() * trans;
-    CHECK(vehicledata->motion.rows() == motion_2d.rows());
-    CHECK(vehicledata->motion.cols() == motion_2d.cols());
+    ACHECK(vehicledata->motion.rows() == motion_2d.rows());
+    ACHECK(vehicledata->motion.cols() == motion_2d.cols());
     vehicledata->motion = motion_2d;
   } else {
     base::MotionType motion_3d = base::MotionType::Identity();
@@ -90,8 +90,8 @@ void PlaneMotion::generate_motion_matrix(base::VehicleStatus *vehicledata) {
 
     motion_3d.block(0, 0, 3, 3) = rot3d.transpose();
     motion_3d.block(0, 3, 3, 1) = -rot3d.transpose() * trans;
-    CHECK(vehicledata->motion.rows() == motion_3d.rows());
-    CHECK(vehicledata->motion.cols() == motion_3d.cols());
+    ACHECK(vehicledata->motion.rows() == motion_3d.rows());
+    ACHECK(vehicledata->motion.cols() == motion_3d.cols());
     vehicledata->motion = motion_3d;
   }
 }

--- a/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.cc
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.cc
@@ -254,7 +254,7 @@ bool YoloObstacleDetector::Init(const ObstacleDetectorInitOptions &options) {
   BASE_CUDA_CHECK(cudaStreamCreate(&stream_));
 
   base_camera_model_ = options.base_camera_model;
-  CHECK(base_camera_model_ != nullptr) << "base_camera_model is nullptr!";
+  ACHECK(base_camera_model_ != nullptr) << "base_camera_model is nullptr!";
   std::string config_path =
       GetAbsolutePath(options.root_dir, options.conf_file);
   if (!cyber::common::GetProtoFromFile(config_path, &yolo_param_)) {
@@ -283,7 +283,7 @@ bool YoloObstacleDetector::Init(const ObstacleDetectorInitOptions &options) {
   if (!LoadExpand(expand_file, &expands_)) {
     return false;
   }
-  CHECK(expands_.size() == types_.size());
+  ACHECK(expands_.size() == types_.size());
   if (!InitNet(yolo_param_, model_root)) {
     return false;
   }

--- a/modules/perception/camera/lib/obstacle/tracker/omt/omt_obstacle_tracker.cc
+++ b/modules/perception/camera/lib/obstacle/tracker/omt/omt_obstacle_tracker.cc
@@ -58,7 +58,7 @@ bool OMTObstacleTracker::Init(const ObstacleTrackerInitOptions &options) {
   std::string type_change_cost =
       GetAbsolutePath(options.root_dir, omt_param_.type_change_cost());
   std::ifstream fin(type_change_cost);
-  CHECK(fin.is_open());
+  ACHECK(fin.is_open());
   kTypeAssociatedCost_.clear();
   int n_type = static_cast<int>(base::ObjectSubType::MAX_OBJECT_TYPE);
   for (int i = 0; i < n_type; ++i) {

--- a/modules/perception/camera/test/camera_app_obstacle_camera_perception_test.cc
+++ b/modules/perception/camera/test/camera_app_obstacle_camera_perception_test.cc
@@ -106,7 +106,7 @@ TEST(ObstacleCameraPerceptionTest, perception_test) {
   data_options.device_id = 0;
   data_options.sensor_name = "front_6mm";
   DataProvider data_provider;
-  CHECK(data_provider.Init(data_options));
+  ACHECK(data_provider.Init(data_options));
   for (auto &frame : frame_list) {
     frame.track_feature_blob.reset(new base::Blob<float>());
     frame.data_provider = &data_provider;

--- a/modules/perception/camera/test/camera_lib_lane_detector_darkscnn_lane_detector_test.cc
+++ b/modules/perception/camera/test/camera_lib_lane_detector_darkscnn_lane_detector_test.cc
@@ -33,7 +33,7 @@ TEST(darkSCNNLaneDetector, darkSCNN_lane_detector_test) {
   cv::Mat img = cv::imread(
       "/apollo/modules/perception/testdata/"
       "camera/lib/lane/detector/darkSCNN/data/test.jpg");
-  CHECK(!img.empty()) << "input image is empty.";
+  ACHECK(!img.empty()) << "input image is empty.";
 
   std::cout << img.rows << std::endl;
 

--- a/modules/perception/camera/test/camera_lib_lane_detector_denseline_lane_detector_test.cc
+++ b/modules/perception/camera/test/camera_lib_lane_detector_denseline_lane_detector_test.cc
@@ -33,7 +33,7 @@ TEST(DenselineLaneDetector, denseline_lane_detector_test) {
   cv::Mat img = cv::imread(
       "/apollo/modules/perception/testdata/"
       "camera/lib/lane/detector/denseline/data/test.jpg");
-  CHECK(!img.empty()) << "input image is empty.";
+  ACHECK(!img.empty()) << "input image is empty.";
 
   std::cout << img.rows << std::endl;
 

--- a/modules/perception/camera/test/camera_lib_lane_postprocessor_darkscnn_lane_postprocessor_test.cc
+++ b/modules/perception/camera/test/camera_lib_lane_postprocessor_darkscnn_lane_postprocessor_test.cc
@@ -145,7 +145,7 @@ TEST(darkSCNNLanePostprocessor, camera_lane_postprocessor_point_test) {
   calibration_service_init_options.image_width =
       static_cast<int>(model.get_width());
   OnlineCalibrationService calibration_service;
-  CHECK(calibration_service.Init(calibration_service_init_options));
+  ACHECK(calibration_service.Init(calibration_service_init_options));
 
   std::map<std::string, float> name_camera_ground_height_map;
   std::map<std::string, float> name_camera_pitch_angle_diff_map;
@@ -214,7 +214,7 @@ TEST(darkSCNNLanePostprocessor, camera_lane_postprocessor_point_test) {
         "darkSCNN/data/test_%d.jpg",
         i);
     cv::Mat img = cv::imread(impath);
-    CHECK(!img.empty()) << "input image is empty.";
+    ACHECK(!img.empty()) << "input image is empty.";
     int size = img.cols * img.rows * img.channels();
     img_gpu_data.reset(new base::SyncedMemory(size, true));
     memcpy(img_gpu_data->mutable_cpu_data(), img.data, size * sizeof(uint8_t));

--- a/modules/perception/camera/test/camera_lib_lane_postprocessor_denseline_lane_postprocessor_test.cc
+++ b/modules/perception/camera/test/camera_lib_lane_postprocessor_denseline_lane_postprocessor_test.cc
@@ -86,7 +86,7 @@ TEST(DenselineLanePostprocessor, camera_lane_postprocessor_point_test) {
   calibration_service_init_options.image_width =
       static_cast<int>(model.get_width());
   OnlineCalibrationService calibration_service;
-  CHECK(calibration_service.Init(calibration_service_init_options));
+  ACHECK(calibration_service.Init(calibration_service_init_options));
 
   std::map<std::string, float> name_camera_ground_height_map;
   std::map<std::string, float> name_camera_pitch_angle_diff_map;
@@ -110,7 +110,7 @@ TEST(DenselineLanePostprocessor, camera_lane_postprocessor_point_test) {
         "denseline/data/test_%d.jpg",
         i);
     cv::Mat img = cv::imread(impath);
-    CHECK(!img.empty()) << "input image is empty.";
+    ACHECK(!img.empty()) << "input image is empty.";
     int size = img.cols * img.rows * img.channels();
     img_gpu_data.reset(new base::SyncedMemory(size, true));
     memcpy(img_gpu_data->mutable_cpu_data(), img.data, size * sizeof(uint8_t));

--- a/modules/perception/camera/test/camera_lib_obstacle_detector_yolo_yolo_obstacle_detector_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_detector_yolo_yolo_obstacle_detector_test.cc
@@ -55,7 +55,7 @@ TEST(YoloCameraDetectorTest, demo_test) {
   dp_init_options.device_id = 0;
   ACHECK(frame.data_provider->Init(dp_init_options));
   ACHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
-                                           image.gpu_data(), "bgr8"));
+                                            image.gpu_data(), "bgr8"));
 
   ObstacleDetectorInitOptions init_options;
   init_options.root_dir =

--- a/modules/perception/camera/test/camera_lib_obstacle_detector_yolo_yolo_obstacle_detector_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_detector_yolo_yolo_obstacle_detector_test.cc
@@ -33,7 +33,7 @@ TEST(YoloCameraDetectorTest, demo_test) {
   cv::Mat cv_img = cv::imread(
       "/apollo/modules/perception/testdata/"
       "camera/lib/obstacle/detector/yolo/img/test.jpg");
-  CHECK(!cv_img.empty()) << "image is empty.";
+  ACHECK(!cv_img.empty()) << "image is empty.";
 
   base::Image8U image(cv_img.rows, cv_img.cols, base::Color::BGR);
 
@@ -53,8 +53,8 @@ TEST(YoloCameraDetectorTest, demo_test) {
   dp_init_options.image_height = cv_img.rows;
   dp_init_options.image_width = cv_img.cols;
   dp_init_options.device_id = 0;
-  CHECK(frame.data_provider->Init(dp_init_options));
-  CHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
+  ACHECK(frame.data_provider->Init(dp_init_options));
+  ACHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
                                            image.gpu_data(), "bgr8"));
 
   ObstacleDetectorInitOptions init_options;

--- a/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_frame_list_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_frame_list_test.cc
@@ -28,7 +28,7 @@ TEST(PatchIndicatorTest, PatchIndicator_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   PatchIndicator p1;
   EXPECT_EQ(p1.frame_id, -1);
@@ -51,7 +51,7 @@ TEST(SimilarMapTest, SimilarMap_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   SimilarMap similar_map;
   ASSERT_FALSE(similar_map.Init(0));
@@ -94,7 +94,7 @@ TEST(FrameListTest, FrameList_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   FrameList frame_list;
   ASSERT_EQ(frame_list.Size(), 0);

--- a/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_omt_obstacle_tracker_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_omt_obstacle_tracker_test.cc
@@ -243,7 +243,7 @@ TEST(FusionObstacleTrackerTest, FusionObstacleTracker_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   // Init camera list
   const std::vector<std::string> camera_names =
@@ -260,7 +260,7 @@ TEST(FusionObstacleTrackerTest, FusionObstacleTracker_test) {
 
   for (int i = 0; i < camera_names.size(); i++) {
     data_options.sensor_name = camera_names[i];
-    CHECK(data_providers[i].Init(data_options));
+    ACHECK(data_providers[i].Init(data_options));
     name_provider_map.insert(std::pair<std::string, DataProvider *>(
         camera_names[i], &data_providers[i]));
     AINFO << "Init data_provider for " << camera_names[i];

--- a/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_reference_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_reference_test.cc
@@ -34,7 +34,7 @@ TEST(RefTest, update_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   ObstacleReference ref;
   omt::OmtParam omt_param;
@@ -42,7 +42,7 @@ TEST(RefTest, update_test) {
       "/apollo/modules/perception/testdata/"
       "camera/lib/obstacle/tracker/omt/data/models/omt_obstacle_tracker",
       "config.pt");
-  CHECK(apollo::cyber::common::GetProtoFromFile(omt_config, &omt_param));
+  ACHECK(apollo::cyber::common::GetProtoFromFile(omt_config, &omt_param));
   ref.Init(omt_param.reference(), 1920.0f, 1080.0f);
   std::string sensor_name = "onsemi_obstacle";
   DataProvider provider;
@@ -115,17 +115,17 @@ TEST(RefTest, update_test) {
   CHECK_EQ(ref.reference_[sensor_name].size(), 1);
   object->size << 0.6, 0.7, 1.5;
   ref.CorrectSize(&frame);
-  CHECK(Equal(1.38566f, object->size[2], 0.01f));
+  ACHECK(Equal(1.38566f, object->size[2], 0.01f));
   object->size << 4, 2, 0.8;
   ref.CorrectSize(&frame);
-  CHECK(Equal(1.38566f, object->size[2], 0.01f));
+  ACHECK(Equal(1.38566f, object->size[2], 0.01f));
 
   object->size << 5.6, 5.7, 1.5;
   ref.CorrectSize(&frame);
-  CHECK(Equal(1.68300f, object->size[2], 0.01f));
+  ACHECK(Equal(1.68300f, object->size[2], 0.01f));
   object->size << 4, 2, 4;
   ref.CorrectSize(&frame);
-  CHECK(Equal(1.68300f, object->size[2], 0.01f));
+  ACHECK(Equal(1.68300f, object->size[2], 0.01f));
 }
 }  // namespace camera
 }  // namespace perception

--- a/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_target_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_tracker_omt_target_test.cc
@@ -35,7 +35,7 @@ TEST(TargetTest, target_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   omt::OmtParam omt_param;
   std::string omt_config = cyber::common::GetAbsolutePath(
@@ -202,7 +202,7 @@ TEST(TargetTest, clapping_velocity_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   omt::OmtParam omt_param;
   std::string omt_config = cyber::common::GetAbsolutePath(

--- a/modules/perception/camera/test/camera_lib_obstacle_transformer_multicue_multicue_obstacle_transformer_test.cc
+++ b/modules/perception/camera/test/camera_lib_obstacle_transformer_multicue_multicue_obstacle_transformer_test.cc
@@ -33,7 +33,7 @@ TEST(MultiCueObstacleTransformerTest, multicue_obstacle_transformer_test) {
       "/apollo/modules/perception/testdata/"
       "camera/app/data/perception/camera/common/object_template/";
   object_template_init_options.conf_file = "object_template.pt";
-  CHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
+  ACHECK(ObjectTemplateManager::Instance()->Init(object_template_init_options));
 
   inference::CudaUtil::set_device_id(0);
   cv::Mat cv_img = cv::imread(

--- a/modules/perception/camera/tools/lane_detection/lane_denseline_eval.cc
+++ b/modules/perception/camera/tools/lane_detection/lane_denseline_eval.cc
@@ -106,7 +106,7 @@ int lane_postprocessor_eval() {
     // Image data initialized
     CameraFrame frame;
     cv::Mat img = cv::imread(impath);
-    CHECK(!img.empty()) << "input image is empty.";
+    ACHECK(!img.empty()) << "input image is empty.";
     std::shared_ptr<base::SyncedMemory> img_gpu_data;
     int size = img.cols * img.rows * img.channels();
     img_gpu_data.reset(new base::SyncedMemory(size, true));
@@ -145,7 +145,7 @@ int lane_postprocessor_eval() {
     calibration_service.reset(
         BaseCalibrationServiceRegisterer::GetInstanceByName(
             "OnlineCalibration"));
-    CHECK(calibration_service->Init(calibration_service_init_options));
+    ACHECK(calibration_service->Init(calibration_service_init_options));
 
     std::map<std::string, float> name_camera_ground_height_map;
     std::map<std::string, float> name_camera_pitch_angle_diff_map;

--- a/modules/perception/camera/tools/obstacle_detection/obstacle_detection.cc
+++ b/modules/perception/camera/tools/obstacle_detection/obstacle_detection.cc
@@ -159,7 +159,7 @@ int main() {
   dp_init_options.device_id = 0;
 
   AINFO << "Init DataProvider ...";
-  CHECK(frame.data_provider->Init(dp_init_options));
+  ACHECK(frame.data_provider->Init(dp_init_options));
   AINFO << "Done!";
 
   ObstacleDetectorInitOptions init_options;
@@ -179,7 +179,7 @@ int main() {
       BaseObstacleDetectorRegisterer::GetInstanceByName(FLAGS_detector);
   if (FLAGS_pre_detected_dir == "") {
     CHECK_EQ(detector->Name(), FLAGS_detector);
-    CHECK(detector->Init(init_options));
+    ACHECK(detector->Init(init_options));
   }
   AINFO << "Done!";
 
@@ -191,7 +191,7 @@ int main() {
   BaseObstacleTransformer *transformer =
       BaseObstacleTransformerRegisterer::GetInstanceByName(FLAGS_transformer);
   CHECK_EQ(transformer->Name(), FLAGS_transformer);
-  CHECK(transformer->Init(transformer_init_options));
+  ACHECK(transformer->Init(transformer_init_options));
   AINFO << "Done!";
 
   ObstacleDetectorOptions options;
@@ -229,7 +229,7 @@ int main() {
                image.width_step());
       }
 
-      CHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
+      ACHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
                                                image.gpu_data(), "bgr8"));
 
       EXPECT_TRUE(detector->Detect(options, &frame));
@@ -267,7 +267,7 @@ int main() {
             cv::Point(static_cast<int>(box.xmax), static_cast<int>(box.ymax)),
             cv::Scalar(0, 0, 0), 8);
         float xmid = (box.xmin + box.xmax) / 2;
-        CHECK(area_id > 0 && area_id < 9);
+        ACHECK(area_id > 0 && area_id < 9);
         if (area_id & 1) {
           cv::rectangle(
               cv_img,

--- a/modules/perception/camera/tools/obstacle_detection/obstacle_detection.cc
+++ b/modules/perception/camera/tools/obstacle_detection/obstacle_detection.cc
@@ -230,7 +230,7 @@ int main() {
       }
 
       ACHECK(frame.data_provider->FillImageData(cv_img.rows, cv_img.cols,
-                                               image.gpu_data(), "bgr8"));
+                                                image.gpu_data(), "bgr8"));
 
       EXPECT_TRUE(detector->Detect(options, &frame));
     }

--- a/modules/perception/camera/tools/offline/offline_obstacle_pipeline.cc
+++ b/modules/perception/camera/tools/offline/offline_obstacle_pipeline.cc
@@ -107,7 +107,7 @@ int work() {
   init_option.conf_file = FLAGS_config_file;
   init_option.lane_calibration_working_sensor_name = FLAGS_base_camera_name;
   init_option.use_cyber_work_root = true;
-  CHECK(perception.Init(init_option));
+  ACHECK(perception.Init(init_option));
 
   // Init frame
   const int FRAME_CAPACITY = 20;
@@ -141,7 +141,7 @@ int work() {
 
   for (size_t i = 0; i < camera_names.size(); ++i) {
     data_options.sensor_name = camera_names[i];
-    CHECK(data_providers[i].Init(data_options));
+    ACHECK(data_providers[i].Init(data_options));
     name_provider_map.insert(std::pair<std::string, DataProvider *>(
         camera_names[i], &data_providers[i]));
     AINFO << "Init data_provider for " << camera_names[i];
@@ -162,12 +162,12 @@ int work() {
 
   // Init extrinsic
   TransformServer transform_server;
-  CHECK(transform_server.Init(camera_names, FLAGS_params_dir));
+  ACHECK(transform_server.Init(camera_names, FLAGS_params_dir));
   transform_server.print();
 
   // Init transform
   if (FLAGS_tf_file != "") {
-    CHECK(transform_server.LoadFromFile(FLAGS_tf_file));
+    ACHECK(transform_server.LoadFromFile(FLAGS_tf_file));
   }
 
   // Set calibration service camera_ground_height
@@ -212,7 +212,7 @@ int work() {
                                      name_camera_pitch_angle_diff_map,
                                      kDefaultPitchAngle);
   Visualizer visualize;
-  CHECK(visualize.Init(camera_names, &transform_server));
+  ACHECK(visualize.Init(camera_names, &transform_server));
   visualize.SetDirectory(FLAGS_visualize_dir);
   std::string line;
   std::string image_name;
@@ -304,7 +304,7 @@ int work() {
             << save_dir + "/" + image_name + FLAGS_image_ext;
     }
 
-    CHECK(perception.Perception(options, &frame));
+    ACHECK(perception.Perception(options, &frame));
     visualize.ShowResult(image, frame);
 
     save_dir = FLAGS_save_dir;

--- a/modules/perception/common/graph/gated_hungarian_bigraph_matcher.h
+++ b/modules/perception/common/graph/gated_hungarian_bigraph_matcher.h
@@ -175,12 +175,12 @@ void GatedHungarianMatcher<T>::MatchInit() {
       {OptimizeFlag::OPTMIN, std::greater<T>()},
   };
   auto find_ret = compare_fun_map.find(opt_flag_);
-  CHECK(find_ret != compare_fun_map.end());
+  ACHECK(find_ret != compare_fun_map.end());
   compare_fun_ = find_ret->second;
   is_valid_cost_ = std::bind1st(compare_fun_, cost_thresh_);
 
   /* check the validity of bound_value */
-  CHECK(!is_valid_cost_(bound_value_));
+  ACHECK(!is_valid_cost_(bound_value_));
 }
 
 template <typename T>

--- a/modules/perception/fusion/common/dst_evidence.cc
+++ b/modules/perception/fusion/common/dst_evidence.cc
@@ -78,16 +78,16 @@ DstCommonDataPtr DstManager::GetAppDataPtr(const std::string &app_name) {
 size_t DstManager::FodSubsetToInd(const std::string &app_name,
                                   const uint64_t &fod_subset) {
   auto iter0 = dst_common_data_.find(app_name);
-  CHECK(iter0 != dst_common_data_.end());
+  ACHECK(iter0 != dst_common_data_.end());
   auto iter = iter0->second.subsets_ind_map_.find(fod_subset);
-  CHECK(iter != iter0->second.subsets_ind_map_.end());
+  ACHECK(iter != iter0->second.subsets_ind_map_.end());
   return iter->second;
 }
 
 uint64_t DstManager::IndToFodSubset(const std::string &app_name,
                                     const size_t &ind) {
   auto iter = dst_common_data_.find(app_name);
-  CHECK(iter != dst_common_data_.end());
+  ACHECK(iter != dst_common_data_.end());
   return iter->second.fod_subsets_[ind];
 }
 
@@ -201,7 +201,7 @@ Dst::Dst(const std::string &app_name) : app_name_(app_name) {
 }
 
 void Dst::SelfCheck() const {
-  CHECK(DstManager::Instance()->IsAppAdded(app_name_));
+  ACHECK(DstManager::Instance()->IsAppAdded(app_name_));
   if (dst_data_ptr_ == nullptr) {
     dst_data_ptr_ = DstManager::Instance()->GetAppDataPtr(app_name_);
     CHECK_NOTNULL(dst_data_ptr_);

--- a/modules/perception/fusion/lib/data_fusion/existance_fusion/dst_existance_fusion/dst_existance_fusion.cc
+++ b/modules/perception/fusion/lib/data_fusion/existance_fusion/dst_existance_fusion/dst_existance_fusion.cc
@@ -248,11 +248,11 @@ void DstExistanceFusion::UpdateToicWithoutCameraMeasurement(
   double in_view_ratio = 0.0;
   // 1.get camera intrinsic and pose
   SensorDataManager *sensor_manager = SensorDataManager::Instance();
-  CHECK(sensor_manager != nullptr) << "Failed to get sensor manager";
+  ACHECK(sensor_manager != nullptr) << "Failed to get sensor manager";
 
   base::BaseCameraModelPtr camera_model =
       sensor_manager->GetCameraIntrinsic(sensor_id);
-  CHECK(camera_model != nullptr)
+  ACHECK(camera_model != nullptr)
       << "Failed to get camera intrinsic for " << sensor_id;
 
   Eigen::Affine3d sensor2world_pose;
@@ -298,7 +298,7 @@ void DstExistanceFusion::UpdateToicWithCameraMeasurement(
 
   base::BaseCameraModelPtr camera_model =
       sensor_manager->GetCameraIntrinsic(sensor_id);
-  CHECK(camera_model != nullptr)
+  ACHECK(camera_model != nullptr)
       << "Failed to get camera intrinsic for " << sensor_id;
 
   Eigen::Affine3d sensor2world_pose;

--- a/modules/perception/fusion/lib/data_fusion/type_fusion/dst_type_fusion/dst_type_fusion.cc
+++ b/modules/perception/fusion/lib/data_fusion/type_fusion/dst_type_fusion/dst_type_fusion.cc
@@ -144,7 +144,7 @@ void DstTypeFusion::UpdateWithoutMeasurement(const std::string &sensor_id,
     SensorDataManager *sensor_data_manager = SensorDataManager::Instance();
     base::BaseCameraModelPtr camera_model =
         sensor_data_manager->GetCameraIntrinsic(sensor_id);
-    CHECK(camera_model != nullptr)
+    ACHECK(camera_model != nullptr)
         << "Failed to get camera intrinsic for " << sensor_id;
 
     Eigen::Affine3d sensor2world_pose;
@@ -252,7 +252,7 @@ Dst DstTypeFusion::TypeProbsToDst(const std::vector<float> &type_probs) {
   //         find_res->second += (1 - type_probs_sum);
   //     }
   // }
-  CHECK(res_dst.SetBba(res_bba_map));
+  ACHECK(res_dst.SetBba(res_bba_map));
   return res_dst;
 }
 

--- a/modules/perception/inference/caffe/caffe_net_test.cc
+++ b/modules/perception/inference/caffe/caffe_net_test.cc
@@ -66,16 +66,16 @@ TEST(CaffeNetTest, init_test) {
   // std::vector<std::string> inputs{"data", "bad"};
   // auto rt_net = apollo::perception::inference::CreateInferenceByName(
   //     "CaffeNet", proto_file, weight_file, outputs, inputs);
-  // CHECK(rt_net);
+  // ACHECK(rt_net);
   // int height = 576;
   // int width = 1440;
   // int offset_y = 312;
   // int batchsize = 1;
   // std::vector<int> shape = {batchsize, height, width, 3};
   // std::map<std::string, std::vector<int>> shape_map{{"bad", shape}};
-  // CHECK(rt_net->Init(shape_map));
+  // ACHECK(rt_net->Init(shape_map));
   // rt_net->Infer();
-  // CHECK(!rt_net->get_blob("bad"));
+  // ACHECK(!rt_net->get_blob("bad"));
 }
 
 TEST(CaffeNetTest, cpu_test) {
@@ -108,7 +108,7 @@ TEST(CaffeNetTest, cpu_test) {
 
   // rt_net = apollo::perception::inference::CreateInferenceByName(
   //     "CaffeNet", proto_file, weight_file, outputs, inputs);
-  // CHECK(rt_net);
+  // ACHECK(rt_net);
   // int height = 576;
   // int width = 1440;
   // int offset_y = 312;
@@ -117,7 +117,7 @@ TEST(CaffeNetTest, cpu_test) {
   // rt_net->set_gpu_id(-1);
   // std::map<std::string, std::vector<int>> shape_map{{input_blob_name,
   // shape}}; rt_net->set_max_batch_size(batchsize);
-  // CHECK(rt_net->Init(shape_map));
+  // ACHECK(rt_net->Init(shape_map));
   // rt_net->Infer();
   // if (rt_net != nullptr) {
   //   delete rt_net;
@@ -156,7 +156,7 @@ TEST(CaffeNetTest, reshape_test) {
   // int batchsize = 2;
   // caffenet.Init(std::map<std::string, std::vector<int>>{});
   // std::vector<int> shape = {batchsize, height, width, 3};
-  // CHECK(!caffenet.shape("bad", &shape));
+  // ACHECK(!caffenet.shape("bad", &shape));
   // auto datablob = caffenet.get_blob("data");
   // {
   //   datablob->Reshape(1, height, width, 3);

--- a/modules/perception/inference/paddlepaddle/paddle_net.cc
+++ b/modules/perception/inference/paddlepaddle/paddle_net.cc
@@ -72,7 +72,7 @@ bool PaddleNet::Init(const std::map<std::string, std::vector<int>> &shapes) {
     input_t->copy_from_cpu(input_data[index].data());
     index += 1;
   }
-  CHECK(predictor_->ZeroCopyRun());
+  ACHECK(predictor_->ZeroCopyRun());
   for (auto name : output_names_) {
     if (name_map_.find(name) == name_map_.end()) {
       continue;

--- a/modules/perception/inference/tensorrt/batch_stream.cc
+++ b/modules/perception/inference/tensorrt/batch_stream.cc
@@ -100,7 +100,7 @@ bool BatchStream::update() {
   int d[4];
   int fs = static_cast<int>(fread(d, sizeof(int), 4, file));
   CHECK_EQ(fs, 4);
-  CHECK(mDims.n() == d[0] && mDims.c() == d[1] && mDims.h() == d[2] &&
+  ACHECK(mDims.n() == d[0] && mDims.c() == d[1] && mDims.h() == d[2] &&
         mDims.w() == d[3]);
 
   size_t readInputCount =

--- a/modules/perception/inference/tensorrt/batch_stream.cc
+++ b/modules/perception/inference/tensorrt/batch_stream.cc
@@ -101,7 +101,7 @@ bool BatchStream::update() {
   int fs = static_cast<int>(fread(d, sizeof(int), 4, file));
   CHECK_EQ(fs, 4);
   ACHECK(mDims.n() == d[0] && mDims.c() == d[1] && mDims.h() == d[2] &&
-        mDims.w() == d[3]);
+         mDims.w() == d[3]);
 
   size_t readInputCount =
       fread(getFileBatch(), sizeof(float), mDims.n() * mImageSize, file);

--- a/modules/perception/inference/tensorrt/rt_common_test.cc
+++ b/modules/perception/inference/tensorrt/rt_common_test.cc
@@ -44,25 +44,25 @@ TEST(RTModifyPoolingParamTest, test) {
     PoolingParameter pool_param;
     pool_param.set_kernel_size(1);
     pool_param.set_stride(1);
-    CHECK(modify_pool_param(&pool_param));
+    ACHECK(modify_pool_param(&pool_param));
     EXPECT_EQ(pool_param.kernel_w(), 1);
     EXPECT_EQ(pool_param.kernel_h(), 1);
   }
   {
     PoolingParameter pool_param;
     pool_param.set_kernel_h(0);
-    CHECK(!modify_pool_param(&pool_param));
+    ACHECK(!modify_pool_param(&pool_param));
   }
   {
     PoolingParameter pool_param;
     pool_param.set_kernel_w(0);
-    CHECK(!modify_pool_param(&pool_param));
+    ACHECK(!modify_pool_param(&pool_param));
   }
   {
     PoolingParameter pool_param;
     pool_param.set_stride(1);
     pool_param.set_kernel_size(1);
-    CHECK(modify_pool_param(&pool_param));
+    ACHECK(modify_pool_param(&pool_param));
     EXPECT_EQ(pool_param.stride_w(), 1);
     EXPECT_EQ(pool_param.stride_h(), 1);
   }
@@ -70,20 +70,20 @@ TEST(RTModifyPoolingParamTest, test) {
     PoolingParameter pool_param;
     pool_param.set_kernel_size(1);
     pool_param.set_stride_h(0);
-    CHECK(!modify_pool_param(&pool_param));
+    ACHECK(!modify_pool_param(&pool_param));
   }
   {
     PoolingParameter pool_param;
     pool_param.set_stride_w(0);
     pool_param.set_kernel_size(1);
-    CHECK(!modify_pool_param(&pool_param));
+    ACHECK(!modify_pool_param(&pool_param));
   }
   {
     PoolingParameter pool_param;
     pool_param.set_pad(1);
     pool_param.set_kernel_size(1);
     pool_param.set_stride(1);
-    CHECK(modify_pool_param(&pool_param));
+    ACHECK(modify_pool_param(&pool_param));
     EXPECT_EQ(pool_param.pad_h(), 1);
     EXPECT_EQ(pool_param.pad_w(), 1);
   }
@@ -91,7 +91,7 @@ TEST(RTModifyPoolingParamTest, test) {
     PoolingParameter pool_param;
     pool_param.set_kernel_size(1);
     pool_param.set_stride(1);
-    CHECK(modify_pool_param(&pool_param));
+    ACHECK(modify_pool_param(&pool_param));
     EXPECT_EQ(pool_param.pad_h(), 0);
     EXPECT_EQ(pool_param.pad_w(), 0);
   }
@@ -104,7 +104,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.add_pad(1);
     conv_param.add_stride(1);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(ParserConvParam(conv_param, &tensorrt_param));
     EXPECT_EQ(tensorrt_param.kernel_h, 3);
     EXPECT_EQ(tensorrt_param.kernel_w, 3);
     EXPECT_EQ(tensorrt_param.padding_h, 1);
@@ -116,21 +116,21 @@ TEST(RTParseConvParamTest, test) {
     ConvolutionParameter conv_param;
     conv_param.clear_kernel_size();
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
     conv_param.clear_kernel_size();
     conv_param.set_kernel_h(3);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
     conv_param.clear_kernel_size();
     conv_param.set_kernel_w(3);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -139,7 +139,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.add_stride(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(ParserConvParam(conv_param, &tensorrt_param));
     EXPECT_EQ(tensorrt_param.kernel_h, 3);
     EXPECT_EQ(tensorrt_param.kernel_w, 3);
     EXPECT_EQ(tensorrt_param.padding_h, 1);
@@ -154,7 +154,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.add_stride(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(ParserConvParam(conv_param, &tensorrt_param));
     EXPECT_EQ(tensorrt_param.kernel_h, 3);
     EXPECT_EQ(tensorrt_param.kernel_w, 3);
     EXPECT_EQ(tensorrt_param.padding_h, 0);
@@ -169,7 +169,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_pad_w(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -178,7 +178,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_pad_h(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -188,7 +188,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_stride_h(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -198,7 +198,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_stride_w(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -207,7 +207,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_stride_h(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
   {
     ConvolutionParameter conv_param;
@@ -216,7 +216,7 @@ TEST(RTParseConvParamTest, test) {
     conv_param.set_stride_w(1);
     conv_param.add_dilation(0);
     apollo::perception::inference::ConvParam tensorrt_param;
-    CHECK(!ParserConvParam(conv_param, &tensorrt_param));
+    ACHECK(!ParserConvParam(conv_param, &tensorrt_param));
   }
 }
 

--- a/modules/perception/inference/tensorrt/rt_net.cc
+++ b/modules/perception/inference/tensorrt/rt_net.cc
@@ -68,7 +68,7 @@ void RTNet::addConvLayer(const LayerParameter &layer_param,
                          TensorModifyMap *tensor_modify_map) {
   ConvolutionParameter conv = layer_param.convolution_param();
   ConvParam param;
-  CHECK(ParserConvParam(conv, &param));
+  ACHECK(ParserConvParam(conv, &param));
   nvinfer1::IConvolutionLayer *convLayer = nullptr;
   int size = conv.num_output() * param.kernel_w * param.kernel_h *
              inputs[0]->getDimensions().d[0];
@@ -215,7 +215,7 @@ void RTNet::addPoolingLayer(const LayerParameter &layer_param,
       (pool.pool() == PoolingParameter_PoolMethod_MAX)
           ? nvinfer1::PoolingType::kMAX
           : nvinfer1::PoolingType::kAVERAGE;
-  CHECK(modify_pool_param(&pool));
+  ACHECK(modify_pool_param(&pool));
   nvinfer1::IPoolingLayer *poolLayer = net->addPooling(
       *inputs[0], pool_type,
       {static_cast<int>(pool.kernel_h()), static_cast<int>(pool.kernel_w())});
@@ -277,7 +277,7 @@ void RTNet::addScaleLayer(const LayerParameter &layer_param,
     lw[1] = loadLayerWeights(power_param.shift(), size);
     lw[2] = loadLayerWeights(power_param.power(), size);
   } else {
-    CHECK(weight_map->find(layer_param.name().c_str()) != weight_map->end());
+    ACHECK(weight_map->find(layer_param.name().c_str()) != weight_map->end());
     for (size_t i = 0; i < (*weight_map)[layer_param.name().c_str()].size();
          i++) {
       lw[i] = (*weight_map)[layer_param.name().c_str()][i];
@@ -609,7 +609,7 @@ void RTNet::init_blob(std::vector<std::string> *names) {
     int count = dims.c() * dims.h() * dims.w() * max_batch_size_;
     cudaMalloc(&buffers_[bindingIndex], count * sizeof(float));
     std::vector<int> shape;
-    CHECK(this->shape(name, &shape));
+    ACHECK(this->shape(name, &shape));
     std::shared_ptr<apollo::perception::base::Blob<float>> blob;
     blob.reset(new apollo::perception::base::Blob<float>(shape));
     blob->set_gpu_data(reinterpret_cast<float *>(buffers_[bindingIndex]));

--- a/modules/perception/inference/tensorrt/rt_net_test.cc
+++ b/modules/perception/inference/tensorrt/rt_net_test.cc
@@ -79,15 +79,15 @@ class TestableRTNet : public RTNet {
 //   std::vector<int> shape = {batchsize, height, width, 3};
 //   std::map<std::string, std::vector<int>> shape_map{{input_blob_name,
 //   shape}}; rt_net.set_max_batch_size(batchsize);
-//   CHECK(rt_net.Init(shape_map));
-//   CHECK(!rt_net.shape("bad", &shape));
+//   ACHECK(rt_net.Init(shape_map));
+//   ACHECK(!rt_net.shape("bad", &shape));
 
-//   CHECK(!rt_net.checkInt8("test", nullptr));
+//   ACHECK(!rt_net.checkInt8("test", nullptr));
 //   std::shared_ptr<nvinfer1::Int8EntropyCalibrator> calibrator;
 //   apollo::perception::inference::BatchStream stream;
 //   calibrator.reset(new nvinfer1::Int8EntropyCalibrator(stream, 0, true, ""));
-//   CHECK(!rt_net.checkInt8("test", calibrator.get()));
-//   CHECK(rt_net.checkInt8("Tesla P4", calibrator.get()));
+//   ACHECK(!rt_net.checkInt8("test", calibrator.get()));
+//   ACHECK(rt_net.checkInt8("Tesla P4", calibrator.get()));
 // }
 // TEST(RTNetLayerOwnCalibratorTest, test) {
 //   std::string image_root =
@@ -230,7 +230,7 @@ class TestableRTNet : public RTNet {
 
 //   rt_net = apollo::perception::inference::CreateInferenceByName(
 //       "RTNet", proto_file, weight_file, outputs, inputs);
-//   CHECK(rt_net);
+//   ACHECK(rt_net);
 //   int height = 576;
 //   int width = 1440;
 //   int offset_y = 312;
@@ -239,7 +239,7 @@ class TestableRTNet : public RTNet {
 //   rt_net->set_gpu_id(-1);
 //   std::map<std::string, std::vector<int>> shape_map{{input_blob_name,
 //   shape}}; rt_net->set_max_batch_size(batchsize);
-//   CHECK(!rt_net->Init(shape_map));
+//   ACHECK(!rt_net->Init(shape_map));
 //   if (rt_net != nullptr) {
 //     delete rt_net;
 //   }
@@ -279,7 +279,7 @@ class TestableRTNet : public RTNet {
 
 //   rt_net = apollo::perception::inference::CreateInferenceByName(
 //       "UNKNWONNet", proto_file, weight_file, outputs, inputs);
-//   CHECK(!rt_net);
+//   ACHECK(!rt_net);
 //   if (rt_net != nullptr) {
 //     delete rt_net;
 //   }
@@ -319,14 +319,14 @@ class TestableRTNet : public RTNet {
 
 //   rt_net = apollo::perception::inference::CreateInferenceByName(
 //       "RTNet", proto_file, weight_file, outputs, inputs);
-//   CHECK(rt_net);
+//   ACHECK(rt_net);
 //   int height = 111;
 //   int width = 222;
 //   int offset_y = 23;
 //   int batchsize = 2;
 //   std::vector<int> shape = {batchsize, height, width, 4};
 //   std::map<std::string, std::vector<int>> shape_map{{"bad", shape}};
-//   CHECK(rt_net->Init(shape_map));
+//   ACHECK(rt_net->Init(shape_map));
 //   auto blob = rt_net->get_blob(input_blob_name);
 //   for (int i = 0; i < shape.size(); i++) {
 //     CHECK_NE(blob->shape(i), shape[i]);
@@ -371,7 +371,7 @@ class TestableRTNet : public RTNet {
 
 //   rt_net = apollo::perception::inference::CreateInferenceByName(
 //       "RTNet", proto_file, weight_file, outputs, inputs);
-//   CHECK(rt_net);
+//   ACHECK(rt_net);
 //   int height = 576;
 //   int width = 1440;
 //   int offset_y = 312;
@@ -447,7 +447,7 @@ class TestableRTNet : public RTNet {
 
 //   rt_net.reset(apollo::perception::inference::CreateInferenceByName(
 //       "CaffeNet", proto_file, weight_file, outputs, inputs));
-//   CHECK(rt_net);
+//   ACHECK(rt_net);
 
 //   int height = 576;
 //   int width = 1440;

--- a/modules/perception/inference/test/inference_util_test.cc
+++ b/modules/perception/inference/test/inference_util_test.cc
@@ -25,7 +25,7 @@ namespace perception {
 namespace inference {
 
 TEST(loadTest, test) {
-  CHECK(!apollo::perception::inference::load_binary_data("unknow.txt"));
+  ACHECK(!apollo::perception::inference::load_binary_data("unknow.txt"));
 }
 
 TEST(UtilTest, GemmTest) {

--- a/modules/perception/inference/tools/denseline_sample.cc
+++ b/modules/perception/inference/tools/denseline_sample.cc
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
   std::vector<int> shape = {1, 3, height, width};
   std::map<std::string, std::vector<int>> shape_map{{input_blob_name, shape}};
 
-  CHECK(rt_net->Init(shape_map));
+  ACHECK(rt_net->Init(shape_map));
 
   auto input_blob = rt_net->get_blob(input_blob_name);
   std::vector<std::string> image_lists;

--- a/modules/perception/inference/utils/gemm.cu
+++ b/modules/perception/inference/utils/gemm.cu
@@ -111,7 +111,7 @@ void GPUGemmFloat(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE TransB,
       (TransA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (TransB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  CHECK(cublasSgemm(CudaUtil::get_handler(), cuTransB, cuTransA, N, M, K,
+  ACHECK(cublasSgemm(CudaUtil::get_handler(), cuTransB, cuTransA, N, M, K,
                     &alpha, B, ldb, A, lda, &beta, C,
                     N) == CUBLAS_STATUS_SUCCESS);
 }

--- a/modules/perception/inference/utils/util_test.cc
+++ b/modules/perception/inference/utils/util_test.cc
@@ -19,7 +19,7 @@
 #include "gtest/gtest.h"
 
 TEST(loadTest, test) {
-  CHECK(!apollo::perception::inference::load_binary_data("unknown.txt"));
+  ACHECK(!apollo::perception::inference::load_binary_data("unknown.txt"));
 }
 
 TEST(UtilTest, test) {
@@ -73,7 +73,7 @@ TEST(UtilTest, test) {
   //     cv::resize(img_roi, img_small, cv::Size(w_small, h_small));
   //     src_gpu->set_cpu_data(img_roi.data);
 
-  //     CHECK(apollo::perception::inference::resize(
+  //     ACHECK(apollo::perception::inference::resize(
   //         img_roi.channels(), img_roi.rows, img_roi.cols,
   //         img_roi.step1(0) / img_roi.step1(1), blob, src_gpu, 0));
   //     for (int i = 0;
@@ -104,7 +104,7 @@ TEST(UtilTest, test) {
 
   //     cv::Mat img_small;
   //     cv::resize(img_roi, img_small, cv::Size(w_small, h_small));
-  //     CHECK(apollo::perception::inference::resize(
+  //     ACHECK(apollo::perception::inference::resize(
   //         img_roi.channels(), img_roi.rows, img_roi.cols,
   //         img_roi.step1(0) / img_roi.step1(1), blob, src_gpu, 0));
   //     for (int i = 0;
@@ -135,7 +135,7 @@ TEST(UtilTest, test) {
 
   //     cv::Mat img_small;
   //     cv::resize(img_roi, img_small, cv::Size(w_small, h_small));
-  //     CHECK(apollo::perception::inference::resize(
+  //     ACHECK(apollo::perception::inference::resize(
   //         img_roi.channels(), img_roi.rows, img_roi.cols,
   //         img_roi.step1(0) / img_roi.step1(1), blob, src_gpu, 0));
   //     for (int i = 0;

--- a/modules/perception/lib/thread/thread.cc
+++ b/modules/perception/lib/thread/thread.cc
@@ -42,7 +42,7 @@ void Thread::Start() {
 }
 
 void Thread::Join() {
-  CHECK(joinable_) << "Thread is not joinable";
+  ACHECK(joinable_) << "Thread is not joinable";
   int result = pthread_join(tid_, nullptr);
   CHECK_EQ(result, 0) << "Could not join thread (" << tid_ << ", "
                       << thread_name_ << ")";

--- a/modules/perception/lidar/app/lidar_obstacle_segmentation.cc
+++ b/modules/perception/lidar/app/lidar_obstacle_segmentation.cc
@@ -31,19 +31,19 @@ bool LidarObstacleSegmentation::Init(
   auto& sensor_name = options.sensor_name;
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
 
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = cyber::common::GetAbsolutePath(work_root, root_path);
   config_file = cyber::common::GetAbsolutePath(config_file, sensor_name);
   config_file = cyber::common::GetAbsolutePath(
       config_file, "lidar_obstacle_segmentation.conf");
 
   LidarObstacleSegmentationConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   segmentor_name_ = config.segmentor();
   use_map_manager_ = config.use_map_manager();
   use_object_filter_bank_ = config.use_object_filter_bank();
@@ -51,11 +51,11 @@ bool LidarObstacleSegmentation::Init(
   use_map_manager_ = use_map_manager_ && options.enable_hdmap_input;
 
   SceneManagerInitOptions scene_manager_init_options;
-  CHECK(SceneManager::Instance().Init(scene_manager_init_options));
+  ACHECK(SceneManager::Instance().Init(scene_manager_init_options));
 
   PointCloudPreprocessorInitOptions preprocessor_init_options;
   preprocessor_init_options.sensor_name = sensor_name;
-  CHECK(cloud_preprocessor_.Init(preprocessor_init_options));
+  ACHECK(cloud_preprocessor_.Init(preprocessor_init_options));
 
   if (use_map_manager_) {
     MapManagerInitOptions map_manager_init_options;
@@ -70,15 +70,15 @@ bool LidarObstacleSegmentation::Init(
   CHECK_NOTNULL(segmentor_.get());
   SegmentationInitOptions segmentation_init_options;
   segmentation_init_options.sensor_name = sensor_name;
-  CHECK(segmentor_->Init(segmentation_init_options));
+  ACHECK(segmentor_->Init(segmentation_init_options));
 
   ObjectBuilderInitOptions builder_init_options;
-  CHECK(builder_.Init(builder_init_options));
+  ACHECK(builder_.Init(builder_init_options));
 
   if (use_object_filter_bank_) {
     ObjectFilterInitOptions filter_bank_init_options;
     filter_bank_init_options.sensor_name = sensor_name;
-    CHECK(filter_bank_.Init(filter_bank_init_options));
+    ACHECK(filter_bank_.Init(filter_bank_init_options));
   }
 
   return true;

--- a/modules/perception/lidar/app/lidar_obstacle_tracking.cc
+++ b/modules/perception/lidar/app/lidar_obstacle_tracking.cc
@@ -30,19 +30,19 @@ bool LidarObstacleTracking::Init(
   auto& sensor_name = options.sensor_name;
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
 
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = cyber::common::GetAbsolutePath(work_root, root_path);
   config_file = cyber::common::GetAbsolutePath(config_file, sensor_name);
   config_file = cyber::common::GetAbsolutePath(config_file,
                                                "lidar_obstacle_tracking.conf");
 
   LidarObstacleTrackingConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   multi_target_tracker_name_ = config.multi_target_tracker();
   fusion_classifier_name_ = config.fusion_classifier();
 
@@ -51,13 +51,13 @@ bool LidarObstacleTracking::Init(
           multi_target_tracker_name_));
   CHECK_NOTNULL(multi_target_tracker_.get());
   MultiTargetTrackerInitOptions tracker_init_options;
-  CHECK(multi_target_tracker_->Init(tracker_init_options));
+  ACHECK(multi_target_tracker_->Init(tracker_init_options));
 
   fusion_classifier_.reset(
       BaseClassifierRegisterer::GetInstanceByName(fusion_classifier_name_));
   CHECK_NOTNULL(fusion_classifier_.get());
   ClassifierInitOptions fusion_classifier_init_options;
-  CHECK(fusion_classifier_->Init(fusion_classifier_init_options));
+  ACHECK(fusion_classifier_->Init(fusion_classifier_init_options));
   return true;
 }
 

--- a/modules/perception/lidar/lib/classifier/fused_classifier/ccrf_type_fusion.cc
+++ b/modules/perception/lidar/lib/classifier/fused_classifier/ccrf_type_fusion.cc
@@ -33,18 +33,18 @@ using apollo::perception::base::ObjectType;
 bool CCRFOneShotTypeFusion::Init(const TypeFusionInitOption& option) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "ccrf_type_fusion.conf");
   CcrfTypeFusionConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   std::string classifiers_property_file_path =
       GetAbsolutePath(work_root, config.classifiers_property_file_path());
-  CHECK(util::LoadMultipleMatricesFile(classifiers_property_file_path,
+  ACHECK(util::LoadMultipleMatricesFile(classifiers_property_file_path,
                                        &smooth_matrices_));
 
   for (auto& pair : smooth_matrices_) {
@@ -124,22 +124,22 @@ bool CCRFOneShotTypeFusion::FuseOneShotTypeProbs(const ObjectPtr& object,
 }
 
 bool CCRFSequenceTypeFusion::Init(const TypeFusionInitOption& option) {
-  CHECK(one_shot_fuser_.Init(option));
+  ACHECK(one_shot_fuser_.Init(option));
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "ccrf_type_fusion.conf");
   CcrfTypeFusionConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   std::string transition_property_file_path =
       GetAbsolutePath(work_root, config.transition_property_file_path());
   s_alpha_ = config.transition_matrix_alpha();
-  CHECK(util::LoadSingleMatrixFile(transition_property_file_path,
+  ACHECK(util::LoadSingleMatrixFile(transition_property_file_path,
                                    &transition_matrix_));
   transition_matrix_ += Matrixd::Ones() * 1e-6;
   util::NormalizeRow(&transition_matrix_);

--- a/modules/perception/lidar/lib/classifier/fused_classifier/ccrf_type_fusion.cc
+++ b/modules/perception/lidar/lib/classifier/fused_classifier/ccrf_type_fusion.cc
@@ -45,7 +45,7 @@ bool CCRFOneShotTypeFusion::Init(const TypeFusionInitOption& option) {
   std::string classifiers_property_file_path =
       GetAbsolutePath(work_root, config.classifiers_property_file_path());
   ACHECK(util::LoadMultipleMatricesFile(classifiers_property_file_path,
-                                       &smooth_matrices_));
+                                        &smooth_matrices_));
 
   for (auto& pair : smooth_matrices_) {
     util::NormalizeRow(&pair.second);
@@ -140,7 +140,7 @@ bool CCRFSequenceTypeFusion::Init(const TypeFusionInitOption& option) {
       GetAbsolutePath(work_root, config.transition_property_file_path());
   s_alpha_ = config.transition_matrix_alpha();
   ACHECK(util::LoadSingleMatrixFile(transition_property_file_path,
-                                   &transition_matrix_));
+                                    &transition_matrix_));
   transition_matrix_ += Matrixd::Ones() * 1e-6;
   util::NormalizeRow(&transition_matrix_);
   AINFO << "transition matrix";

--- a/modules/perception/lidar/lib/classifier/fused_classifier/fused_classifier.cc
+++ b/modules/perception/lidar/lib/classifier/fused_classifier/fused_classifier.cc
@@ -31,15 +31,15 @@ using apollo::perception::base::ObjectType;
 bool FusedClassifier::Init(const ClassifierInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "fused_classifier.conf");
   FusedClassifierConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   temporal_window_ = config.temporal_window();
   enable_temporal_fusion_ = config.enable_temporal_fusion();
   use_tracked_objects_ = config.use_tracked_objects();
@@ -49,11 +49,11 @@ bool FusedClassifier::Init(const ClassifierInitOptions& options) {
       one_shot_fusion_method_));
   bool init_success = true;
   CHECK_NOTNULL(one_shot_fuser_.get());
-  CHECK(one_shot_fuser_->Init(init_option_));
+  ACHECK(one_shot_fuser_->Init(init_option_));
   sequence_fuser_.reset(BaseSequenceTypeFusionRegisterer::GetInstanceByName(
       sequence_fusion_method_));
   CHECK_NOTNULL(sequence_fuser_.get());
-  CHECK(sequence_fuser_->Init(init_option_));
+  ACHECK(sequence_fuser_->Init(init_option_));
   return init_success;
 }
 

--- a/modules/perception/lidar/lib/ground_detector/ground_service_detector/ground_service_detector.cc
+++ b/modules/perception/lidar/lib/ground_detector/ground_service_detector/ground_service_detector.cc
@@ -31,18 +31,18 @@ bool GroundServiceDetector::Init(const GroundDetectorInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
 
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
 
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
 
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "ground_service_detector.conf");
 
   GroundServiceDetectorConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   ground_threshold_ = config.ground_threshold();
 
   ground_service_ = std::dynamic_pointer_cast<GroundService>(

--- a/modules/perception/lidar/lib/ground_detector/ground_service_detector/ground_service_detector_test.cc
+++ b/modules/perception/lidar/lib/ground_detector/ground_service_detector/ground_service_detector_test.cc
@@ -103,7 +103,7 @@ TEST_F(LidarLibGroundServiceDetectorTest,
 
   GroundServiceContent ground_service_content;
   auto ground_service = SceneManager::Instance().Service("GroundService");
-  CHECK(ground_service);
+  ACHECK(ground_service);
   ground_service->GetServiceContentCopy(&ground_service_content);
   ground_service->UpdateServiceContent(ground_service_content);
 

--- a/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector.cc
+++ b/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector.cc
@@ -34,7 +34,7 @@ bool SpatioTemporalGroundDetector::Init(
   const lib::ModelConfig* model_config = nullptr;
   auto config_manager = lib::ConfigManager::Instance();
   ACHECK(config_manager->GetModelConfig("SpatioTemporalGroundDetector",
-                                       &model_config))
+                                        &model_config))
       << "Failed to get model config: SpatioTemporalGroundDetector";
 
   const std::string& work_root = config_manager->work_root();

--- a/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector.cc
+++ b/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector.cc
@@ -33,13 +33,13 @@ bool SpatioTemporalGroundDetector::Init(
     const GroundDetectorInitOptions& options) {
   const lib::ModelConfig* model_config = nullptr;
   auto config_manager = lib::ConfigManager::Instance();
-  CHECK(config_manager->GetModelConfig("SpatioTemporalGroundDetector",
+  ACHECK(config_manager->GetModelConfig("SpatioTemporalGroundDetector",
                                        &model_config))
       << "Failed to get model config: SpatioTemporalGroundDetector";
 
   const std::string& work_root = config_manager->work_root();
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path))
+  ACHECK(model_config->get_value("root_path", &root_path))
       << "Failed to get value of root_path.";
   std::string config_file;
   config_file = apollo::cyber::common::GetAbsolutePath(work_root, root_path);
@@ -48,7 +48,7 @@ bool SpatioTemporalGroundDetector::Init(
 
   // get config params
   SpatioTemporalGroundDetectorConfig config_params;
-  CHECK(GetProtoFromFile(config_file, &config_params))
+  ACHECK(GetProtoFromFile(config_file, &config_params))
       << "Failed to parse SpatioTemporalGroundDetectorConfig config file.";
   ground_thres_ = config_params.ground_thres();
   use_roi_ = config_params.use_roi();

--- a/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector_test.cc
+++ b/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/spatio_temporal_ground_detector_test.cc
@@ -72,7 +72,7 @@ TEST(SpatioTemporalGroundDetectorTest, test_spatio_temporal_ground_detector) {
   //     "ground_detector/spatio_temporal_ground_detector/"
   //     "pcd_data/QB9178_3_1461752790_1461753090_36701.pcd";
   // bool ret = LoadPCDFile(filename, pc_ptr);
-  // CHECK(ret) << "Failed to load " << filename;
+  // ACHECK(ret) << "Failed to load " << filename;
 
   // // test init
   // std::shared_ptr<SpatioTemporalGroundDetector> detector(

--- a/modules/perception/lidar/lib/map_manager/map_manager.cc
+++ b/modules/perception/lidar/lib/map_manager/map_manager.cc
@@ -30,15 +30,15 @@ using cyber::common::GetAbsolutePath;
 bool MapManager::Init(const MapManagerInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "map_manager.conf");
   MapManagerConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   update_pose_ = config.update_pose();
   roi_search_distance_ = config.roi_search_distance();
   hdmap_input_ = map::HDMapInput::Instance();

--- a/modules/perception/lidar/lib/object_filter_bank/object_filter_bank.cc
+++ b/modules/perception/lidar/lib/object_filter_bank/object_filter_bank.cc
@@ -29,16 +29,16 @@ using apollo::cyber::common::GetAbsolutePath;
 bool ObjectFilterBank::Init(const ObjectFilterInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, options.sensor_name);
   config_file = GetAbsolutePath(config_file, "filter_bank.conf");
   FilterBankConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
   filter_bank_.clear();
   for (int i = 0; i < config.filter_name_size(); ++i) {
     const auto& name = config.filter_name(i);

--- a/modules/perception/lidar/lib/object_filter_bank/roi_boundary_filter/roi_boundary_filter.cc
+++ b/modules/perception/lidar/lib/object_filter_bank/roi_boundary_filter/roi_boundary_filter.cc
@@ -31,15 +31,15 @@ using cyber::common::GetAbsolutePath;
 bool ROIBoundaryFilter::Init(const ObjectFilterInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "roi_boundary_filter.conf");
   ROIBoundaryFilterConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   distance_to_boundary_threshold_ = config.distance_to_boundary_threshold();
   confidence_threshold_ = config.confidence_threshold();
   cross_roi_threshold_ = config.cross_roi_threshold();

--- a/modules/perception/lidar/lib/pointcloud_preprocessor/pointcloud_preprocessor.cc
+++ b/modules/perception/lidar/lib/pointcloud_preprocessor/pointcloud_preprocessor.cc
@@ -34,16 +34,16 @@ bool PointCloudPreprocessor::Init(
     const PointCloudPreprocessorInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, options.sensor_name);
   config_file = GetAbsolutePath(config_file, "pointcloud_preprocessor.conf");
   PointCloudPreprocessorConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
   filter_naninf_points_ = config.filter_naninf_points();
   filter_nearby_box_points_ = config.filter_nearby_box_points();
   box_forward_x_ = config.box_forward_x();

--- a/modules/perception/lidar/lib/roi_filter/hdmap_roi_filter/hdmap_roi_filter.cc
+++ b/modules/perception/lidar/lib/roi_filter/hdmap_roi_filter/hdmap_roi_filter.cc
@@ -40,15 +40,15 @@ bool HdmapROIFilter::Init(const ROIFilterInitOptions& options) {
   // load model config
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "hdmap_roi_filter.conf");
   HDMapRoiFilterConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
   range_ = config.range();
   cell_size_ = config.cell_size();
   extend_dist_ = config.extend_dist();

--- a/modules/perception/lidar/lib/roi_filter/roi_service_filter/roi_service_filter_test.cc
+++ b/modules/perception/lidar/lib/roi_filter/roi_service_filter/roi_service_filter_test.cc
@@ -81,7 +81,7 @@ void MockData(LidarFrame* frame) {
   point.z = frame->lidar2world_pose.translation()(2);
   frame->hdmap_struct.reset(new base::HdmapStruct);
   ACHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
-                                                       frame->hdmap_struct));
+                                                        frame->hdmap_struct));
 
   // d. trans points
   frame->world_cloud = base::PointDCloudPool::Instance().Get();

--- a/modules/perception/lidar/lib/roi_filter/roi_service_filter/roi_service_filter_test.cc
+++ b/modules/perception/lidar/lib/roi_filter/roi_service_filter/roi_service_filter_test.cc
@@ -80,7 +80,7 @@ void MockData(LidarFrame* frame) {
   point.y = frame->lidar2world_pose.translation()(1);
   point.z = frame->lidar2world_pose.translation()(2);
   frame->hdmap_struct.reset(new base::HdmapStruct);
-  CHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
+  ACHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
                                                        frame->hdmap_struct));
 
   // d. trans points
@@ -112,10 +112,10 @@ TEST_F(LidarLibROIServiceFilterTest, lidar_lib_roi_service_filter_test) {
   EXPECT_FALSE(roi_service_filter.Filter(ROIFilterOptions(), &frame));
 
   HdmapROIFilter roi_filter;
-  CHECK(roi_filter.Init(ROIFilterInitOptions()));
+  ACHECK(roi_filter.Init(ROIFilterInitOptions()));
   // TODO(All): Add back tests when data is ready.
   /*
-  CHECK(roi_filter.Filter(ROIFilterOptions(), &frame));
+  ACHECK(roi_filter.Filter(ROIFilterOptions(), &frame));
 
   base::PointIndices filter_indices = frame.roi_indices;
 

--- a/modules/perception/lidar/lib/scene_manager/ground_service/ground_service.cc
+++ b/modules/perception/lidar/lib/scene_manager/ground_service/ground_service.cc
@@ -139,12 +139,12 @@ bool GroundService::Init(const SceneServiceInitOptions& options) {
   // including resolution, grid size, ...
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config))
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config))
       << "Failed to get model config: SceneManager";
 
   const std::string& work_root = config_manager->work_root();
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path))
+  ACHECK(model_config->get_value("root_path", &root_path))
       << "Failed to get value of root_path.";
 
   std::string config_file;
@@ -152,7 +152,7 @@ bool GroundService::Init(const SceneServiceInitOptions& options) {
   config_file = GetAbsolutePath(config_file, "ground_service.conf");
 
   GroundServiceConfig config_params;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config_params))
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config_params))
       << "Failed to parse GroundServiceConfig config file.";
 
   double roi_region_rad_x = config_params.roi_rad_x();

--- a/modules/perception/lidar/lib/scene_manager/roi_service/roi_service.cc
+++ b/modules/perception/lidar/lib/scene_manager/roi_service/roi_service.cc
@@ -86,15 +86,15 @@ bool ROIService::Init(const SceneServiceInitOptions& options) {
   roi_content_ref_ = dynamic_cast<ROIServiceContent*>(self_content_.get());
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "roi_service.conf");
   ROIServiceConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   roi_content_ref_->cell_size_ = config.cell_size();
   roi_content_ref_->range_ = config.range();
   return true;

--- a/modules/perception/lidar/lib/scene_manager/scene_manager.cc
+++ b/modules/perception/lidar/lib/scene_manager/scene_manager.cc
@@ -33,15 +33,15 @@ bool SceneManager::InitInternal(const SceneManagerInitOptions& options) {
   }
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "scene_manager.conf");
   SceneManagerConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   services_.clear();
   for (int i = 0; i < config.service_name_size(); ++i) {
     const auto& name = config.service_name(i);

--- a/modules/perception/lidar/lib/scene_manager/scene_manager_test.cc
+++ b/modules/perception/lidar/lib/scene_manager/scene_manager_test.cc
@@ -214,7 +214,7 @@ void MockData(LidarFrame* frame) {
   point.y = frame->lidar2world_pose.translation()(1);
   point.z = frame->lidar2world_pose.translation()(2);
   frame->hdmap_struct.reset(new base::HdmapStruct);
-  CHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
+  ACHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
                                                        frame->hdmap_struct));
 
   // d. trans points
@@ -262,12 +262,12 @@ TEST_F(LidarLibSceneManagerTest, lidar_lib_roi_service_test) {
   MockData(&frame);
 
   HdmapROIFilter roi_filter;
-  CHECK(roi_filter.Init(ROIFilterInitOptions()));
-  CHECK(roi_filter.Filter(ROIFilterOptions(), &frame));
+  ACHECK(roi_filter.Init(ROIFilterInitOptions()));
+  ACHECK(roi_filter.Filter(ROIFilterOptions(), &frame));
 
   auto roi_service = std::dynamic_pointer_cast<ROIService>(
       SceneManager::Instance().Service("ROIService"));
-  CHECK(roi_service);
+  ACHECK(roi_service);
   EXPECT_EQ(roi_service->Name(), "ROIService");
 
   base::PointIndices filter_indices;

--- a/modules/perception/lidar/lib/scene_manager/scene_manager_test.cc
+++ b/modules/perception/lidar/lib/scene_manager/scene_manager_test.cc
@@ -215,7 +215,7 @@ void MockData(LidarFrame* frame) {
   point.z = frame->lidar2world_pose.translation()(2);
   frame->hdmap_struct.reset(new base::HdmapStruct);
   ACHECK(map::HDMapInput::Instance()->GetRoiHDMapStruct(point, 120.0,
-                                                       frame->hdmap_struct));
+                                                        frame->hdmap_struct));
 
   // d. trans points
   frame->world_cloud = base::PointDCloudPool::Instance().Get();

--- a/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation.cc
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation.cc
@@ -45,16 +45,16 @@ bool CNNSegmentation::Init(const SegmentationInitOptions& options) {
   std::string weight_file;
   std::string engine_file;
   sensor_name_ = options.sensor_name;
-  CHECK(GetConfigs(&param_file, &proto_file, &weight_file, &engine_file));
+  ACHECK(GetConfigs(&param_file, &proto_file, &weight_file, &engine_file));
   AINFO << "--    param_file: " << param_file;
   AINFO << "--    proto_file: " << proto_file;
   AINFO << "--    weight_file: " << weight_file;
   AINFO << "--    engine_file: " << engine_file;
 
   // get cnnseg params
-  CHECK(GetProtoFromFile(param_file, &cnnseg_param_))
+  ACHECK(GetProtoFromFile(param_file, &cnnseg_param_))
       << "Failed to parse CNNSegParam config file." << param_file;
-  CHECK(GetProtoFromFile(engine_file, &spp_engine_config_))
+  ACHECK(GetProtoFromFile(engine_file, &spp_engine_config_))
       << "Failed to parse SppEngine config file." << engine_file;
 
   // init feature parameters
@@ -94,7 +94,7 @@ bool CNNSegmentation::Init(const SegmentationInitOptions& options) {
   if (!feature_param.use_constant_feature()) {
     input_shape[1] -= 2;
   }
-  CHECK(inference_->Init(input_shapes)) << "Failed to init inference.";
+  ACHECK(inference_->Init(input_shapes)) << "Failed to init inference.";
 
   // init blobs
   instance_pt_blob_ = inference_->get_blob(network_param.instance_pt_blob());
@@ -119,13 +119,13 @@ bool CNNSegmentation::Init(const SegmentationInitOptions& options) {
 
   // init feature generator
   feature_generator_.reset(new FeatureGenerator);
-  CHECK(feature_generator_->Init(feature_param, feature_blob_.get()))
+  ACHECK(feature_generator_->Init(feature_param, feature_blob_.get()))
       << "Failed to init feature generator.";
 
   point2grid_.reserve(kDefaultPointCloudSize);
 
   // init cluster and background segmentation methods
-  CHECK(InitClusterAndBackgroundSegmentation());
+  ACHECK(InitClusterAndBackgroundSegmentation());
 
   // secondary segmentor
   /*if (cnnseg_param_.fill_recall_with_ncut()) {
@@ -144,7 +144,7 @@ bool CNNSegmentation::InitClusterAndBackgroundSegmentation() {
       cnnseg_param_.ground_detector()));
   CHECK_NOTNULL(ground_detector_.get());
   GroundDetectorInitOptions ground_detector_init_options;
-  CHECK(ground_detector_->Init(ground_detector_init_options))
+  ACHECK(ground_detector_->Init(ground_detector_init_options))
       << "Failed to init ground detection.";
 
   // init roi filter
@@ -152,7 +152,7 @@ bool CNNSegmentation::InitClusterAndBackgroundSegmentation() {
       BaseROIFilterRegisterer::GetInstanceByName(cnnseg_param_.roi_filter()));
   CHECK_NOTNULL(roi_filter_.get());
   ROIFilterInitOptions roi_filter_init_options;
-  CHECK(roi_filter_->Init(roi_filter_init_options))
+  ACHECK(roi_filter_->Init(roi_filter_init_options))
       << "Failed to init roi filter.";
 
   // init spp engine
@@ -382,7 +382,7 @@ void CNNSegmentation::GetObjectsFromSppEngine(
     object->lidar_supplement.num_points_in_roi = cluster->points_in_roi;
     object->lidar_supplement.on_use = true;
     object->lidar_supplement.is_background = false;
-    // CHECK(cluster->points.size() == cluster->point_ids.size())
+    // ACHECK(cluster->points.size() == cluster->point_ids.size())
     //  << "cluster points size: " << cluster->points.size()
     //  << "cluster point ids size: " << cluster->point_ids.size();
     object->lidar_supplement.cloud.CopyPointCloud(*original_cloud_,
@@ -463,12 +463,12 @@ bool CNNSegmentation::GetConfigs(std::string* param_file,
                                  std::string* engine_file) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig("CNNSegmentation", &model_config))
+  ACHECK(config_manager->GetModelConfig("CNNSegmentation", &model_config))
       << "Failed to get model config: CNNSegmentation";
 
   const std::string& work_root = config_manager->work_root();
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path))
+  ACHECK(model_config->get_value("root_path", &root_path))
       << "Failed to get value of root_path.";
   std::string config_file;
   config_file = GetAbsolutePath(work_root, root_path);
@@ -476,7 +476,7 @@ bool CNNSegmentation::GetConfigs(std::string* param_file,
   config_file = GetAbsolutePath(config_file, "cnnseg.conf");
 
   CNNSegConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config))
       << "Failed to parse CNNSeg config file";
   if (config.use_paddle()) {
     *proto_file = GetAbsolutePath(work_root, config.paddle_proto_file());

--- a/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation_test.cc
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation_test.cc
@@ -131,7 +131,7 @@ TEST(CNNSegmentationTest, cnn_segmentation_test) {
       "/apollo/modules/perception/testdata/lidar/lib/segmentation/cnnseg/"
       "pcd_data/3_car_1_person.pcd";
   bool ret = LoadPCDFile(filename, pc_ptr);
-  CHECK(ret) << "Failed to load " << filename;
+  ACHECK(ret) << "Failed to load " << filename;
   // load non ground indices
   base::PointIndices non_ground_indices;
   auto& indices = non_ground_indices.indices;

--- a/modules/perception/lidar/lib/segmentation/cnnseg/feature_generator_test.cc
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/feature_generator_test.cc
@@ -127,7 +127,7 @@ TEST_F(FeatureGeneratorTest, basic_test) {
       "/apollo/modules/perception/testdata/lidar/lib/segmentation/cnnseg/"
       "pcd_data/3_car_1_person.pcd";
   bool ret = LoadPCLPCD(filename, pc_ptr.get());
-  CHECK(ret) << "Failed to load " << filename;
+  ACHECK(ret) << "Failed to load " << filename;
 
   std::vector<int> point2grid;
   float range = 60.f;
@@ -158,7 +158,7 @@ TEST_F(FeatureGeneratorTest, basic_test) {
     EXPECT_NE(generator_->top_intensity_data_, nullptr);
     // save feature map
     std::ofstream ofs("cpu_top_intensity_map.txt");
-    CHECK(ofs.is_open());
+    ACHECK(ofs.is_open());
     for (size_t i = 0; i < param.height() * param.width(); ++i) {
       ofs << generator_->top_intensity_data_[i] << std::endl;
     }
@@ -195,7 +195,7 @@ TEST_F(FeatureGeneratorTest, basic_test) {
     cudaMemcpy(top_intensity_data.data(), generator_->top_intensity_data_,
                map_size * sizeof(float), cudaMemcpyDeviceToHost);
     std::ofstream ofs("gpu_top_intensity_map.txt");
-    CHECK(ofs.is_open());
+    ACHECK(ofs.is_open());
     for (size_t i = 0; i < param.height() * param.width(); ++i) {
       ofs << top_intensity_data[i] << std::endl;
     }

--- a/modules/perception/lidar/lib/segmentation/ncut/ncut_segmentation.cc
+++ b/modules/perception/lidar/lib/segmentation/ncut/ncut_segmentation.cc
@@ -34,7 +34,7 @@ using Eigen::MatrixXf;
 
 bool NCutSegmentation::Init(const SegmentationInitOptions& options) {
   std::string param_file;
-  CHECK(GetConfigs(&param_file));
+  ACHECK(GetConfigs(&param_file));
   AINFO << "--    param_file: " << param_file;
 
   if (!Configure(param_file)) {
@@ -47,7 +47,7 @@ bool NCutSegmentation::Init(const SegmentationInitOptions& options) {
       BaseGroundDetectorRegisterer::GetInstanceByName(ground_detector_str_));
   CHECK_NOTNULL(ground_detector_.get());
   GroundDetectorInitOptions ground_detector_init_options;
-  CHECK(ground_detector_->Init(ground_detector_init_options))
+  ACHECK(ground_detector_->Init(ground_detector_init_options))
       << "Failed to init ground detection.";
 
   // init roi filter
@@ -55,7 +55,7 @@ bool NCutSegmentation::Init(const SegmentationInitOptions& options) {
       BaseROIFilterRegisterer::GetInstanceByName(roi_filter_str_));
   CHECK_NOTNULL(roi_filter_.get());
   ROIFilterInitOptions roi_filter_init_options;
-  CHECK(roi_filter_->Init(roi_filter_init_options))
+  ACHECK(roi_filter_->Init(roi_filter_init_options))
       << "Failed to init roi filter.";
 
   _outliers.reset(new std::vector<ObjectPtr>);
@@ -128,7 +128,7 @@ bool NCutSegmentation::Init(const SegmentationInitOptions& options) {
 bool NCutSegmentation::Configure(std::string param_file) {
   NCutSegmentationParam seg_param_;
   // get cnnseg params
-  CHECK(GetProtoFromFile(param_file, &seg_param_))
+  ACHECK(GetProtoFromFile(param_file, &seg_param_))
       << "Failed to parse CNNSegParam config file." << param_file;
   grid_radius_ = seg_param_.grid_radius();
   height_threshold_ = seg_param_.height_threshold();
@@ -152,19 +152,19 @@ bool NCutSegmentation::Configure(std::string param_file) {
 bool NCutSegmentation::GetConfigs(std::string* param_file) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig("NCutSegmentation", &model_config))
+  ACHECK(config_manager->GetModelConfig("NCutSegmentation", &model_config))
       << "Failed to get model config: CNNSegmentation";
 
   const std::string& work_root = config_manager->work_root();
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path))
+  ACHECK(model_config->get_value("root_path", &root_path))
       << "Failed to get value of root_path.";
   std::string config_file;
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "ncut.conf");
 
   NCutConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config))
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config))
       << "Failed to parse CNNSeg config file";
   *param_file = GetAbsolutePath(work_root, config.param_file());
   return true;

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.cc
@@ -32,15 +32,15 @@ using cyber::common::GetAbsolutePath;
 bool MlfEngine::Init(const MultiTargetTrackerInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "mlf_engine.conf");
   MlfEngineConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
 
   main_sensor_.clear();
   for (int i = 0; i < config.main_sensor_size(); ++i) {
@@ -63,11 +63,11 @@ bool MlfEngine::Init(const MultiTargetTrackerInitOptions& options) {
 
   matcher_.reset(new MlfTrackObjectMatcher);
   MlfTrackObjectMatcherInitOptions matcher_init_options;
-  CHECK(matcher_->Init(matcher_init_options));
+  ACHECK(matcher_->Init(matcher_init_options));
 
   tracker_.reset(new MlfTracker);
   MlfTrackerInitOptions tracker_init_options;
-  CHECK(tracker_->Init(tracker_init_options));
+  ACHECK(tracker_->Init(tracker_init_options));
   return true;
 }
 

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_filter.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_filter.cc
@@ -33,15 +33,15 @@ using cyber::common::GetAbsolutePath;
 bool MlfMotionFilter::Init(const MlfFilterInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "mlf_motion_filter.conf");
   MlfMotionFilterConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   use_adaptive_ = config.use_adaptive();
   use_breakdown_ = config.use_breakdown();
   use_convergence_boostup_ = config.use_convergence_boostup();
@@ -58,7 +58,7 @@ bool MlfMotionFilter::Init(const MlfFilterInitOptions& options) {
   motion_measurer_.reset(new MlfMotionMeasurement);
 
   motion_refiner_.reset(new MlfMotionRefiner);
-  CHECK(motion_refiner_->Init());
+  ACHECK(motion_refiner_->Init());
   return true;
 }
 

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_refiner.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_motion_refiner.cc
@@ -32,15 +32,15 @@ using cyber::common::GetAbsolutePath;
 bool MlfMotionRefiner::Init(const MlfMotionRefinerInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "mlf_motion_refiner.conf");
   MlfMotionRefinerConfig config;
-  CHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(apollo::cyber::common::GetProtoFromFile(config_file, &config));
   // read from proto config
   claping_speed_threshold_ = config.claping_speed_threshold();
   claping_acceleration_threshold_ = config.claping_acceleration_threshold();

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_shape_filter.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_shape_filter.cc
@@ -30,15 +30,15 @@ using cyber::common::GetAbsolutePath;
 bool MlfShapeFilter::Init(const MlfFilterInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "mlf_shape_filter.conf");
   MlfShapeFilterConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
 
   bottom_points_ignore_threshold_ = config.bottom_points_ignore_threshold();
   top_points_ignore_threshold_ = config.top_points_ignore_threshold();

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_distance.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_distance.cc
@@ -40,16 +40,16 @@ bool MlfTrackObjectDistance::Init(
     const MlfTrackObjectDistanceInitOptions& options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = cyber::common::GetAbsolutePath(work_root, root_path);
   config_file = cyber::common::GetAbsolutePath(
       config_file, "mlf_track_object_distance.conf");
   MlfDistanceConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
 
   foreground_weight_table_.clear();
   background_weight_table_.clear();

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_matcher.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_track_object_matcher.cc
@@ -28,33 +28,33 @@ bool MlfTrackObjectMatcher::Init(
     const MlfTrackObjectMatcherInitOptions &options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig *model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = cyber::common::GetAbsolutePath(work_root, root_path);
   config_file = cyber::common::GetAbsolutePath(config_file,
                                                "mlf_track_object_matcher.conf");
   MlfTrackObjectMatcherConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
 
   foreground_matcher_.reset(
       BaseBipartiteGraphMatcherRegisterer::GetInstanceByName(
           config.foreground_mathcer_method()));
-  CHECK(foreground_matcher_ != nullptr);
+  ACHECK(foreground_matcher_ != nullptr);
   AINFO << "MlfTrackObjectMatcher, fg: " << foreground_matcher_->Name();
   background_matcher_.reset(
       BaseBipartiteGraphMatcherRegisterer::GetInstanceByName(
           config.background_matcher_method()));
-  CHECK(background_matcher_ != nullptr);
+  ACHECK(background_matcher_ != nullptr);
   AINFO << "MlfTrackObjectMatcher, bg: " << background_matcher_->Name();
   foreground_matcher_->cost_matrix()->Reserve(1000, 1000);
   background_matcher_->cost_matrix()->Reserve(1000, 1000);
 
   track_object_distance_.reset(new MlfTrackObjectDistance);
   MlfTrackObjectDistanceInitOptions distance_init_options;
-  CHECK(track_object_distance_->Init(distance_init_options));
+  ACHECK(track_object_distance_->Init(distance_init_options));
 
   bound_value_ = config.bound_value();
   max_match_distance_ = config.max_match_distance();

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_tracker.cc
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_tracker.cc
@@ -29,22 +29,22 @@ using cyber::common::GetAbsolutePath;
 bool MlfTracker::Init(const MlfTrackerInitOptions options) {
   auto config_manager = lib::ConfigManager::Instance();
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(config_manager->GetModelConfig(Name(), &model_config));
+  ACHECK(config_manager->GetModelConfig(Name(), &model_config));
   const std::string work_root = config_manager->work_root();
   std::string config_file;
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path));
+  ACHECK(model_config->get_value("root_path", &root_path));
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "mlf_tracker.conf");
   MlfTrackerConfig config;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config));
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
 
   for (int i = 0; i < config.filter_name_size(); ++i) {
     const auto& name = config.filter_name(i);
     MlfBaseFilter* filter = MlfBaseFilterRegisterer::GetInstanceByName(name);
-    CHECK(filter);
+    ACHECK(filter);
     MlfFilterInitOptions filter_init_options;
-    CHECK(filter->Init(filter_init_options));
+    ACHECK(filter->Init(filter_init_options));
     filters_.push_back(filter);
     AINFO << "MlfTracker add filter: " << filter->Name();
   }

--- a/modules/perception/lidar/tools/offline_lidar_obstacle_perception.cc
+++ b/modules/perception/lidar/tools/offline_lidar_obstacle_perception.cc
@@ -170,7 +170,7 @@ class OfflineLidarObstaclePerception {
                       return lhs->id < rhs->id;
                     });
           for (std::size_t j = 0; j < objects.size(); ++j) {
-            CHECK(objects[j]->id == result_objects[j]->id);
+            ACHECK(objects[j]->id == result_objects[j]->id);
             objects[j]->track_id = result_objects[j]->track_id;
             objects[j]->tracking_time = result_objects[j]->tracking_time;
             objects[j]->center =

--- a/modules/perception/onboard/component/fusion_camera_detection_component.cc
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.cc
@@ -235,7 +235,7 @@ bool FusionCameraDetectionComponent::Init() {
                  &ex_lidar2imu);
   AINFO << "velodyne128_novatel_extrinsics: " << ex_lidar2imu;
 
-  CHECK(visualize_.Init_all_info_single_camera(
+  ACHECK(visualize_.Init_all_info_single_camera(
       camera_names_, visual_camera_, intrinsic_map_, extrinsic_map_,
       ex_lidar2imu, pitch_adj_degree, yaw_adj_degree, roll_adj_degree,
       image_height_, image_width_));

--- a/modules/perception/onboard/component/fusion_component.cc
+++ b/modules/perception/onboard/component/fusion_component.cc
@@ -42,7 +42,7 @@ bool FusionComponent::Init() {
   radius_for_roi_object_check_ = comp_config.radius_for_roi_object_check();
 
   // init algorithm plugin
-  CHECK(InitAlgorithmPlugin()) << "Failed to init algorithm plugin.";
+  ACHECK(InitAlgorithmPlugin()) << "Failed to init algorithm plugin.";
   writer_ = node_->CreateWriter<PerceptionObstacles>(
       comp_config.output_obstacles_channel_name());
   inner_writer_ = node_->CreateWriter<SensorFrameMessage>(
@@ -83,11 +83,11 @@ bool FusionComponent::InitAlgorithmPlugin() {
   fusion::ObstacleMultiSensorFusionParam param;
   param.main_sensor = fusion_main_sensor_;
   param.fusion_method = fusion_method_;
-  CHECK(fusion_->Init(param)) << "Failed to init ObstacleMultiSensorFusion";
+  ACHECK(fusion_->Init(param)) << "Failed to init ObstacleMultiSensorFusion";
 
   if (FLAGS_obs_enable_hdmap_input && object_in_roi_check_) {
     hdmap_input_ = map::HDMapInput::Instance();
-    CHECK(hdmap_input_->Init()) << "Failed to init hdmap input.";
+    ACHECK(hdmap_input_->Init()) << "Failed to init hdmap input.";
   }
   AINFO << "Init algorithm successfully, onboard fusion: " << fusion_method_;
   return true;

--- a/modules/perception/onboard/component/lane_detection_component.cc
+++ b/modules/perception/onboard/component/lane_detection_component.cc
@@ -211,7 +211,7 @@ bool LaneDetectionComponent::Init() {
                  &ex_lidar2imu);
   AINFO << "velodyne128_novatel_extrinsics: " << ex_lidar2imu;
 
-  CHECK(visualize_.Init_all_info_single_camera(
+  ACHECK(visualize_.Init_all_info_single_camera(
       camera_names_, visual_camera_, intrinsic_map_, extrinsic_map_,
       ex_lidar2imu, pitch_adj_degree, yaw_adj_degree, roll_adj_degree,
       image_height_, image_width_));

--- a/modules/perception/onboard/component/radar_detection_component.cc
+++ b/modules/perception/onboard/component/radar_detection_component.cc
@@ -49,7 +49,7 @@ bool RadarDetectionComponent::Init() {
       comp_config.output_channel_name());
 
   // Init algorithm plugin
-  CHECK(InitAlgorithmPlugin()) << "Failed to init algorithm plugin.";
+  ACHECK(InitAlgorithmPlugin()) << "Failed to init algorithm plugin.";
   radar2world_trans_.Init(tf_child_frame_id_);
   radar2novatel_trans_.Init(tf_child_frame_id_);
   localization_subscriber_.Init(
@@ -76,21 +76,21 @@ bool RadarDetectionComponent::InitAlgorithmPlugin() {
   AINFO << "onboard radar_preprocessor: " << preprocessor_method_;
   if (FLAGS_obs_enable_hdmap_input) {
     hdmap_input_ = map::HDMapInput::Instance();
-    CHECK(hdmap_input_->Init()) << "Failed to init hdmap input.";
+    ACHECK(hdmap_input_->Init()) << "Failed to init hdmap input.";
   }
   radar::BasePreprocessor* preprocessor =
       radar::BasePreprocessorRegisterer::GetInstanceByName(
           preprocessor_method_);
   CHECK_NOTNULL(preprocessor);
   radar_preprocessor_.reset(preprocessor);
-  CHECK(radar_preprocessor_->Init()) << "Failed to init radar preprocessor.";
+  ACHECK(radar_preprocessor_->Init()) << "Failed to init radar preprocessor.";
   radar::BaseRadarObstaclePerception* radar_perception =
       radar::BaseRadarObstaclePerceptionRegisterer::GetInstanceByName(
           perception_method_);
-  CHECK(radar_perception != nullptr)
+  ACHECK(radar_perception != nullptr)
       << "No radar obstacle perception named: " << perception_method_;
   radar_perception_.reset(radar_perception);
-  CHECK(radar_perception_->Init(pipeline_name_))
+  ACHECK(radar_perception_->Init(pipeline_name_))
       << "Failed to init radar perception.";
   AINFO << "Init algorithm plugin successfully.";
   return true;

--- a/modules/perception/onboard/component/segmentation_component.cc
+++ b/modules/perception/onboard/component/segmentation_component.cc
@@ -71,7 +71,7 @@ bool SegmentationComponent::Proc(
 
 bool SegmentationComponent::InitAlgorithmPlugin() {
   ACHECK(common::SensorManager::Instance()->GetSensorInfo(sensor_name_,
-                                                         &sensor_info_));
+                                                          &sensor_info_));
 
   segmentor_.reset(new lidar::LidarObstacleSegmentation);
   if (segmentor_ == nullptr) {

--- a/modules/perception/onboard/component/segmentation_component.cc
+++ b/modules/perception/onboard/component/segmentation_component.cc
@@ -70,7 +70,7 @@ bool SegmentationComponent::Proc(
 }
 
 bool SegmentationComponent::InitAlgorithmPlugin() {
-  CHECK(common::SensorManager::Instance()->GetSensorInfo(sensor_name_,
+  ACHECK(common::SensorManager::Instance()->GetSensorInfo(sensor_name_,
                                                          &sensor_info_));
 
   segmentor_.reset(new lidar::LidarObstacleSegmentation);

--- a/modules/perception/radar/app/radar_obstacle_perception.cc
+++ b/modules/perception/radar/app/radar_obstacle_perception.cc
@@ -29,19 +29,19 @@ namespace radar {
 bool RadarObstaclePerception::Init(const std::string& pipeline_name) {
   std::string model_name = pipeline_name;
   const ModelConfig* model_config = nullptr;
-  CHECK(ConfigManager::Instance()->GetModelConfig(model_name, &model_config))
+  ACHECK(ConfigManager::Instance()->GetModelConfig(model_name, &model_config))
       << "not found model: " << model_name;
 
   std::string detector_name;
-  CHECK(model_config->get_value("Detector", &detector_name))
+  ACHECK(model_config->get_value("Detector", &detector_name))
       << "Detector not found";
 
   std::string roi_filter_name;
-  CHECK(model_config->get_value("RoiFilter", &roi_filter_name))
+  ACHECK(model_config->get_value("RoiFilter", &roi_filter_name))
       << "RoiFilter not found";
 
   std::string tracker_name;
-  CHECK(model_config->get_value("Tracker", &tracker_name))
+  ACHECK(model_config->get_value("Tracker", &tracker_name))
       << "Tracker not found";
 
   BaseDetector* detector =
@@ -58,9 +58,9 @@ bool RadarObstaclePerception::Init(const std::string& pipeline_name) {
   CHECK_NOTNULL(tracker);
   tracker_.reset(tracker);
 
-  CHECK(detector_->Init()) << "radar detector init error";
-  CHECK(roi_filter_->Init()) << "radar roi filter init error";
-  CHECK(tracker_->Init()) << "radar tracker init error";
+  ACHECK(detector_->Init()) << "radar detector init error";
+  ACHECK(roi_filter_->Init()) << "radar roi filter init error";
+  ACHECK(tracker_->Init()) << "radar tracker init error";
 
   return true;
 }

--- a/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
+++ b/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
@@ -27,7 +27,7 @@ bool ContiArsPreprocessor::Init() {
   std::string model_name = "ContiArsPreprocessor";
   const lib::ModelConfig* model_config = nullptr;
   ACHECK(lib::ConfigManager::Instance()->GetModelConfig(model_name,
-                                                       &model_config));
+                                                        &model_config));
   ACHECK(model_config->get_value("delay_time", &delay_time_));
   return true;
 }

--- a/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
+++ b/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
@@ -26,9 +26,9 @@ int ContiArsPreprocessor::local2global_[ORIGIN_CONTI_MAX_ID_NUM] = {0};
 bool ContiArsPreprocessor::Init() {
   std::string model_name = "ContiArsPreprocessor";
   const lib::ModelConfig* model_config = nullptr;
-  CHECK(lib::ConfigManager::Instance()->GetModelConfig(model_name,
+  ACHECK(lib::ConfigManager::Instance()->GetModelConfig(model_name,
                                                        &model_config));
-  CHECK(model_config->get_value("delay_time", &delay_time_));
+  ACHECK(model_config->get_value("delay_time", &delay_time_));
   return true;
 }
 

--- a/modules/perception/radar/lib/tracker/conti_ars_tracker/conti_ars_tracker.cc
+++ b/modules/perception/radar/lib/tracker/conti_ars_tracker/conti_ars_tracker.cc
@@ -80,7 +80,7 @@ bool ContiArsTracker::Init() {
   }
 
   track_manager_ = new RadarTrackManager();
-  CHECK(track_manager_ != nullptr)
+  ACHECK(track_manager_ != nullptr)
       << "Failed to get RadarTrackManager instance.";
   return state;
 }

--- a/modules/perception/radar/lib/tracker/matcher/hm_matcher.cc
+++ b/modules/perception/radar/lib/tracker/matcher/hm_matcher.cc
@@ -44,14 +44,14 @@ bool HMMatcher::Init() {
 
   const std::string &work_root = config_manager->work_root();
   std::string root_path;
-  CHECK(model_config->get_value("root_path", &root_path))
+  ACHECK(model_config->get_value("root_path", &root_path))
       << "Failed to get value of root_path.";
   std::string config_file;
   config_file = GetAbsolutePath(work_root, root_path);
   config_file = GetAbsolutePath(config_file, "hm_matcher.conf");
   // get config params
   MatcherConfig config_params;
-  CHECK(cyber::common::GetProtoFromFile(config_file, &config_params))
+  ACHECK(cyber::common::GetProtoFromFile(config_file, &config_params))
       << "Failed to parse MatcherConfig config file.";
   double max_match_distance = config_params.max_match_distance();
   double bound_match_distance = config_params.bound_match_distance();

--- a/modules/planning/common/obstacle.cc
+++ b/modules/planning/common/obstacle.cc
@@ -84,7 +84,7 @@ Obstacle::Obstacle(const std::string& id,
     }
   }
   ACHECK(common::math::Polygon2d::ComputeConvexHull(polygon_points,
-                                                   &perception_polygon_))
+                                                    &perception_polygon_))
       << "object[" << id << "] polygon is not a valid convex hull.\n"
       << perception_obstacle.DebugString();
 

--- a/modules/planning/common/obstacle.cc
+++ b/modules/planning/common/obstacle.cc
@@ -77,13 +77,13 @@ Obstacle::Obstacle(const std::string& id,
       perception_obstacle.polygon_point_size() <= 2) {
     perception_bounding_box_.GetAllCorners(&polygon_points);
   } else {
-    CHECK(perception_obstacle.polygon_point_size() > 2)
+    ACHECK(perception_obstacle.polygon_point_size() > 2)
         << "object " << id << "has less than 3 polygon points";
     for (const auto& point : perception_obstacle.polygon_point()) {
       polygon_points.emplace_back(point.x(), point.y());
     }
   }
-  CHECK(common::math::Polygon2d::ComputeConvexHull(polygon_points,
+  ACHECK(common::math::Polygon2d::ComputeConvexHull(polygon_points,
                                                    &perception_polygon_))
       << "object[" << id << "] polygon is not a valid convex hull.\n"
       << perception_obstacle.DebugString();

--- a/modules/planning/common/path/discretized_path.cc
+++ b/modules/planning/common/path/discretized_path.cc
@@ -40,7 +40,7 @@ double DiscretizedPath::Length() const {
 }
 
 PathPoint DiscretizedPath::Evaluate(const double path_s) const {
-  CHECK(!empty());
+  ACHECK(!empty());
   auto it_lower = QueryLowerBound(path_s);
   if (it_lower == begin()) {
     return front();
@@ -61,7 +61,7 @@ std::vector<PathPoint>::const_iterator DiscretizedPath::QueryLowerBound(
 }
 
 PathPoint DiscretizedPath::EvaluateReverse(const double path_s) const {
-  CHECK(!empty());
+  ACHECK(!empty());
   auto it_upper = QueryUpperBound(path_s);
   if (it_upper == begin()) {
     return front();

--- a/modules/planning/common/path/path_data.cc
+++ b/modules/planning/common/path/path_data.cc
@@ -119,7 +119,7 @@ common::PathPoint PathData::GetPathPointWithPathS(const double s) const {
 
 bool PathData::GetPathPointWithRefS(const double ref_s,
                                     common::PathPoint *const path_point) const {
-  CHECK(reference_line_);
+  ACHECK(reference_line_);
   DCHECK_EQ(discretized_path_.size(), frenet_path_.size());
   if (ref_s < 0) {
     AERROR << "ref_s[" << ref_s << "] should be > 0";
@@ -214,7 +214,7 @@ bool PathData::SLToXY(const FrenetFramePath &frenet_path,
 
 bool PathData::XYToSL(const DiscretizedPath &discretized_path,
                       FrenetFramePath *const frenet_path) {
-  CHECK(reference_line_);
+  ACHECK(reference_line_);
   std::vector<common::FrenetFramePoint> frenet_frame_points;
   const double max_len = reference_line_->Length();
   for (const auto &path_point : discretized_path) {
@@ -241,7 +241,7 @@ bool PathData::XYToSL(const DiscretizedPath &discretized_path,
 }
 
 bool PathData::LeftTrimWithRefS(const common::FrenetFramePoint &frenet_point) {
-  CHECK(reference_line_);
+  ACHECK(reference_line_);
   std::vector<common::FrenetFramePoint> frenet_frame_points;
   frenet_frame_points.emplace_back(frenet_point);
 

--- a/modules/planning/common/reference_line_info.cc
+++ b/modules/planning/common/reference_line_info.cc
@@ -191,7 +191,7 @@ bool ReferenceLineInfo::GetNeighborLaneInfo(
       break;
     }
     default:
-      CHECK(false);
+      ACHECK(false);
   }
   auto ptr_neighbor_lane =
       hdmap::HDMapUtil::BaseMapPtr()->GetLaneById(*ptr_lane_id);
@@ -494,7 +494,7 @@ RSSInfo* ReferenceLineInfo::mutable_rss_info() { return &rss_info_; }
 bool ReferenceLineInfo::CombinePathAndSpeedProfile(
     const double relative_time, const double start_s,
     DiscretizedTrajectory* ptr_discretized_trajectory) {
-  CHECK(ptr_discretized_trajectory != nullptr);
+  ACHECK(ptr_discretized_trajectory != nullptr);
   // use varied resolution to reduce data load but also provide enough data
   // point for control module
   const double kDenseTimeResoltuion = FLAGS_trajectory_time_min_interval;

--- a/modules/planning/common/speed/speed_data.cc
+++ b/modules/planning/common/speed/speed_data.cc
@@ -46,7 +46,7 @@ void SpeedData::AppendSpeedPoint(const double s, const double time,
                                  const double v, const double a,
                                  const double da) {
   if (!empty()) {
-    CHECK(back().t() < time);
+    ACHECK(back().t() < time);
   }
   push_back(common::util::PointFactory::ToSpeedPoint(s, time, v, a, da));
 }

--- a/modules/planning/common/speed/st_boundary.cc
+++ b/modules/planning/common/speed/st_boundary.cc
@@ -33,7 +33,7 @@ using apollo::common::math::Vec2d;
 STBoundary::STBoundary(
     const std::vector<std::pair<STPoint, STPoint>>& point_pairs,
     bool is_accurate_boundary) {
-  CHECK(IsValid(point_pairs)) << "The input point_pairs are NOT valid";
+  ACHECK(IsValid(point_pairs)) << "The input point_pairs are NOT valid";
 
   std::vector<std::pair<STPoint, STPoint>> reduced_pairs(point_pairs);
   if (!is_accurate_boundary) {

--- a/modules/planning/common/trajectory/discretized_trajectory.cc
+++ b/modules/planning/common/trajectory/discretized_trajectory.cc
@@ -34,7 +34,7 @@ using apollo::common::TrajectoryPoint;
 DiscretizedTrajectory::DiscretizedTrajectory(
     const std::vector<TrajectoryPoint>& trajectory_points)
     : std::vector<TrajectoryPoint>(trajectory_points) {
-  CHECK(!trajectory_points.empty())
+  ACHECK(!trajectory_points.empty())
       << "trajectory_points should NOT be empty()";
 }
 
@@ -64,7 +64,7 @@ TrajectoryPoint DiscretizedTrajectory::Evaluate(
 
 size_t DiscretizedTrajectory::QueryLowerBoundPoint(const double relative_time,
                                                    const double epsilon) const {
-  CHECK(!empty());
+  ACHECK(!empty());
 
   if (relative_time >= back().relative_time()) {
     return size() - 1;
@@ -126,7 +126,7 @@ const TrajectoryPoint& DiscretizedTrajectory::TrajectoryPointAt(
 }
 
 TrajectoryPoint DiscretizedTrajectory::StartPoint() const {
-  CHECK(!empty());
+  ACHECK(!empty());
   return front();
 }
 

--- a/modules/planning/common/trajectory/discretized_trajectory.h
+++ b/modules/planning/common/trajectory/discretized_trajectory.h
@@ -69,7 +69,8 @@ class DiscretizedTrajectory : public std::vector<common::TrajectoryPoint> {
   void PrependTrajectoryPoints(
       const std::vector<common::TrajectoryPoint>& trajectory_points) {
     if (!empty() && trajectory_points.size() > 1) {
-      ACHECK(trajectory_points.back().relative_time() < front().relative_time());
+      ACHECK(trajectory_points.back().relative_time() <
+             front().relative_time());
     }
     insert(begin(), trajectory_points.begin(), trajectory_points.end());
   }

--- a/modules/planning/common/trajectory/discretized_trajectory.h
+++ b/modules/planning/common/trajectory/discretized_trajectory.h
@@ -69,7 +69,7 @@ class DiscretizedTrajectory : public std::vector<common::TrajectoryPoint> {
   void PrependTrajectoryPoints(
       const std::vector<common::TrajectoryPoint>& trajectory_points) {
     if (!empty() && trajectory_points.size() > 1) {
-      CHECK(trajectory_points.back().relative_time() < front().relative_time());
+      ACHECK(trajectory_points.back().relative_time() < front().relative_time());
     }
     insert(begin(), trajectory_points.begin(), trajectory_points.end());
   }

--- a/modules/planning/common/trajectory1d/constant_deceleration_trajectory1d.cc
+++ b/modules/planning/common/trajectory1d/constant_deceleration_trajectory1d.cc
@@ -35,7 +35,7 @@ ConstantDecelerationTrajectory1d::ConstantDecelerationTrajectory1d(
     AERROR << "negative init v = " << init_v_;
   }
   init_v_ = std::fabs(init_v_);
-  CHECK(deceleration_ > 0.0);
+  ACHECK(deceleration_ > 0.0);
   end_t_ = init_v_ / deceleration_;
   end_s_ = init_v_ * init_v_ / (2.0 * deceleration_) + init_s_;
 }

--- a/modules/planning/common/trajectory1d/piecewise_acceleration_trajectory1d.cc
+++ b/modules/planning/common/trajectory1d/piecewise_acceleration_trajectory1d.cc
@@ -46,13 +46,13 @@ void PiecewiseAccelerationTrajectory1d::AppendSegment(const double a,
   double t0 = t_.back();
 
   double v1 = v0 + a * t_duration;
-  CHECK(v1 >= -FLAGS_numerical_epsilon);
+  ACHECK(v1 >= -FLAGS_numerical_epsilon);
 
   double delta_s = (v0 + v1) * t_duration * 0.5;
   double s1 = s0 + delta_s;
   double t1 = t0 + t_duration;
 
-  CHECK(s1 >= s0 - FLAGS_numerical_epsilon);
+  ACHECK(s1 >= s0 - FLAGS_numerical_epsilon);
   s1 = std::max(s1, s0);
   s_.push_back(s1);
   v_.push_back(v1);
@@ -82,7 +82,7 @@ std::string PiecewiseAccelerationTrajectory1d::ToString() const {
 double PiecewiseAccelerationTrajectory1d::Evaluate(const std::uint32_t order,
                                                    const double param) const {
   CHECK_GT(t_.size(), 1);
-  CHECK(t_.front() <= param && param <= t_.back());
+  ACHECK(t_.front() <= param && param <= t_.back());
 
   switch (order) {
     case 0:
@@ -140,7 +140,7 @@ double PiecewiseAccelerationTrajectory1d::Evaluate_j(const double t) const {
 std::array<double, 4> PiecewiseAccelerationTrajectory1d::Evaluate(
     const double t) const {
   CHECK_GT(t_.size(), 1);
-  CHECK(t_.front() <= t && t <= t_.back());
+  ACHECK(t_.front() <= t && t <= t_.back());
 
   auto it_lower = std::lower_bound(t_.begin(), t_.end(), t);
   auto index = std::distance(t_.begin(), it_lower);

--- a/modules/planning/common/trajectory1d/piecewise_trajectory1d.cc
+++ b/modules/planning/common/trajectory1d/piecewise_trajectory1d.cc
@@ -31,7 +31,7 @@ double PiecewiseTrajectory1d::Evaluate(const std::uint32_t order,
                                        const double param) const {
   auto it_lower = std::lower_bound(accumulated_param_lengths_.begin(),
                                    accumulated_param_lengths_.end(), param);
-  CHECK(it_lower != accumulated_param_lengths_.end());
+  ACHECK(it_lower != accumulated_param_lengths_.end());
 
   size_t index = (size_t)(it_lower - accumulated_param_lengths_.begin());
 

--- a/modules/planning/common/trajectory1d/standing_still_trajectory1d.cc
+++ b/modules/planning/common/trajectory1d/standing_still_trajectory1d.cc
@@ -33,7 +33,7 @@ std::string StandingStillTrajectory1d::ToString() const { return ""; }
 
 double StandingStillTrajectory1d::Evaluate(const std::uint32_t order,
                                            const double param) const {
-  //  CHECK(param <= duration_);
+  //  ACHECK(param <= duration_);
   switch (order) {
     case 0:
       return Evaluate_s(param);

--- a/modules/planning/common/util/util.cc
+++ b/modules/planning/common/util/util.cc
@@ -133,7 +133,7 @@ bool CheckInsidePnCJunction(const ReferenceLineInfo& reference_line_info) {
  */
 void GetFilesByPath(const boost::filesystem::path& path,
                     std::vector<std::string>* files) {
-  CHECK(files);
+  ACHECK(files);
   if (!boost::filesystem::exists(path)) {
     return;
   }

--- a/modules/planning/constraint_checker/collision_checker.cc
+++ b/modules/planning/constraint_checker/collision_checker.cc
@@ -117,7 +117,7 @@ void CollisionChecker::BuildPredictedEnvironment(
     const std::vector<const Obstacle*>& obstacles, const double ego_vehicle_s,
     const double ego_vehicle_d,
     const std::vector<PathPoint>& discretized_reference_line) {
-  CHECK(predicted_bounding_rectangles_.empty());
+  ACHECK(predicted_bounding_rectangles_.empty());
 
   // If the ego vehicle is in lane,
   // then, ignore all obstacles from the same lane.

--- a/modules/planning/integration_tests/planning_test_base.cc
+++ b/modules/planning/integration_tests/planning_test_base.cc
@@ -156,18 +156,18 @@ void PlanningTestBase::SetUp() {
     planning_ = std::unique_ptr<PlanningBase>(new OnLanePlanning());
   }
 
-  CHECK(FeedTestData()) << "Failed to feed test data";
+  ACHECK(FeedTestData()) << "Failed to feed test data";
 
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_planning_config_file, &config_))
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_planning_config_file, &config_))
       << "failed to load planning config file " << FLAGS_planning_config_file;
 
-  CHECK(planning_->Init(config_).ok()) << "Failed to init planning module";
+  ACHECK(planning_->Init(config_).ok()) << "Failed to init planning module";
 
   if (!FLAGS_test_previous_planning_file.empty()) {
     const auto prev_planning_file =
         FLAGS_test_data_dir + "/" + FLAGS_test_previous_planning_file;
     ADCTrajectory prev_planning;
-    CHECK(cyber::common::GetProtoFromFile(prev_planning_file, &prev_planning));
+    ACHECK(cyber::common::GetProtoFromFile(prev_planning_file, &prev_planning));
     planning_->last_publishable_trajectory_.reset(
         new PublishableTrajectory(prev_planning));
   }
@@ -180,13 +180,13 @@ void PlanningTestBase::SetUp() {
 }
 
 void PlanningTestBase::UpdateData() {
-  CHECK(FeedTestData()) << "Failed to feed test data";
+  ACHECK(FeedTestData()) << "Failed to feed test data";
 
   if (!FLAGS_test_previous_planning_file.empty()) {
     const auto prev_planning_file =
         FLAGS_test_data_dir + "/" + FLAGS_test_previous_planning_file;
     ADCTrajectory prev_planning;
-    CHECK(cyber::common::GetProtoFromFile(prev_planning_file, &prev_planning));
+    ACHECK(cyber::common::GetProtoFromFile(prev_planning_file, &prev_planning));
     planning_->last_publishable_trajectory_.reset(
         new PublishableTrajectory(prev_planning));
   }

--- a/modules/planning/lattice/behavior/feasible_region.cc
+++ b/modules/planning/lattice/behavior/feasible_region.cc
@@ -38,7 +38,7 @@ FeasibleRegion::FeasibleRegion(const std::array<double, 3>& init_s) {
 }
 
 double FeasibleRegion::SUpper(const double t) const {
-  CHECK(t >= 0.0);
+  ACHECK(t >= 0.0);
   return init_s_[0] + init_s_[1] * t +
          0.5 * FLAGS_longitudinal_acceleration_upper_bound * t * t;
 }
@@ -62,7 +62,7 @@ double FeasibleRegion::VLower(const double t) const {
 }
 
 double FeasibleRegion::TLower(const double s) const {
-  CHECK(s >= init_s_[0]);
+  ACHECK(s >= init_s_[0]);
 
   double delta_s = s - init_s_[0];
   double v = init_s_[1];

--- a/modules/planning/lattice/behavior/path_time_graph.cc
+++ b/modules/planning/lattice/behavior/path_time_graph.cc
@@ -215,7 +215,7 @@ bool PathTimeGraph::GetPathTimeObstacle(const std::string& obstacle_id,
 
 std::vector<std::pair<double, double>> PathTimeGraph::GetPathBlockingIntervals(
     const double t) const {
-  CHECK(time_range_.first <= t && t <= time_range_.second);
+  ACHECK(time_range_.first <= t && t <= time_range_.second);
   std::vector<std::pair<double, double>> intervals;
   for (const auto& pt_obstacle : path_time_obstacles_) {
     if (t > pt_obstacle.max_t() || t < pt_obstacle.min_t()) {
@@ -258,7 +258,7 @@ std::pair<double, double> PathTimeGraph::get_time_range() const {
 std::vector<STPoint> PathTimeGraph::GetObstacleSurroundingPoints(
     const std::string& obstacle_id, const double s_dist,
     const double t_min_density) const {
-  CHECK(t_min_density > 0.0);
+  ACHECK(t_min_density > 0.0);
   std::vector<STPoint> pt_pairs;
   if (path_time_obstacle_map_.find(obstacle_id) ==
       path_time_obstacle_map_.end()) {
@@ -287,7 +287,7 @@ std::vector<STPoint> PathTimeGraph::GetObstacleSurroundingPoints(
   }
 
   double time_gap = t1 - t0;
-  CHECK(time_gap > -FLAGS_numerical_epsilon);
+  ACHECK(time_gap > -FLAGS_numerical_epsilon);
   time_gap = std::fabs(time_gap);
 
   size_t num_sections = static_cast<size_t>(time_gap / t_min_density + 1);

--- a/modules/planning/lattice/behavior/prediction_querier.cc
+++ b/modules/planning/lattice/behavior/prediction_querier.cc
@@ -46,7 +46,7 @@ std::vector<const Obstacle*> PredictionQuerier::GetObstacles() const {
 
 double PredictionQuerier::ProjectVelocityAlongReferenceLine(
     const std::string& obstacle_id, const double s, const double t) const {
-  CHECK(id_obstacle_map_.find(obstacle_id) != id_obstacle_map_.end());
+  ACHECK(id_obstacle_map_.find(obstacle_id) != id_obstacle_map_.end());
 
   const auto& trajectory = id_obstacle_map_.at(obstacle_id)->Trajectory();
   int num_traj_point = trajectory.trajectory_point_size();

--- a/modules/planning/lattice/trajectory_generation/lateral_qp_optimizer.cc
+++ b/modules/planning/lattice/trajectory_generation/lateral_qp_optimizer.cc
@@ -22,7 +22,7 @@ namespace apollo {
 namespace planning {
 
 PiecewiseJerkTrajectory1d LateralQPOptimizer::GetOptimalTrajectory() const {
-  CHECK(!opt_d_.empty() && !opt_d_prime_.empty() && !opt_d_pprime_.empty());
+  ACHECK(!opt_d_.empty() && !opt_d_prime_.empty() && !opt_d_pprime_.empty());
 
   PiecewiseJerkTrajectory1d optimal_trajectory(
       opt_d_.front(), opt_d_prime_.front(), opt_d_pprime_.front());

--- a/modules/planning/lattice/trajectory_generation/lattice_trajectory1d.cc
+++ b/modules/planning/lattice/trajectory_generation/lattice_trajectory1d.cc
@@ -76,17 +76,17 @@ bool LatticeTrajectory1d::has_target_velocity() const {
 bool LatticeTrajectory1d::has_target_time() const { return has_target_time_; }
 
 double LatticeTrajectory1d::target_position() const {
-  CHECK(has_target_position_);
+  ACHECK(has_target_position_);
   return target_position_;
 }
 
 double LatticeTrajectory1d::target_velocity() const {
-  CHECK(has_target_velocity_);
+  ACHECK(has_target_velocity_);
   return target_velocity_;
 }
 
 double LatticeTrajectory1d::target_time() const {
-  CHECK(has_target_time_);
+  ACHECK(has_target_time_);
   return target_time_;
 }
 

--- a/modules/planning/lattice/trajectory_generation/piecewise_braking_trajectory_generator.cc
+++ b/modules/planning/lattice/trajectory_generation/piecewise_braking_trajectory_generator.cc
@@ -111,7 +111,7 @@ std::shared_ptr<Curve1d> PiecewiseBrakingTrajectoryGenerator::Generate(
 
 double PiecewiseBrakingTrajectoryGenerator::ComputeStopDistance(
     const double v, const double dec) {
-  CHECK(dec > 0.0);
+  ACHECK(dec > 0.0);
   return v * v / dec * 0.5;
 }
 

--- a/modules/planning/lattice/trajectory_generation/trajectory1d_generator.h
+++ b/modules/planning/lattice/trajectory_generation/trajectory1d_generator.h
@@ -94,7 +94,7 @@ inline void Trajectory1dGenerator::GenerateTrajectory1DBundle<4>(
     const std::vector<std::pair<std::array<double, 3>, double>>& end_conditions,
     std::vector<std::shared_ptr<Curve1d>>* ptr_trajectory_bundle) const {
   CHECK_NOTNULL(ptr_trajectory_bundle);
-  CHECK(!end_conditions.empty());
+  ACHECK(!end_conditions.empty());
 
   ptr_trajectory_bundle->reserve(ptr_trajectory_bundle->size() +
                                  end_conditions.size());
@@ -116,7 +116,7 @@ inline void Trajectory1dGenerator::GenerateTrajectory1DBundle<5>(
     const std::vector<std::pair<std::array<double, 3>, double>>& end_conditions,
     std::vector<std::shared_ptr<Curve1d>>* ptr_trajectory_bundle) const {
   CHECK_NOTNULL(ptr_trajectory_bundle);
-  CHECK(!end_conditions.empty());
+  ACHECK(!end_conditions.empty());
 
   ptr_trajectory_bundle->reserve(ptr_trajectory_bundle->size() +
                                  end_conditions.size());

--- a/modules/planning/lattice/trajectory_generation/trajectory_evaluator.cc
+++ b/modules/planning/lattice/trajectory_generation/trajectory_evaluator.cc
@@ -100,7 +100,7 @@ size_t TrajectoryEvaluator::num_of_trajectory_pairs() const {
 
 std::pair<PtrTrajectory1d, PtrTrajectory1d>
 TrajectoryEvaluator::next_top_trajectory_pair() {
-  CHECK(has_more_trajectory_pairs());
+  ACHECK(has_more_trajectory_pairs());
   auto top = cost_queue_.top();
   cost_queue_.pop();
   return top.first;
@@ -279,7 +279,7 @@ double TrajectoryEvaluator::CentripetalAccelerationCost(
     double s = lon_trajectory->Evaluate(0, t);
     double v = lon_trajectory->Evaluate(1, t);
     PathPoint ref_point = PathMatcher::MatchToPath(*reference_line_, s);
-    CHECK(ref_point.has_kappa());
+    ACHECK(ref_point.has_kappa());
     double centripetal_acc = v * v * ref_point.kappa();
     centripetal_acc_sum += std::fabs(centripetal_acc);
     centripetal_acc_sqr_sum += centripetal_acc * centripetal_acc;

--- a/modules/planning/math/curve1d/piecewise_quintic_spiral_path.cc
+++ b/modules/planning/math/curve1d/piecewise_quintic_spiral_path.cc
@@ -62,7 +62,7 @@ double PiecewiseQuinticSpiralPath::ParamLength() const {
 }
 
 size_t PiecewiseQuinticSpiralPath::LocatePiece(const double s) const {
-  CHECK(s >= accumulated_s_.front() && s <= accumulated_s_.back());
+  ACHECK(s >= accumulated_s_.front() && s <= accumulated_s_.back());
 
   auto it_lower =
       std::lower_bound(accumulated_s_.begin(), accumulated_s_.end(), s);

--- a/modules/planning/math/curve1d/quintic_spiral_path.cc
+++ b/modules/planning/math/curve1d/quintic_spiral_path.cc
@@ -28,7 +28,7 @@ QuinticSpiralPath::QuinticSpiralPath(const double x0, const double dx0,
                                      const double dx1, const double ddx1,
                                      const double p)
     : QuinticPolynomialCurve1d(x0, dx0, ddx0, x1, dx1, ddx1, p) {
-  CHECK(p > 0.0);
+  ACHECK(p > 0.0);
 
   double p2 = p * p;
   double p3 = p2 * p;

--- a/modules/planning/math/curve1d/quintic_spiral_path_with_derivation.h
+++ b/modules/planning/math/curve1d/quintic_spiral_path_with_derivation.h
@@ -118,7 +118,7 @@ QuinticSpiralPathWithDerivation<N>::QuinticSpiralPathWithDerivation(
     const double x0, const double dx0, const double ddx0, const double x1,
     const double dx1, const double ddx1, const double s)
     : QuinticPolynomialCurve1d(x0, dx0, ddx0, x1, dx1, ddx1, s) {
-  CHECK(s > 0.0);
+  ACHECK(s > 0.0);
 
   auto gauss_points = common::math::GetGaussLegendrePoints<N>();
   gauss_points_ = gauss_points.first;

--- a/modules/planning/math/polynomial_xd.cc
+++ b/modules/planning/math/polynomial_xd.cc
@@ -32,7 +32,7 @@ PolynomialXd::PolynomialXd(const std::uint32_t order)
 
 PolynomialXd::PolynomialXd(const std::vector<double>& params)
     : params_(params) {
-  CHECK(!params.empty());
+  ACHECK(!params.empty());
 }
 
 std::uint32_t PolynomialXd::order() const {
@@ -40,7 +40,7 @@ std::uint32_t PolynomialXd::order() const {
 }
 
 void PolynomialXd::SetParams(const std::vector<double>& params) {
-  CHECK(!params.empty());
+  ACHECK(!params.empty());
   params_ = params;
 }
 

--- a/modules/planning/navi/decider/navi_speed_decider.cc
+++ b/modules/planning/navi/decider/navi_speed_decider.cc
@@ -58,57 +58,57 @@ bool NaviSpeedDecider::Init(const PlanningConfig& planning_config) {
   ACHECK(config.has_planner_navi_config());
   ACHECK(config.planner_navi_config().has_navi_speed_decider_config());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_preferred_accel());
+             .navi_speed_decider_config()
+             .has_preferred_accel());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_preferred_decel());
+             .navi_speed_decider_config()
+             .has_preferred_decel());
   ACHECK(
       config.planner_navi_config().navi_speed_decider_config().has_max_accel());
   ACHECK(
       config.planner_navi_config().navi_speed_decider_config().has_max_decel());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_preferred_jerk());
+             .navi_speed_decider_config()
+             .has_preferred_jerk());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_obstacle_buffer());
+             .navi_speed_decider_config()
+             .has_obstacle_buffer());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_safe_distance_base());
+             .navi_speed_decider_config()
+             .has_safe_distance_base());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_safe_distance_ratio());
+             .navi_speed_decider_config()
+             .has_safe_distance_ratio());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_following_accel_ratio());
+             .navi_speed_decider_config()
+             .has_following_accel_ratio());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_soft_centric_accel_limit());
+             .navi_speed_decider_config()
+             .has_soft_centric_accel_limit());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_hard_centric_accel_limit());
+             .navi_speed_decider_config()
+             .has_hard_centric_accel_limit());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_hard_speed_limit());
+             .navi_speed_decider_config()
+             .has_hard_speed_limit());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_hard_accel_limit());
+             .navi_speed_decider_config()
+             .has_hard_accel_limit());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_enable_safe_path());
+             .navi_speed_decider_config()
+             .has_enable_safe_path());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_enable_planning_start_point());
+             .navi_speed_decider_config()
+             .has_enable_planning_start_point());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_enable_accel_auto_compensation());
+             .navi_speed_decider_config()
+             .has_enable_accel_auto_compensation());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_kappa_preview());
+             .navi_speed_decider_config()
+             .has_kappa_preview());
   ACHECK(config.planner_navi_config()
-            .navi_speed_decider_config()
-            .has_kappa_threshold());
+             .navi_speed_decider_config()
+             .has_kappa_threshold());
 
   max_speed_ = FLAGS_planning_upper_speed_limit;
   preferred_accel_ = std::abs(config.planner_navi_config()

--- a/modules/planning/navi/decider/navi_speed_decider.cc
+++ b/modules/planning/navi/decider/navi_speed_decider.cc
@@ -55,58 +55,58 @@ bool NaviSpeedDecider::Init(const PlanningConfig& planning_config) {
   CHECK_GT(FLAGS_planning_upper_speed_limit, 0.0);
   NavigationPlanningConfig config =
       planning_config.navigation_planning_config();
-  CHECK(config.has_planner_navi_config());
-  CHECK(config.planner_navi_config().has_navi_speed_decider_config());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.has_planner_navi_config());
+  ACHECK(config.planner_navi_config().has_navi_speed_decider_config());
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_preferred_accel());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_preferred_decel());
-  CHECK(
+  ACHECK(
       config.planner_navi_config().navi_speed_decider_config().has_max_accel());
-  CHECK(
+  ACHECK(
       config.planner_navi_config().navi_speed_decider_config().has_max_decel());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_preferred_jerk());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_obstacle_buffer());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_safe_distance_base());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_safe_distance_ratio());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_following_accel_ratio());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_soft_centric_accel_limit());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_hard_centric_accel_limit());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_hard_speed_limit());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_hard_accel_limit());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_enable_safe_path());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_enable_planning_start_point());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_enable_accel_auto_compensation());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_kappa_preview());
-  CHECK(config.planner_navi_config()
+  ACHECK(config.planner_navi_config()
             .navi_speed_decider_config()
             .has_kappa_threshold());
 

--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -71,7 +71,7 @@ Status NaviPlanning::Init(const PlanningConfig& config) {
 
   planner_dispatcher_->Init();
 
-  CHECK(apollo::cyber::common::GetProtoFromFile(
+  ACHECK(apollo::cyber::common::GetProtoFromFile(
       FLAGS_traffic_rule_config_filename, &traffic_rule_configs_))
       << "Failed to load traffic rule config file "
       << FLAGS_traffic_rule_config_filename;

--- a/modules/planning/on_lane_planning.cc
+++ b/modules/planning/on_lane_planning.cc
@@ -86,7 +86,7 @@ Status OnLanePlanning::Init(const PlanningConfig& config) {
 
   planner_dispatcher_->Init();
 
-  CHECK(apollo::cyber::common::GetProtoFromFile(
+  ACHECK(apollo::cyber::common::GetProtoFromFile(
       FLAGS_traffic_rule_config_filename, &traffic_rule_configs_))
       << "Failed to load traffic rule config file "
       << FLAGS_traffic_rule_config_filename;
@@ -99,7 +99,7 @@ Status OnLanePlanning::Init(const PlanningConfig& config) {
 
   // load map
   hdmap_ = HDMapUtil::BaseMapPtr();
-  CHECK(hdmap_) << "Failed to load map";
+  ACHECK(hdmap_) << "Failed to load map";
 
   // instantiate reference line provider
   reference_line_provider_ = std::make_unique<ReferenceLineProvider>(hdmap_);

--- a/modules/planning/open_space/coarse_trajectory_generator/hybrid_a_star_test.cc
+++ b/modules/planning/open_space/coarse_trajectory_generator/hybrid_a_star_test.cc
@@ -39,7 +39,7 @@ class HybridATest : public ::testing::Test {
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
 
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/tools/distance_approach_problem_wrapper.cc
+++ b/modules/planning/open_space/tools/distance_approach_problem_wrapper.cc
@@ -211,7 +211,7 @@ class ResultContainer {
 extern "C" {
 HybridAStar* CreateHybridAPtr() {
   apollo::planning::PlannerOpenSpaceConfig planner_open_space_config_;
-  CHECK(apollo::cyber::common::GetProtoFromFile(
+  ACHECK(apollo::cyber::common::GetProtoFromFile(
       FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
       << "Failed to load open space config file "
       << FLAGS_planner_open_space_config_filename;
@@ -418,7 +418,7 @@ bool DistancePlan(HybridAStar* hybridA_ptr, ObstacleContainer* obstacles_ptr,
                   double sphi, double ex, double ey, double ephi,
                   double* XYbounds) {
   apollo::planning::PlannerOpenSpaceConfig planner_open_space_config_;
-  CHECK(apollo::cyber::common::GetProtoFromFile(
+  ACHECK(apollo::cyber::common::GetProtoFromFile(
       FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
       << "Failed to load open space config file "
       << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/tools/hybrid_a_star_wrapper.cc
+++ b/modules/planning/open_space/tools/hybrid_a_star_wrapper.cc
@@ -78,7 +78,7 @@ extern "C" {
 HybridAStar* CreatePlannerPtr() {
   apollo::planning::PlannerOpenSpaceConfig planner_open_space_config_;
 
-  CHECK(apollo::cyber::common::GetProtoFromFile(
+  ACHECK(apollo::cyber::common::GetProtoFromFile(
       FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
       << "Failed to load open space config file "
       << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/tools/open_space_roi_wrapper.cc
+++ b/modules/planning/open_space/tools/open_space_roi_wrapper.cc
@@ -355,7 +355,7 @@ class OpenSpaceROITest {
       return false;
     }
 
-    CHECK(cyber::common::GetProtoFromFile(
+    ACHECK(cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_cuda_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_cuda_interface.cc
@@ -48,10 +48,10 @@ DistanceApproachIPOPTCUDAInterface::DistanceApproachIPOPTCUDAInterface(
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   obstacles_num_ = static_cast<int>(obstacles_num);
@@ -173,7 +173,7 @@ bool DistanceApproachIPOPTCUDAInterface::get_bounds_info(int n, double* x_l,
                                                          double* g_l,
                                                          double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -391,7 +391,7 @@ bool DistanceApproachIPOPTCUDAInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_cuda_interface_test.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_cuda_interface_test.cc
@@ -31,7 +31,7 @@ class DistanceApproachIPOPTCUDAInterfaceTest : public ::testing::Test {
     FLAGS_planner_open_space_config_filename =
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_fixed_dual_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_fixed_dual_interface.cc
@@ -44,11 +44,11 @@ DistanceApproachIPOPTFixedDualInterface::
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
   ADEBUG << "horizon length: " << horizon_;
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   obstacles_num_ = static_cast<int>(obstacles_num);
@@ -153,7 +153,7 @@ bool DistanceApproachIPOPTFixedDualInterface::get_nlp_info(
 bool DistanceApproachIPOPTFixedDualInterface::get_bounds_info(
     int n, double* x_l, double* x_u, int m, double* g_l, double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -319,7 +319,7 @@ bool DistanceApproachIPOPTFixedDualInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_fixed_ts_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_fixed_ts_interface.cc
@@ -43,10 +43,10 @@ DistanceApproachIPOPTFixedTsInterface::DistanceApproachIPOPTFixedTsInterface(
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   obstacles_num_ = static_cast<int>(obstacles_num);
@@ -152,7 +152,7 @@ bool DistanceApproachIPOPTFixedTsInterface::get_bounds_info(int n, double* x_l,
                                                             double* g_l,
                                                             double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -342,7 +342,7 @@ bool DistanceApproachIPOPTFixedTsInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_interface.cc
@@ -44,10 +44,10 @@ DistanceApproachIPOPTInterface::DistanceApproachIPOPTInterface(
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   obstacles_num_ = static_cast<int>(obstacles_num);
@@ -168,7 +168,7 @@ bool DistanceApproachIPOPTInterface::get_bounds_info(int n, double* x_l,
                                                      double* x_u, int m,
                                                      double* g_l, double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -386,7 +386,7 @@ bool DistanceApproachIPOPTInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_interface_test.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_interface_test.cc
@@ -31,7 +31,7 @@ class DistanceApproachIPOPTInterfaceTest : public ::testing::Test {
     FLAGS_planner_open_space_config_filename =
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_relax_end_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_relax_end_interface.cc
@@ -44,10 +44,10 @@ DistanceApproachIPOPTRelaxEndInterface::DistanceApproachIPOPTRelaxEndInterface(
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   obstacles_num_ = static_cast<int>(obstacles_num);
@@ -169,7 +169,7 @@ bool DistanceApproachIPOPTRelaxEndInterface::get_bounds_info(int n, double* x_l,
                                                              double* g_l,
                                                              double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -387,7 +387,7 @@ bool DistanceApproachIPOPTRelaxEndInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_relax_end_slack_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_ipopt_relax_end_slack_interface.cc
@@ -47,10 +47,10 @@ DistanceApproachIPOPTRelaxEndSlackInterface::
       obstacles_edges_num_(obstacles_edges_num),
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
 
   // TODO(RHe): use relax slacks from dual warm up
@@ -169,7 +169,7 @@ bool DistanceApproachIPOPTRelaxEndSlackInterface::get_nlp_info(
 bool DistanceApproachIPOPTRelaxEndSlackInterface::get_bounds_info(
     int n, double* x_l, double* x_u, int m, double* g_l, double* g_u) {
   ADEBUG << "get_bounds_info";
-  CHECK(XYbounds_.size() == 4)
+  ACHECK(XYbounds_.size() == 4)
       << "XYbounds_ size is not 4, but" << XYbounds_.size();
 
   // Variables: includes state, u, sample time and lagrange multipliers
@@ -403,7 +403,7 @@ bool DistanceApproachIPOPTRelaxEndSlackInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
 
   CHECK_EQ(horizon_, uWS_.cols());
   CHECK_EQ(horizon_ + 1, xWS_.cols());

--- a/modules/planning/open_space/trajectory_smoother/distance_approach_problem_test.cc
+++ b/modules/planning/open_space/trajectory_smoother/distance_approach_problem_test.cc
@@ -33,7 +33,7 @@ class DistanceApproachProblemTest : public ::testing::Test {
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
 
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_interface.cc
@@ -41,10 +41,10 @@ DualVariableWarmStartIPOPTInterface::DualVariableWarmStartIPOPTInterface(
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b),
       xWS_(xWS) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
   obstacles_num_ = static_cast<int>(obstacles_num);
   w_ev_ = ego_(1, 0) + ego_(3, 0);
@@ -102,9 +102,9 @@ bool DualVariableWarmStartIPOPTInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
-  CHECK(!init_z) << "Warm start init_z setting failed";
-  CHECK(!init_lambda) << "Warm start init_lambda setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(!init_z) << "Warm start init_z setting failed";
+  ACHECK(!init_lambda) << "Warm start init_lambda setting failed";
 
   int l_index = l_start_index_;
   int n_index = n_start_index_;

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_interface_test.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_interface_test.cc
@@ -34,7 +34,7 @@ class DualVariableWarmStartIPOPTInterfaceTest : public ::testing::Test {
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
 
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_qp_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_ipopt_qp_interface.cc
@@ -41,10 +41,10 @@ DualVariableWarmStartIPOPTQPInterface::DualVariableWarmStartIPOPTQPInterface(
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b),
       xWS_(xWS) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
   obstacles_num_ = static_cast<int>(obstacles_num);
   w_ev_ = ego_(1, 0) + ego_(3, 0);
@@ -101,9 +101,9 @@ bool DualVariableWarmStartIPOPTQPInterface::get_starting_point(
     int n, bool init_x, double* x, bool init_z, double* z_L, double* z_U, int m,
     bool init_lambda, double* lambda) {
   ADEBUG << "get_starting_point";
-  CHECK(init_x) << "Warm start init_x setting failed";
-  CHECK(!init_z) << "Warm start init_z setting failed";
-  CHECK(!init_lambda) << "Warm start init_lambda setting failed";
+  ACHECK(init_x) << "Warm start init_x setting failed";
+  ACHECK(!init_z) << "Warm start init_z setting failed";
+  ACHECK(!init_lambda) << "Warm start init_lambda setting failed";
 
   int l_index = l_start_index_;
   int n_index = n_start_index_;

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_osqp_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_osqp_interface.cc
@@ -41,10 +41,10 @@ DualVariableWarmStartOSQPInterface::DualVariableWarmStartOSQPInterface(
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b),
       xWS_(xWS) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
   obstacles_num_ = static_cast<int>(obstacles_num);
   w_ev_ = ego_(1, 0) + ego_(3, 0);

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_osqp_interface_test.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_osqp_interface_test.cc
@@ -38,7 +38,7 @@ class DualVariableWarmStartOSQPInterfaceTest : public ::testing::Test {
         "/apollo/modules/planning/testdata/conf/"
         "open_space_standard_parking_lot.pb.txt";
 
-    CHECK(apollo::cyber::common::GetProtoFromFile(
+    ACHECK(apollo::cyber::common::GetProtoFromFile(
         FLAGS_planner_open_space_config_filename, &planner_open_space_config_))
         << "Failed to load open space config file "
         << FLAGS_planner_open_space_config_filename;

--- a/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_slack_osqp_interface.cc
+++ b/modules/planning/open_space/trajectory_smoother/dual_variable_warm_start_slack_osqp_interface.cc
@@ -42,10 +42,10 @@ DualVariableWarmStartSlackOSQPInterface::
       obstacles_A_(obstacles_A),
       obstacles_b_(obstacles_b),
       xWS_(xWS) {
-  CHECK(horizon < std::numeric_limits<int>::max())
+  ACHECK(horizon < std::numeric_limits<int>::max())
       << "Invalid cast on horizon in open space planner";
   horizon_ = static_cast<int>(horizon);
-  CHECK(obstacles_num < std::numeric_limits<int>::max())
+  ACHECK(obstacles_num < std::numeric_limits<int>::max())
       << "Invalid cast on obstacles_num in open space planner";
   obstacles_num_ = static_cast<int>(obstacles_num);
   w_ev_ = ego_(1, 0) + ego_(3, 0);

--- a/modules/planning/planning_component.cc
+++ b/modules/planning/planning_component.cc
@@ -43,7 +43,7 @@ bool PlanningComponent::Init() {
     planning_base_ = std::make_unique<OnLanePlanning>();
   }
 
-  CHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_planning_config_file,
+  ACHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_planning_config_file,
                                                 &config_))
       << "failed to load planning config file " << FLAGS_planning_config_file;
   planning_base_->Init(config_);
@@ -96,7 +96,7 @@ bool PlanningComponent::Proc(
     const std::shared_ptr<canbus::Chassis>& chassis,
     const std::shared_ptr<localization::LocalizationEstimate>&
         localization_estimate) {
-  CHECK(prediction_obstacles != nullptr);
+  ACHECK(prediction_obstacles != nullptr);
 
   // check and process possible rerouting request
   CheckRerouting();

--- a/modules/planning/planning_component.cc
+++ b/modules/planning/planning_component.cc
@@ -44,7 +44,7 @@ bool PlanningComponent::Init() {
   }
 
   ACHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_planning_config_file,
-                                                &config_))
+                                                 &config_))
       << "failed to load planning config file " << FLAGS_planning_config_file;
   planning_base_->Init(config_);
 

--- a/modules/planning/reference_line/reference_line.cc
+++ b/modules/planning/reference_line/reference_line.cc
@@ -214,7 +214,7 @@ common::FrenetFramePoint ReferenceLine::GetFrenetPoint(
 
 std::pair<std::array<double, 3>, std::array<double, 3>>
 ReferenceLine::ToFrenetFrame(const common::TrajectoryPoint& traj_point) const {
-  CHECK(!reference_points_.empty());
+  ACHECK(!reference_points_.empty());
 
   common::SLPoint sl_point;
   XYToSL(traj_point.path_point(), &sl_point);

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -70,7 +70,7 @@ ReferenceLineProvider::ReferenceLineProvider(
   }
 
   ACHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
-                                        &smoother_config_))
+                                         &smoother_config_))
       << "Failed to load smoother config file "
       << FLAGS_smoother_config_filename;
   if (smoother_config_.has_qp_spline()) {
@@ -81,7 +81,7 @@ ReferenceLineProvider::ReferenceLineProvider(
     smoother_.reset(new DiscretePointsReferenceLineSmoother(smoother_config_));
   } else {
     ACHECK(false) << "unknown smoother config "
-                 << smoother_config_.DebugString();
+                  << smoother_config_.DebugString();
   }
   is_initialized_ = true;
 }

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -69,7 +69,7 @@ ReferenceLineProvider::ReferenceLineProvider(
     relative_map_ = relative_map;
   }
 
-  CHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
+  ACHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
                                         &smoother_config_))
       << "Failed to load smoother config file "
       << FLAGS_smoother_config_filename;
@@ -80,7 +80,7 @@ ReferenceLineProvider::ReferenceLineProvider(
   } else if (smoother_config_.has_discrete_points()) {
     smoother_.reset(new DiscretePointsReferenceLineSmoother(smoother_config_));
   } else {
-    CHECK(false) << "unknown smoother config "
+    ACHECK(false) << "unknown smoother config "
                  << smoother_config_.DebugString();
   }
   is_initialized_ = true;

--- a/modules/planning/reference_line/smoother_util.cc
+++ b/modules/planning/reference_line/smoother_util.cc
@@ -58,7 +58,7 @@ class SmootherUtil {
       raw_points_.emplace_back(std::stod(x_str), std::stod(y_str));
     }
     ACHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
-                                          &config_))
+                                           &config_))
         << "Failed to read smoother config file: "
         << FLAGS_smoother_config_filename;
   }

--- a/modules/planning/reference_line/smoother_util.cc
+++ b/modules/planning/reference_line/smoother_util.cc
@@ -57,7 +57,7 @@ class SmootherUtil {
       auto y_str = point_str.substr(idx + 1);
       raw_points_.emplace_back(std::stod(x_str), std::stod(y_str));
     }
-    CHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
+    ACHECK(cyber::common::GetProtoFromFile(FLAGS_smoother_config_filename,
                                           &config_))
         << "Failed to read smoother config file: "
         << FLAGS_smoother_config_filename;

--- a/modules/planning/reference_line/spiral_problem_interface.cc
+++ b/modules/planning/reference_line/spiral_problem_interface.cc
@@ -234,9 +234,9 @@ bool SpiralProblemInterface::get_starting_point(int n, bool init_x, double* x,
                                                 bool init_lambda,
                                                 double* lambda) {
   CHECK_EQ(n, num_of_variables_);
-  CHECK(init_x);
-  CHECK(!init_z);
-  CHECK(!init_lambda);
+  ACHECK(init_x);
+  ACHECK(!init_z);
+  ACHECK(!init_lambda);
 
   for (int i = 0; i < num_of_points_; ++i) {
     int index = i * 5;
@@ -655,7 +655,7 @@ bool SpiralProblemInterface::eval_h(int n, const double* x, bool new_x,
                                     const double* lambda, bool new_lambda,
                                     int nele_hess, int* iRow, int* jCol,
                                     double* values) {
-  CHECK(false);
+  ACHECK(false);
   return true;
 }
 

--- a/modules/planning/reference_line/spiral_smoother_util.cc
+++ b/modules/planning/reference_line/spiral_smoother_util.cc
@@ -99,7 +99,7 @@ class SpiralSmootherUtil {
                   [&start_point](Eigen::Vector2d& p) { p = p - start_point; });
 
     ReferenceLineSmootherConfig config;
-    CHECK(cyber::common::GetProtoFromFile(
+    ACHECK(cyber::common::GetProtoFromFile(
         "modules/planning/conf/spiral_smoother_config.pb.txt", &config));
 
     std::vector<double> opt_theta;

--- a/modules/planning/scenarios/scenario.cc
+++ b/modules/planning/scenarios/scenario.cc
@@ -40,7 +40,7 @@ bool Scenario::LoadConfig(const std::string& config_file,
 }
 
 void Scenario::Init() {
-  CHECK(!config_.stage_type().empty());
+  ACHECK(!config_.stage_type().empty());
 
   // set scenario_type in PlanningContext
   auto* scenario = PlanningContext::Instance()
@@ -54,7 +54,7 @@ void Scenario::Init() {
   }
   for (int i = 0; i < config_.stage_type_size(); ++i) {
     auto stage_type = config_.stage_type(i);
-    CHECK(common::util::ContainsKey(stage_config_map_, stage_type))
+    ACHECK(common::util::ContainsKey(stage_config_map_, stage_type))
         << "stage type : " << ScenarioConfig::StageType_Name(stage_type)
         << " has no config";
   }

--- a/modules/planning/scenarios/scenario_manager.cc
+++ b/modules/planning/scenarios/scenario_manager.cc
@@ -124,7 +124,7 @@ std::unique_ptr<Scenario> ScenarioManager::CreateScenario(
 void ScenarioManager::RegisterScenarios() {
   // lane_follow
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_lane_follow_config_file,
-                             &config_map_[ScenarioConfig::LANE_FOLLOW]));
+                              &config_map_[ScenarioConfig::LANE_FOLLOW]));
 
   // bare_intersection
   ACHECK(Scenario::LoadConfig(
@@ -138,15 +138,15 @@ void ScenarioManager::RegisterScenarios() {
 
   // emergency_stop
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_emergency_stop_config_file,
-                             &config_map_[ScenarioConfig::EMERGENCY_STOP]));
+                              &config_map_[ScenarioConfig::EMERGENCY_STOP]));
 
   // park_and_go
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_park_and_go_config_file,
-                             &config_map_[ScenarioConfig::PARK_AND_GO]));
+                              &config_map_[ScenarioConfig::PARK_AND_GO]));
 
   // pull_over
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_pull_over_config_file,
-                             &config_map_[ScenarioConfig::PULL_OVER]));
+                              &config_map_[ScenarioConfig::PULL_OVER]));
 
   // stop_sign
   ACHECK(Scenario::LoadConfig(
@@ -166,11 +166,11 @@ void ScenarioManager::RegisterScenarios() {
 
   // valet parking
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_valet_parking_config_file,
-                             &config_map_[ScenarioConfig::VALET_PARKING]));
+                              &config_map_[ScenarioConfig::VALET_PARKING]));
 
   // yield_sign
   ACHECK(Scenario::LoadConfig(FLAGS_scenario_yield_sign_config_file,
-                             &config_map_[ScenarioConfig::YIELD_SIGN]));
+                              &config_map_[ScenarioConfig::YIELD_SIGN]));
 }
 
 ScenarioConfig::ScenarioType ScenarioManager::SelectPullOverScenario(

--- a/modules/planning/scenarios/scenario_manager.cc
+++ b/modules/planning/scenarios/scenario_manager.cc
@@ -123,53 +123,53 @@ std::unique_ptr<Scenario> ScenarioManager::CreateScenario(
 
 void ScenarioManager::RegisterScenarios() {
   // lane_follow
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_lane_follow_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_lane_follow_config_file,
                              &config_map_[ScenarioConfig::LANE_FOLLOW]));
 
   // bare_intersection
-  CHECK(Scenario::LoadConfig(
+  ACHECK(Scenario::LoadConfig(
       FLAGS_scenario_bare_intersection_unprotected_config_file,
       &config_map_[ScenarioConfig::BARE_INTERSECTION_UNPROTECTED]));
 
   // emergency_pull_over
-  CHECK(
+  ACHECK(
       Scenario::LoadConfig(FLAGS_scenario_emergency_pull_over_config_file,
                            &config_map_[ScenarioConfig::EMERGENCY_PULL_OVER]));
 
   // emergency_stop
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_emergency_stop_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_emergency_stop_config_file,
                              &config_map_[ScenarioConfig::EMERGENCY_STOP]));
 
   // park_and_go
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_park_and_go_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_park_and_go_config_file,
                              &config_map_[ScenarioConfig::PARK_AND_GO]));
 
   // pull_over
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_pull_over_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_pull_over_config_file,
                              &config_map_[ScenarioConfig::PULL_OVER]));
 
   // stop_sign
-  CHECK(Scenario::LoadConfig(
+  ACHECK(Scenario::LoadConfig(
       FLAGS_scenario_stop_sign_unprotected_config_file,
       &config_map_[ScenarioConfig::STOP_SIGN_UNPROTECTED]));
 
   // traffic_light
-  CHECK(Scenario::LoadConfig(
+  ACHECK(Scenario::LoadConfig(
       FLAGS_scenario_traffic_light_protected_config_file,
       &config_map_[ScenarioConfig::TRAFFIC_LIGHT_PROTECTED]));
-  CHECK(Scenario::LoadConfig(
+  ACHECK(Scenario::LoadConfig(
       FLAGS_scenario_traffic_light_unprotected_left_turn_config_file,
       &config_map_[ScenarioConfig::TRAFFIC_LIGHT_UNPROTECTED_LEFT_TURN]));
-  CHECK(Scenario::LoadConfig(
+  ACHECK(Scenario::LoadConfig(
       FLAGS_scenario_traffic_light_unprotected_right_turn_config_file,
       &config_map_[ScenarioConfig::TRAFFIC_LIGHT_UNPROTECTED_RIGHT_TURN]));
 
   // valet parking
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_valet_parking_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_valet_parking_config_file,
                              &config_map_[ScenarioConfig::VALET_PARKING]));
 
   // yield_sign
-  CHECK(Scenario::LoadConfig(FLAGS_scenario_yield_sign_config_file,
+  ACHECK(Scenario::LoadConfig(FLAGS_scenario_yield_sign_config_file,
                              &config_map_[ScenarioConfig::YIELD_SIGN]));
 }
 
@@ -776,7 +776,7 @@ void ScenarioManager::Observe(const Frame& frame) {
 
 void ScenarioManager::Update(const common::TrajectoryPoint& ego_point,
                              const Frame& frame) {
-  CHECK(!frame.reference_line_info().empty());
+  ACHECK(!frame.reference_line_info().empty());
 
   Observe(frame);
 
@@ -785,7 +785,7 @@ void ScenarioManager::Update(const common::TrajectoryPoint& ego_point,
 
 void ScenarioManager::ScenarioDispatch(const common::TrajectoryPoint& ego_point,
                                        const Frame& frame) {
-  CHECK(!frame.reference_line_info().empty());
+  ACHECK(!frame.reference_line_info().empty());
 
   ////////////////////////////////////////
   // default: LANE_FOLLOW

--- a/modules/planning/scenarios/stage.cc
+++ b/modules/planning/scenarios/stage.cc
@@ -57,7 +57,7 @@ Stage::Stage(const ScenarioConfig::StageConfig& config) : config_(config) {
   }
   for (int i = 0; i < config_.task_type_size(); ++i) {
     auto task_type = config_.task_type(i);
-    CHECK(config_map.find(task_type) != config_map.end())
+    ACHECK(config_map.find(task_type) != config_map.end())
         << "Task: " << TaskConfig::TaskType_Name(task_type)
         << " used but not configured";
     auto iter = tasks_.find(task_type);

--- a/modules/planning/tasks/deciders/creep_decider/creep_decider.cc
+++ b/modules/planning/tasks/deciders/creep_decider/creep_decider.cc
@@ -38,7 +38,7 @@ using apollo::hdmap::PathOverlap;
 uint32_t CreepDecider::creep_clear_counter_ = 0;
 
 CreepDecider::CreepDecider(const TaskConfig& config) : Decider(config) {
-  CHECK(config_.has_creep_decider_config());
+  ACHECK(config_.has_creep_decider_config());
 }
 
 Status CreepDecider::Process(Frame* frame,

--- a/modules/planning/tasks/deciders/lane_change_decider/lane_change_decider.cc
+++ b/modules/planning/tasks/deciders/lane_change_decider/lane_change_decider.cc
@@ -32,7 +32,7 @@ using apollo::common::time::Clock;
 
 LaneChangeDecider::LaneChangeDecider(const TaskConfig& config)
     : Decider(config) {
-  CHECK(config_.has_lane_change_decider_config());
+  ACHECK(config_.has_lane_change_decider_config());
 }
 
 // added a dummy parameter to enable this task in ExecuteTaskOnReferenceLine

--- a/modules/planning/tasks/deciders/open_space_decider/open_space_pre_stop_decider.cc
+++ b/modules/planning/tasks/deciders/open_space_decider/open_space_pre_stop_decider.cc
@@ -39,7 +39,7 @@ using apollo::hdmap::ParkingSpaceInfoConstPtr;
 
 OpenSpacePreStopDecider::OpenSpacePreStopDecider(const TaskConfig& config)
     : Decider(config) {
-  CHECK(config.has_open_space_pre_stop_decider_config());
+  ACHECK(config.has_open_space_pre_stop_decider_config());
 }
 
 Status OpenSpacePreStopDecider::Process(

--- a/modules/planning/tasks/deciders/path_assessment_decider/path_assessment_decider.cc
+++ b/modules/planning/tasks/deciders/path_assessment_decider/path_assessment_decider.cc
@@ -806,8 +806,8 @@ int ContainsOutOnReverseLane(
 
 int GetBackToInLaneIndex(
     const std::vector<PathPointDecision>& path_point_decision) {
-  // CHECK(!path_point_decision.empty());
-  // CHECK(std::get<1>(path_point_decision.back()) ==
+  // ACHECK(!path_point_decision.empty());
+  // ACHECK(std::get<1>(path_point_decision.back()) ==
   //       PathData::PathPointType::IN_LANE);
 
   for (int i = static_cast<int>(path_point_decision.size()) - 1; i >= 0; --i) {

--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -109,7 +109,7 @@ Status PathBoundsDecider::Process(
     if (!ret.ok()) {
       AWARN << "Cannot generate a pullover path bound, do regular planning.";
     } else {
-      CHECK(!pull_over_path_bound.empty());
+      ACHECK(!pull_over_path_bound.empty());
       CHECK_LE(adc_frenet_l_, std::get<2>(pull_over_path_bound[0]));
       CHECK_GE(adc_frenet_l_, std::get<1>(pull_over_path_bound[0]));
 
@@ -909,7 +909,7 @@ bool PathBoundsDecider::GetBoundaryFromRoads(
     const ReferenceLineInfo& reference_line_info, PathBound* const path_bound) {
   // Sanity checks.
   CHECK_NOTNULL(path_bound);
-  CHECK(!path_bound->empty());
+  ACHECK(!path_bound->empty());
   const ReferenceLine& reference_line = reference_line_info.reference_line();
 
   // Go through every point, update the boudnary based on the road boundary.
@@ -963,7 +963,7 @@ bool PathBoundsDecider::GetBoundaryFromLanes(
     std::string* const borrow_lane_type) {
   // Sanity checks.
   CHECK_NOTNULL(path_bound);
-  CHECK(!path_bound->empty());
+  ACHECK(!path_bound->empty());
   const ReferenceLine& reference_line = reference_line_info.reference_line();
 
   // Go through every point, update the boundary based on lane-info.
@@ -1062,7 +1062,7 @@ bool PathBoundsDecider::GetBoundaryFromADC(
     PathBound* const path_bound) {
   // Sanity checks.
   CHECK_NOTNULL(path_bound);
-  CHECK(!path_bound->empty());
+  ACHECK(!path_bound->empty());
 
   // Calculate the ADC's lateral boundary.
   static constexpr double kMaxLateralAccelerations = 1.5;
@@ -1096,7 +1096,7 @@ bool PathBoundsDecider::GetBoundaryFromLanesAndADC(
     PathBound* const path_bound, std::string* const borrow_lane_type) {
   // Sanity checks.
   CHECK_NOTNULL(path_bound);
-  CHECK(!path_bound->empty());
+  ACHECK(!path_bound->empty());
   const ReferenceLine& reference_line = reference_line_info.reference_line();
 
   // Go through every point, update the boundary based on lane info and
@@ -1805,7 +1805,7 @@ void PathBoundsDecider::RecordDebugInfo(
     const PathBound& path_boundaries, const std::string& debug_name,
     ReferenceLineInfo* const reference_line_info) {
   // Sanity checks.
-  CHECK(!path_boundaries.empty());
+  ACHECK(!path_boundaries.empty());
   CHECK_NOTNULL(reference_line_info);
 
   // Take the left and right path boundaries, and transform them into two

--- a/modules/planning/tasks/deciders/path_decider/path_decider.cc
+++ b/modules/planning/tasks/deciders/path_decider/path_decider.cc
@@ -79,7 +79,7 @@ bool PathDecider::MakeStaticObstacleDecision(
     const PathData &path_data, const std::string &blocking_obstacle_id,
     PathDecision *const path_decision) {
   // Sanity checks and get important values.
-  CHECK(path_decision);
+  ACHECK(path_decision);
   const auto &frenet_path = path_data.frenet_frame_path();
   if (frenet_path.empty()) {
     AERROR << "Path is empty.";

--- a/modules/planning/tasks/deciders/rule_based_stop_decider/rule_based_stop_decider.cc
+++ b/modules/planning/tasks/deciders/rule_based_stop_decider/rule_based_stop_decider.cc
@@ -43,7 +43,7 @@ constexpr double kStraightForwardLineCost = 10.0;
 
 RuleBasedStopDecider::RuleBasedStopDecider(const TaskConfig &config)
     : Decider(config) {
-  CHECK(config.has_rule_based_stop_decider_config());
+  ACHECK(config.has_rule_based_stop_decider_config());
   rule_based_stop_decider_config_ = config.rule_based_stop_decider_config();
 }
 

--- a/modules/planning/tasks/deciders/speed_bounds_decider/speed_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/speed_bounds_decider.cc
@@ -41,7 +41,7 @@ using apollo::planning_internal::STGraphDebug;
 
 SpeedBoundsDecider::SpeedBoundsDecider(const TaskConfig &config)
     : Decider(config) {
-  CHECK(config.has_speed_bounds_decider_config());
+  ACHECK(config.has_speed_bounds_decider_config());
   speed_bounds_config_ = config.speed_bounds_decider_config();
 }
 

--- a/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
+++ b/modules/planning/tasks/deciders/speed_bounds_decider/st_boundary_mapper.cc
@@ -76,7 +76,7 @@ Status STBoundaryMapper::ComputeSTBoundary(PathDecision* path_decision) const {
   double min_stop_s = std::numeric_limits<double>::max();
   for (const auto* ptr_obstacle_item : path_decision->obstacles().Items()) {
     Obstacle* ptr_obstacle = path_decision->Find(ptr_obstacle_item->Id());
-    CHECK(ptr_obstacle != nullptr);
+    ACHECK(ptr_obstacle != nullptr);
 
     // If no longitudinal decision has been made, then plot it onto ST-graph.
     if (!ptr_obstacle->HasLongitudinalDecision()) {

--- a/modules/planning/tasks/deciders/st_bounds_decider/st_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/st_bounds_decider/st_bounds_decider.cc
@@ -39,7 +39,7 @@ using ObsDecSet = std::vector<std::pair<std::string, ObjectDecisionType>>;
 }  // namespace
 
 STBoundsDecider::STBoundsDecider(const TaskConfig& config) : Decider(config) {
-  CHECK(config.has_st_bounds_decider_config());
+  ACHECK(config.has_st_bounds_decider_config());
   st_bounds_config_ = config.st_bounds_decider_config();
 }
 

--- a/modules/planning/tasks/optimizers/path_time_heuristic/gridded_path_time_graph_test.cc
+++ b/modules/planning/tasks/optimizers/path_time_heuristic/gridded_path_time_graph_test.cc
@@ -41,12 +41,12 @@ class DpStGraphTest : public ::testing::Test {
     FLAGS_scenario_lane_follow_config_file =
         "/apollo/modules/planning/conf/scenario/lane_follow_config.pb.txt";
     ScenarioConfig config;
-    CHECK(GetProtoFromFile(FLAGS_scenario_lane_follow_config_file, &config));
+    ACHECK(GetProtoFromFile(FLAGS_scenario_lane_follow_config_file, &config));
 
     FLAGS_planning_config_file =
         "/apollo/modules/planning/conf/planning_config.pb.txt";
     PlanningConfig planning_config;
-    CHECK(GetProtoFromFile(FLAGS_planning_config_file, &planning_config))
+    ACHECK(GetProtoFromFile(FLAGS_planning_config_file, &planning_config))
         << "failed to load planning config file " << FLAGS_planning_config_file;
 
     DpStSpeedConfig default_dp_config;

--- a/modules/planning/tasks/optimizers/path_time_heuristic/path_time_heuristic_optimizer.cc
+++ b/modules/planning/tasks/optimizers/path_time_heuristic/path_time_heuristic_optimizer.cc
@@ -35,7 +35,7 @@ using apollo::common::Status;
 
 PathTimeHeuristicOptimizer::PathTimeHeuristicOptimizer(const TaskConfig& config)
     : SpeedOptimizer(config) {
-  CHECK(config.has_speed_heuristic_config());
+  ACHECK(config.has_speed_heuristic_config());
   speed_heuristic_config_ = config.speed_heuristic_config();
 }
 

--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -37,7 +37,7 @@ using apollo::common::VehicleConfigHelper;
 
 PiecewiseJerkPathOptimizer::PiecewiseJerkPathOptimizer(const TaskConfig& config)
     : PathOptimizer(config) {
-  CHECK(config_.has_piecewise_jerk_path_config());
+  ACHECK(config_.has_piecewise_jerk_path_config());
 }
 
 common::Status PiecewiseJerkPathOptimizer::Process(
@@ -270,9 +270,9 @@ FrenetFramePath PiecewiseJerkPathOptimizer::ToPiecewiseJerkPath(
     const std::vector<double>& x, const std::vector<double>& dx,
     const std::vector<double>& ddx, const double delta_s,
     const double start_s) const {
-  CHECK(!x.empty());
-  CHECK(!dx.empty());
-  CHECK(!ddx.empty());
+  ACHECK(!x.empty());
+  ACHECK(!dx.empty());
+  ACHECK(!ddx.empty());
 
   PiecewiseJerkTrajectory1d piecewise_jerk_traj(x.front(), dx.front(),
                                                 ddx.front());

--- a/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_nonlinear_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_nonlinear_optimizer.cc
@@ -49,7 +49,7 @@ PiecewiseJerkSpeedNonlinearOptimizer::PiecewiseJerkSpeedNonlinearOptimizer(
     : SpeedOptimizer(config),
       smoothed_speed_limit_(0.0, 0.0, 0.0),
       smoothed_path_curvature_(0.0, 0.0, 0.0) {
-  CHECK(config_.has_piecewise_jerk_nonlinear_speed_config());
+  ACHECK(config_.has_piecewise_jerk_nonlinear_speed_config());
 }
 
 Status PiecewiseJerkSpeedNonlinearOptimizer::Process(

--- a/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_speed/piecewise_jerk_speed_optimizer.cc
@@ -44,7 +44,7 @@ using apollo::common::TrajectoryPoint;
 PiecewiseJerkSpeedOptimizer::PiecewiseJerkSpeedOptimizer(
     const TaskConfig& config)
     : SpeedOptimizer(config) {
-  CHECK(config_.has_piecewise_jerk_speed_config());
+  ACHECK(config_.has_piecewise_jerk_speed_config());
 }
 
 Status PiecewiseJerkSpeedOptimizer::Process(const PathData& path_data,
@@ -54,7 +54,7 @@ Status PiecewiseJerkSpeedOptimizer::Process(const PathData& path_data,
     return Status::OK();
   }
 
-  CHECK(speed_data != nullptr);
+  ACHECK(speed_data != nullptr);
   SpeedData reference_speed_data = *speed_data;
 
   if (path_data.discretized_path().empty()) {

--- a/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
+++ b/modules/planning/tasks/optimizers/road_graph/dp_road_graph.cc
@@ -107,7 +107,7 @@ bool DpRoadGraph::FindPathTunnel(const common::TrajectoryPoint &init_point,
 bool DpRoadGraph::GenerateMinCostPath(
     const std::vector<const Obstacle *> &obstacles,
     std::vector<DpRoadGraphNode> *min_cost_path) {
-  CHECK(min_cost_path != nullptr);
+  ACHECK(min_cost_path != nullptr);
 
   std::vector<std::vector<common::SLPoint>> path_waypoints;
   if (!waypoint_sampler_->SamplePathWaypoints(init_point_, &path_waypoints) ||

--- a/modules/prediction/common/environment_features.cc
+++ b/modules/prediction/common/environment_features.cc
@@ -66,7 +66,7 @@ void EnvironmentFeatures::SetEgoLane(const std::string& lane_id,
 }
 
 std::pair<std::string, double> EnvironmentFeatures::GetEgoLane() const {
-  CHECK(has_ego_lane_);
+  ACHECK(has_ego_lane_);
   return {ego_lane_id_, ego_lane_s_};
 }
 
@@ -87,7 +87,7 @@ void EnvironmentFeatures::SetLeftNeighborLane(const std::string& lane_id,
 
 std::pair<std::string, double> EnvironmentFeatures::GetLeftNeighborLane()
     const {
-  CHECK(has_left_neighbor_lane_);
+  ACHECK(has_left_neighbor_lane_);
   return {left_neighbor_lane_id_, left_neighbor_lane_s_};
 }
 
@@ -108,7 +108,7 @@ void EnvironmentFeatures::SetRightNeighborLane(const std::string& lane_id,
 
 std::pair<std::string, double> EnvironmentFeatures::GetRightNeighborLane()
     const {
-  CHECK(has_right_neighbor_lane_);
+  ACHECK(has_right_neighbor_lane_);
   return {right_neighbor_lane_id_, right_neighbor_lane_s_};
 }
 
@@ -128,7 +128,7 @@ void EnvironmentFeatures::SetFrontJunction(const std::string& junction_id,
 }
 
 std::pair<std::string, double> EnvironmentFeatures::GetFrontJunction() const {
-  CHECK(has_front_junction_);
+  ACHECK(has_front_junction_);
   return {front_junction_id_, dist_to_front_junction_};
 }
 

--- a/modules/prediction/common/message_process.cc
+++ b/modules/prediction/common/message_process.cc
@@ -245,7 +245,7 @@ void MessageProcess::OnLocalization(
   auto ptr_ego_pose_container =
       ContainerManager::Instance()->GetContainer<PoseContainer>(
           AdapterConfig::LOCALIZATION);
-  CHECK(ptr_ego_pose_container != nullptr);
+  ACHECK(ptr_ego_pose_container != nullptr);
   ptr_ego_pose_container->Insert(localization);
 
   ADEBUG << "Received a localization message ["
@@ -256,7 +256,7 @@ void MessageProcess::OnPlanning(const planning::ADCTrajectory& adc_trajectory) {
   auto ptr_ego_trajectory_container =
       ContainerManager::Instance()->GetContainer<ADCTrajectoryContainer>(
           AdapterConfig::PLANNING_TRAJECTORY);
-  CHECK(ptr_ego_trajectory_container != nullptr);
+  ACHECK(ptr_ego_trajectory_container != nullptr);
   ptr_ego_trajectory_container->Insert(adc_trajectory);
 
   ADEBUG << "Received a planning message [" << adc_trajectory.ShortDebugString()

--- a/modules/prediction/common/prediction_map.cc
+++ b/modules/prediction/common/prediction_map.cc
@@ -659,8 +659,8 @@ int PredictionMap::LaneTurnType(const std::string& lane_id) {
 
 std::vector<std::shared_ptr<const LaneInfo>> PredictionMap::GetNearbyLanes(
     const common::PointENU& position, const double nearby_radius) {
-  CHECK(position.has_x() && position.has_y() && position.has_z());
-  CHECK(nearby_radius > 0.0);
+  ACHECK(position.has_x() && position.has_y() && position.has_z());
+  ACHECK(nearby_radius > 0.0);
 
   std::vector<std::shared_ptr<const LaneInfo>> nearby_lanes;
 
@@ -670,7 +670,7 @@ std::vector<std::shared_ptr<const LaneInfo>> PredictionMap::GetNearbyLanes(
 
 std::shared_ptr<const LaneInfo> PredictionMap::LaneWithSmallestAverageCurvature(
     const std::vector<std::shared_ptr<const LaneInfo>>& lane_infos) {
-  CHECK(!lane_infos.empty());
+  ACHECK(!lane_infos.empty());
   size_t sample_size = FLAGS_sample_size_for_average_lane_curvature;
   std::shared_ptr<const hdmap::LaneInfo> selected_lane_info = lane_infos[0];
   if (selected_lane_info == nullptr) {

--- a/modules/prediction/container/obstacles/obstacle.cc
+++ b/modules/prediction/container/obstacles/obstacle.cc
@@ -53,33 +53,33 @@ PerceptionObstacle::Type Obstacle::type() const { return type_; }
 int Obstacle::id() const { return id_; }
 
 double Obstacle::timestamp() const {
-  CHECK(!feature_history_.empty());
+  ACHECK(!feature_history_.empty());
   return feature_history_.front().timestamp();
 }
 
 const Feature& Obstacle::feature(const size_t i) const {
-  CHECK(i < feature_history_.size());
+  ACHECK(i < feature_history_.size());
   return feature_history_[i];
 }
 
 Feature* Obstacle::mutable_feature(const size_t i) {
-  CHECK(!feature_history_.empty());
-  CHECK(i < feature_history_.size());
+  ACHECK(!feature_history_.empty());
+  ACHECK(i < feature_history_.size());
   return &feature_history_[i];
 }
 
 const Feature& Obstacle::latest_feature() const {
-  CHECK(!feature_history_.empty());
+  ACHECK(!feature_history_.empty());
   return feature_history_.front();
 }
 
 const Feature& Obstacle::earliest_feature() const {
-  CHECK(!feature_history_.empty());
+  ACHECK(!feature_history_.empty());
   return feature_history_.back();
 }
 
 Feature* Obstacle::mutable_latest_feature() {
-  CHECK(!feature_history_.empty());
+  ACHECK(!feature_history_.empty());
   return &(feature_history_.front());
 }
 
@@ -248,7 +248,7 @@ void Obstacle::BuildJunctionFeature() {
   }
   const Feature& prev_feature = feature(1);
   if (prev_feature.junction_feature().has_enter_lane()) {
-    CHECK(prev_feature.junction_feature().enter_lane().has_lane_id());
+    ACHECK(prev_feature.junction_feature().enter_lane().has_lane_id());
     std::string enter_lane_id =
         prev_feature.junction_feature().enter_lane().lane_id();
     // TODO(all) use enter lane when tracking is better

--- a/modules/prediction/evaluator/cyclist/cyclist_keep_lane_evaluator_test.cc
+++ b/modules/prediction/evaluator/cyclist/cyclist_keep_lane_evaluator_test.cc
@@ -28,7 +28,7 @@ class CyclistKeepLaneEvaluatorTest : public KMLMapBasedTest {
   void SetUp() override {
     const std::string file =
         "modules/prediction/testdata/single_perception_cyclist_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/evaluator/evaluator_manager_test.cc
+++ b/modules/prediction/evaluator/evaluator_manager_test.cc
@@ -31,7 +31,7 @@ class EvaluatorManagerTest : public KMLMapBasedTest {
   virtual void SetUp() {
     const std::string file =
         "modules/prediction/testdata/single_perception_vehicle_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/evaluator/pedestrian/pedestrian_interaction_evaluator.cc
+++ b/modules/prediction/evaluator/pedestrian/pedestrian_interaction_evaluator.cc
@@ -191,7 +191,7 @@ bool PedestrianInteractionEvaluator::Evaluate(
   for (int i = 1; i <= kShortTermPredictionPointNum; ++i) {
     double prev_x = trajectory->trajectory_point(i - 1).path_point().x();
     double prev_y = trajectory->trajectory_point(i - 1).path_point().y();
-    CHECK(obstacle_id_lstm_state_map_.find(id) !=
+    ACHECK(obstacle_id_lstm_state_map_.find(id) !=
           obstacle_id_lstm_state_map_.end());
     torch::Tensor torch_position = torch::zeros({1, 2});
     double curr_rel_x = rel_x;

--- a/modules/prediction/evaluator/pedestrian/pedestrian_interaction_evaluator.cc
+++ b/modules/prediction/evaluator/pedestrian/pedestrian_interaction_evaluator.cc
@@ -192,7 +192,7 @@ bool PedestrianInteractionEvaluator::Evaluate(
     double prev_x = trajectory->trajectory_point(i - 1).path_point().x();
     double prev_y = trajectory->trajectory_point(i - 1).path_point().y();
     ACHECK(obstacle_id_lstm_state_map_.find(id) !=
-          obstacle_id_lstm_state_map_.end());
+           obstacle_id_lstm_state_map_.end());
     torch::Tensor torch_position = torch::zeros({1, 2});
     double curr_rel_x = rel_x;
     double curr_rel_y = rel_y;

--- a/modules/prediction/evaluator/vehicle/cost_evaluator_test.cc
+++ b/modules/prediction/evaluator/vehicle/cost_evaluator_test.cc
@@ -28,7 +28,7 @@ class CostEvaluatorTest : public KMLMapBasedTest {
   void SetUp() override {
     const std::string file =
         "modules/prediction/testdata/single_perception_vehicle_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/evaluator/vehicle/cruise_mlp_evaluator_test.cc
+++ b/modules/prediction/evaluator/vehicle/cruise_mlp_evaluator_test.cc
@@ -28,7 +28,7 @@ class CruiseMLPEvaluatorTest : public KMLMapBasedTest {
   void SetUp() override {
     const std::string file =
         "modules/prediction/testdata/single_perception_vehicle_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/evaluator/vehicle/junction_mlp_evaluator_test.cc
+++ b/modules/prediction/evaluator/vehicle/junction_mlp_evaluator_test.cc
@@ -31,7 +31,7 @@ class JunctionMLPEvaluatorTest : public KMLMapBasedTest {
     const std::string file =
         "modules/prediction/testdata/"
         "single_perception_vehicle_injunction.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
     FLAGS_enable_all_junction = true;
     JunctionAnalyzer::Init("j2");
   }

--- a/modules/prediction/evaluator/vehicle/lane_aggregating_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/lane_aggregating_evaluator.cc
@@ -440,7 +440,7 @@ torch::Tensor LaneAggregatingEvaluator::AggregateLaneEncodings(
 
 torch::Tensor LaneAggregatingEvaluator::LaneEncodingMaxPooling(
     const std::vector<torch::Tensor>& lane_encoding_list) {
-  CHECK(!lane_encoding_list.empty());
+  ACHECK(!lane_encoding_list.empty());
   torch::Tensor output_tensor = lane_encoding_list[0];
 
   for (size_t i = 1; i < lane_encoding_list.size(); ++i) {
@@ -454,7 +454,7 @@ torch::Tensor LaneAggregatingEvaluator::LaneEncodingMaxPooling(
 
 torch::Tensor LaneAggregatingEvaluator::LaneEncodingAvgPooling(
     const std::vector<torch::Tensor>& lane_encoding_list) {
-  CHECK(!lane_encoding_list.empty());
+  ACHECK(!lane_encoding_list.empty());
   torch::Tensor output_tensor = lane_encoding_list[0];
 
   for (size_t i = 1; i < lane_encoding_list.size(); ++i) {

--- a/modules/prediction/evaluator/vehicle/mlp_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/mlp_evaluator.cc
@@ -94,7 +94,7 @@ bool MLPEvaluator::Evaluate(Obstacle* obstacle_ptr,
 
   for (int i = 0; i < lane_graph_ptr->lane_sequence_size(); ++i) {
     LaneSequence* lane_sequence_ptr = lane_graph_ptr->mutable_lane_sequence(i);
-    CHECK(lane_sequence_ptr != nullptr);
+    ACHECK(lane_sequence_ptr != nullptr);
     std::vector<double> lane_feature_values;
     SetLaneFeatureValues(obstacle_ptr, lane_sequence_ptr, &lane_feature_values);
     if (lane_feature_values.size() != LANE_FEATURE_SIZE) {
@@ -358,8 +358,8 @@ void MLPEvaluator::SetLaneFeatureValues(Obstacle* obstacle_ptr,
 
 void MLPEvaluator::LoadModel(const std::string& model_file) {
   model_ptr_.reset(new FnnVehicleModel());
-  CHECK(model_ptr_ != nullptr);
-  CHECK(cyber::common::GetProtoFromFile(model_file, model_ptr_.get()))
+  ACHECK(model_ptr_ != nullptr);
+  ACHECK(cyber::common::GetProtoFromFile(model_file, model_ptr_.get()))
       << "Unable to load model file: " << model_file << ".";
 
   AINFO << "Succeeded in loading the model file: " << model_file << ".";

--- a/modules/prediction/evaluator/vehicle/mlp_evaluator_test.cc
+++ b/modules/prediction/evaluator/vehicle/mlp_evaluator_test.cc
@@ -28,7 +28,7 @@ class MLPEvaluatorTest : public KMLMapBasedTest {
   void SetUp() override {
     const std::string file =
         "modules/prediction/testdata/single_perception_vehicle_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/network/net_layer.cc
+++ b/modules/prediction/network/net_layer.cc
@@ -161,7 +161,7 @@ bool MaxPool1d::Load(const LayerParameter& layer_pb) {
 }
 
 bool MaxPool1d::Load(const MaxPool1dParameter& maxpool1d_pb) {
-  CHECK(maxpool1d_pb.has_kernel_size());
+  ACHECK(maxpool1d_pb.has_kernel_size());
   CHECK_GT(maxpool1d_pb.has_kernel_size(), 0);
   kernel_size_ = maxpool1d_pb.kernel_size();
   if (maxpool1d_pb.has_stride() && maxpool1d_pb.stride() > 0) {
@@ -204,7 +204,7 @@ bool AvgPool1d::Load(const LayerParameter& layer_pb) {
 }
 
 bool AvgPool1d::Load(const AvgPool1dParameter& avgpool1d_pb) {
-  CHECK(avgpool1d_pb.has_kernel_size());
+  ACHECK(avgpool1d_pb.has_kernel_size());
   CHECK_GT(avgpool1d_pb.has_kernel_size(), 0);
   kernel_size_ = avgpool1d_pb.kernel_size();
   if (avgpool1d_pb.has_stride() && avgpool1d_pb.stride() > 0) {

--- a/modules/prediction/predictor/free_move/free_move_predictor_test.cc
+++ b/modules/prediction/predictor/free_move/free_move_predictor_test.cc
@@ -27,7 +27,7 @@ namespace prediction {
 class FreeMovePredictorTest : public KMLMapBasedTest {
  public:
   FreeMovePredictorTest() {
-    CHECK(cyber::common::GetProtoFromFile(
+    ACHECK(cyber::common::GetProtoFromFile(
         "modules/prediction/testdata/single_perception_vehicle_offlane.pb.txt",
         &perception_obstacles_));
     FLAGS_p_var = 0.1;

--- a/modules/prediction/predictor/junction/junction_predictor_test.cc
+++ b/modules/prediction/predictor/junction/junction_predictor_test.cc
@@ -32,7 +32,7 @@ class JunctionPredictorTest : public KMLMapBasedTest {
     const std::string file =
         "modules/prediction/testdata/"
         "single_perception_vehicle_injunction.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
     FLAGS_enable_all_junction = true;
     JunctionAnalyzer::Init("j2");
   }

--- a/modules/prediction/predictor/predictor.cc
+++ b/modules/prediction/predictor/predictor.cc
@@ -42,7 +42,7 @@ void Predictor::SetEqualProbability(const double total_probability,
                                     const int start_index,
                                     Obstacle* obstacle_ptr) {
   int num = NumOfTrajectories(*obstacle_ptr);
-  CHECK(num > start_index);
+  ACHECK(num > start_index);
 
   const auto prob = total_probability / static_cast<double>(num - start_index);
   for (int i = start_index; i < num; ++i) {

--- a/modules/prediction/predictor/predictor_manager_test.cc
+++ b/modules/prediction/predictor/predictor_manager_test.cc
@@ -33,7 +33,7 @@ class PredictorManagerTest : public KMLMapBasedTest {
   void SetUp() override {
     std::string file =
         "modules/prediction/testdata/single_perception_vehicle_onlane.pb.txt";
-    CHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
+    ACHECK(cyber::common::GetProtoFromFile(file, &perception_obstacles_));
   }
 
  protected:

--- a/modules/prediction/scenario/scenario_features/junction_scenario_features.cc
+++ b/modules/prediction/scenario/scenario_features/junction_scenario_features.cc
@@ -27,7 +27,7 @@ JunctionScenarioFeatures::~JunctionScenarioFeatures() {}
 
 void JunctionScenarioFeatures::BuildJunctionScenarioFeatures(
     const EnvironmentFeatures& environment_features) {
-  // CHECK(environment_features.has_front_junction());
+  // ACHECK(environment_features.has_front_junction());
   scenario_.set_junction_id(environment_features.GetFrontJunction().first);
 }
 

--- a/modules/prediction/util/data_extraction.cc
+++ b/modules/prediction/util/data_extraction.cc
@@ -23,7 +23,7 @@ namespace prediction {
 
 void GetRecordFileNames(const boost::filesystem::path& p,
                         std::vector<std::string>* record_files) {
-  CHECK(record_files);
+  ACHECK(record_files);
   if (!boost::filesystem::exists(p)) {
     return;
   }

--- a/modules/routing/core/result_generator.cc
+++ b/modules/routing/core/result_generator.cc
@@ -34,7 +34,7 @@ bool IsCloseEnough(double value_1, double value_2) {
 
 const NodeWithRange& GetLargestRange(
     const std::vector<NodeWithRange>& node_vec) {
-  CHECK(!node_vec.empty());
+  ACHECK(!node_vec.empty());
   size_t result_idx = 0;
   double result_range_length = 0.0;
   for (size_t i = 0; i < node_vec.size(); ++i) {
@@ -49,7 +49,7 @@ const NodeWithRange& GetLargestRange(
 bool ResultGenerator::ExtractBasicPassages(
     const std::vector<NodeWithRange>& nodes,
     std::vector<PassageInfo>* const passages) {
-  CHECK(!nodes.empty());
+  ACHECK(!nodes.empty());
   passages->clear();
   std::vector<NodeWithRange> nodes_of_passage;
   nodes_of_passage.push_back(nodes.at(0));
@@ -349,7 +349,7 @@ void ResultGenerator::AddRoadSegment(
 
 void ResultGenerator::CreateRoadSegments(
     const std::vector<PassageInfo>& passages, RoutingResponse* result) {
-  CHECK(!passages.empty()) << "passages empty";
+  ACHECK(!passages.empty()) << "passages empty";
   NodeWithRange fake_node_range(passages.front().nodes.front());
   bool in_change_lane = false;
   std::pair<std::size_t, std::size_t> start_index(0, 0);

--- a/modules/routing/graph/topo_node.cc
+++ b/modules/routing/graph/topo_node.cc
@@ -96,7 +96,7 @@ bool TopoNode::IsOutRangeEnough(const std::vector<NodeSRange>& range_vec,
 
 TopoNode::TopoNode(const Node& node)
     : pb_node_(node), start_s_(0.0), end_s_(pb_node_.length()) {
-  CHECK(pb_node_.length() > kLenghtEpsilon)
+  ACHECK(pb_node_.length() > kLenghtEpsilon)
       << "Node length is invalid in pb: " << pb_node_.DebugString();
   Init();
   origin_node_ = this;

--- a/modules/routing/routing.cc
+++ b/modules/routing/routing.cc
@@ -35,14 +35,14 @@ apollo::common::Status Routing::Init() {
   const auto routing_map_file = apollo::hdmap::RoutingMapFile();
   AINFO << "Use routing topology graph path: " << routing_map_file;
   navigator_ptr_.reset(new Navigator(routing_map_file));
-  CHECK(
+  ACHECK(
       cyber::common::GetProtoFromFile(FLAGS_routing_conf_file, &routing_conf_))
       << "Unable to load routing conf file: " + FLAGS_routing_conf_file;
 
   AINFO << "Conf file: " << FLAGS_routing_conf_file << " is loaded.";
 
   hdmap_ = apollo::hdmap::HDMapUtil::BaseMapPtr();
-  CHECK(hdmap_) << "Failed to load map file:" << apollo::hdmap::BaseMapFile();
+  ACHECK(hdmap_) << "Failed to load map file:" << apollo::hdmap::BaseMapFile();
 
   return apollo::common::Status::OK();
 }

--- a/modules/routing/topo_creator/topo_creator.cc
+++ b/modules/routing/topo_creator/topo_creator.cc
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
   apollo::routing::RoutingConfig routing_conf;
 
   ACHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_routing_conf_file,
-                                                &routing_conf))
+                                                 &routing_conf))
       << "Unable to load routing conf file: " + FLAGS_routing_conf_file;
 
   AINFO << "Conf file: " << FLAGS_routing_conf_file << " is loaded.";

--- a/modules/routing/topo_creator/topo_creator.cc
+++ b/modules/routing/topo_creator/topo_creator.cc
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 
   apollo::routing::RoutingConfig routing_conf;
 
-  CHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_routing_conf_file,
+  ACHECK(apollo::cyber::common::GetProtoFromFile(FLAGS_routing_conf_file,
                                                 &routing_conf))
       << "Unable to load routing conf file: " + FLAGS_routing_conf_file;
 
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
   const auto routing_map = apollo::hdmap::RoutingMapFile();
 
   apollo::routing::GraphCreator creator(base_map, routing_map, routing_conf);
-  CHECK(creator.Create()) << "Create routing topo failed!";
+  ACHECK(creator.Create()) << "Create routing topo failed!";
 
   AINFO << "Create routing topo successfully from " << base_map << " to "
         << routing_map;

--- a/modules/storytelling/story_tellers/close_to_junction_teller.cc
+++ b/modules/storytelling/story_tellers/close_to_junction_teller.cc
@@ -101,7 +101,7 @@ double DistanceToJunction(const ADCTrajectory& adc_trajectory,
 void CloseToJunctionTeller::Init() {
   auto* manager = FrameManager::Instance();
   manager->CreateOrGetReader<ADCTrajectory>(FLAGS_planning_trajectory_topic);
-  CHECK(PredictionMap::Ready()) << "PredictionMap not ready";
+  ACHECK(PredictionMap::Ready()) << "PredictionMap not ready";
 }
 
 void CloseToJunctionTeller::Update(Stories* stories) {

--- a/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_server.cc
+++ b/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_server.cc
@@ -28,10 +28,10 @@ using apollo::perception::PerceptionObstacles;
 using grpc::Status;
 
 GrpcServerImpl::GrpcServerImpl() : node_(cyber::CreateNode("v2x_grpc_server")) {
-  CHECK(node_) << "Create v2x grpc server node failed";
+  ACHECK(node_) << "Create v2x grpc server node failed";
   first_flag_writer_ =
       node_->CreateWriter<StatusResponse>("/apollo/v2x/inner/sync_flag");
-  CHECK(first_flag_writer_) << "Create sync flag writer failed";
+  ACHECK(first_flag_writer_) << "Create sync flag writer failed";
   AINFO << "GrpcServerImpl initial success";
   init_flag_ = true;
 }

--- a/modules/v2x/v2x_proxy/obu_interface/obu_interface_grpc_impl.cc
+++ b/modules/v2x/v2x_proxy/obu_interface/obu_interface_grpc_impl.cc
@@ -36,11 +36,11 @@ ObuInterFaceGrpcImpl::ObuInterFaceGrpcImpl() {
                           grpc::InsecureChannelCredentials()));
   grpc_client_init_flag_ = grpc_client_->InitFlag();
   bool res_client = InitialClient();
-  CHECK(res_client) << "ObuInterFaceGrpcImpl grpc client initial failed";
+  ACHECK(res_client) << "ObuInterFaceGrpcImpl grpc client initial failed";
   grpc_server_ = std::make_shared<GrpcServerImpl>();
   grpc_server_init_flag_ = grpc_server_->InitFlag();
   bool res_server = InitialServer();
-  CHECK(res_server) << "ObuInterFaceGrpcImpl grpc server initial failed";
+  ACHECK(res_server) << "ObuInterFaceGrpcImpl grpc server initial failed";
   init_succ_ = true;
 }
 

--- a/modules/v2x/v2x_proxy/os_interface/os_interface.cc
+++ b/modules/v2x/v2x_proxy/os_interface/os_interface.cc
@@ -29,9 +29,9 @@ using apollo::perception::PerceptionObstacles;
 
 OsInterFace::OsInterFace()
     : node_(cyber::CreateNode("v2x_os_interface")), init_flag_(false) {
-  CHECK(node_) << "ERROR: Create v2x os interface node failed.";
-  CHECK(InitReaders()) << "ERROR: Initial readers failed.";
-  CHECK(InitWriters()) << "ERROR: Initial writers failed.";
+  ACHECK(node_) << "ERROR: Create v2x os interface node failed.";
+  ACHECK(InitReaders()) << "ERROR: Initial readers failed.";
+  ACHECK(InitWriters()) << "ERROR: Initial writers failed.";
   PrintModuleDetails();
   AINFO << "v2x os interface initial success";
 


### PR DESCRIPTION
There's an `ACHECK` macro for log files to go to the module log file defined by the `MODULE_NAME`. If mainboard is used, the `MODULE_NAME` will be mainboard unless otherwise set. Most of the code base uses `CHECK` so most of the output goes to mainboard.INFO. This change should put the fatal output into the respective log file.

Created with
```
git grep -l " CHECK(" | xargs sed -i 's/ CHECK(/ ACHECK(/g'
git commit
git clang-format-6.0 HEAD~1
```