### PR TITLE
Cyber: mainboard exits without parameters

### DIFF
--- a/cyber/mainboard/mainboard.cc
+++ b/cyber/mainboard/mainboard.cc
@@ -21,14 +21,10 @@
 #include "cyber/mainboard/module_controller.h"
 #include "cyber/state.h"
 
-#include "gflags/gflags.h"
-
 using apollo::cyber::mainboard::ModuleArgument;
 using apollo::cyber::mainboard::ModuleController;
 
 int main(int argc, char** argv) {
-  google::SetUsageMessage("we use this program to load dag and run user apps.");
-
   // parse the argument
   ModuleArgument module_args;
   module_args.ParseArgument(argc, argv);

--- a/cyber/mainboard/module_argument.cc
+++ b/cyber/mainboard/module_argument.cc
@@ -80,6 +80,11 @@ void ModuleArgument::GetOptions(const int argc, char* const argv[]) {
   }
   AINFO << "command: " << cmd;
 
+  if (1 == argc) {
+    DisplayUsage();
+    exit(0);
+  }
+
   do {
     int opt =
         getopt_long(argc, argv, short_opts.c_str(), long_opts, &long_index);

--- a/cyber/mainboard/module_argument.cc
+++ b/cyber/mainboard/module_argument.cc
@@ -115,6 +115,18 @@ void ModuleArgument::GetOptions(const int argc, char* const argv[]) {
         break;
     }
   } while (true);
+
+  if (optind < argc) {
+    AINFO << "Found non-option ARGV-element \"" << argv[optind++] << "\"";
+    DisplayUsage();
+    exit(1);
+  }
+
+  if (dag_conf_list_.empty()) {
+    AINFO << "-d parameter must be specified";
+    DisplayUsage();
+    exit(1);
+  }
 }
 
 }  // namespace mainboard


### PR DESCRIPTION
# Dependencies
 It seems like the `SetUsageMessage` doesn't do anything in mainboard. It adds an unnecessary direct dependency on gflags. Therefore, I recommend removing it.

# User Friendliness
mainboard will hang without parameters. New users may make mistakes and not realize it.

## Compile
```bash
bazel build -c opt //modules/planning:libplanning_component.so //cyber:mainboard
```

## Test cases
### Print usage and exit 0
```c++
mainboard && echo $?
mainboard -h && echo $?
```
### Print usage and exit 1
```c++
mainboard -p asdf && echo $?
mainboard -d modules/planning/dag/planning.dag asdf && echo $?
mainboard modules/planning/dag/planning.dag && echo $?
```
### Work as expected
```c++
mainboard -d modules/planning/dag/planning.dag
```