### PR TITLE
Dreamview: closes cleanly

### DIFF
--- a/modules/dreamview/backend/main.cc
+++ b/modules/dreamview/backend/main.cc
@@ -31,7 +31,5 @@ int main(int argc, char *argv[]) {
     return -1;
   }
   apollo::cyber::WaitForShutdown();
-  dreamview.Stop();
-  apollo::cyber::Clear();
   return 0;
 }

--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.h
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.h
@@ -113,8 +113,6 @@ class SimulationWorldUpdater {
 
   void RegisterMessageHandlers();
 
-  std::unique_ptr<cyber::Timer> timer_;
-
   SimulationWorldService sim_world_service_;
   const MapService *map_service_ = nullptr;
   WebSocketHandler *websocket_ = nullptr;
@@ -138,6 +136,8 @@ class SimulationWorldUpdater {
   // Mutex to protect concurrent access to simulation_world_json_.
   // NOTE: Use boost until we have std version of rwlock support.
   boost::shared_mutex mutex_;
+
+  std::unique_ptr<cyber::Timer> timer_;
 };
 
 }  // namespace dreamview


### PR DESCRIPTION
## Description
Dreamview sefaults after SIGINT. There are two issues.
1. `~Dreamview()` is called after `apollo::cyber::Clear()`. This causes a segfault because AINFO is called, but the logger is shutdown.
2. The SimulationWorldUpdater timer callback can be run while it is shutting down. This means that it can access out of scope data.

## Test
1. `bazel-bin/modules/dreamview/dreamview`
2. Wait 5 seconds
3. Press ctrl-c
4. Assert that the program returns within 5 seconds
5. `echo $?`
6. Assert that the exit code is 0