### PR TITLE
remove redundant options

### DIFF
--- a/docker/build/installers/install_user.sh
+++ b/docker/build/installers/install_user.sh
@@ -19,11 +19,15 @@
 # Fail on first error.
 set -e
 
+apt-get -y update && \
+    apt-get -y install sudo
+
 USER_NAME=apollo
 
 adduser --disabled-password --gecos '' ${USER_NAME}
 usermod -aG sudo ${USER_NAME}
-echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g'
 
 echo """
 ulimit -c unlimited

--- a/docker/scripts/dev_into.sh
+++ b/docker/scripts/dev_into.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright 2017 The Apollo Authors. All Rights Reserved.
+# Copyright 2020 The Apollo Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,11 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
+USER_ID=$(id -u)
+DOCKER_USER=apollo
+
+if [[ "$USER" != "apollo" ]] && [[ $USER_ID -ne 1000 ]]; then
+    DOCKER_USER=$USER
+fi
 
 xhost +local:root 1>/dev/null 2>&1
+
 docker exec \
-    -u $USER \
+    -u $DOCKER_USER \
     -e HISTFILE=/apollo/.dev_bash_hist \
     -it apollo_dev_$USER \
     /bin/bash
+
 xhost -local:root 1>/dev/null 2>&1

--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright 2017 The Apollo Authors. All Rights Reserved.
+# Copyright 2020 The Apollo Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ function set_registry_mirrors()
 {
 sed -i '$aDOCKER_OPTS=\"--registry-mirror=http://hub-mirror.c.163.com\"' /etc/default/docker
 sed -i '$i  ,"registry-mirrors": [ "http://hub-mirror.c.163.com"]' /etc/docker/daemon.json
-service docker restart	
+service docker restart
 
 }
 APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd -P )"
@@ -121,7 +121,7 @@ OTHER_VOLUME_CONF=""
 
 while [ $# -gt 0 ]
 do
- 
+
     case "$1" in
     -image)
         echo -e "\033[093mWarning\033[0m: This option has been replaced by \"-t\" and \"--tag\", please use the new one.\n"
@@ -424,8 +424,10 @@ function main(){
     fi
     set +x
 
-    if [ "${USER}" != "root" ]; then
-        docker exec $APOLLO_DEV bash -c '/apollo/scripts/docker_adduser.sh'
+    # User with uid=1000 or username=apollo excluded
+    if [[ "${USER}" != "root" ]] && [[ "${USER}" != "apollo" ]] \
+        && [[ $USER_ID -ne 1000 ]]; then
+        docker exec -u root $APOLLO_DEV bash -c '/apollo/scripts/docker_adduser.sh'
     fi
 
     ok "Finished setting up Apollo docker environment. Now you can enter with: \nbash docker/scripts/dev_into.sh"

--- a/scripts/docker_adduser.sh
+++ b/scripts/docker_adduser.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright 2017 The Apollo Authors. All Rights Reserved.
+# Copyright 2020 The Apollo Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 # limitations under the License.
 ###############################################################################
 
-
 addgroup --gid "$DOCKER_GRP_ID" "$DOCKER_GRP"
 adduser --disabled-password --force-badname --gecos '' "$DOCKER_USER" \
     --uid "$DOCKER_USER_ID" --gid "$DOCKER_GRP_ID" 2>/dev/null
 usermod -aG sudo "$DOCKER_USER"
-echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 cp -r /etc/skel/. /home/${DOCKER_USER}
 echo '
 export PATH=${PATH}:/apollo/scripts:/usr/local/miniconda/bin


### PR DESCRIPTION
Remove two options from the `test` command as they can be inherited from the `build` command.