### PR TITLE
Update dev.x86_64.dockerfile

### DIFF
--- a/docker/build/dev.x86_64.dockerfile
+++ b/docker/build/dev.x86_64.dockerfile
@@ -74,7 +74,6 @@ RUN bash /tmp/installers/install_protobuf.sh
 RUN bash /tmp/installers/install_python_modules.sh
 RUN bash /tmp/installers/install_qp_oases.sh
 RUN bash /tmp/installers/install_qt.sh
-RUN bash /tmp/installers/install_supervisor.sh
 RUN bash /tmp/installers/install_undistort.sh
 RUN bash /tmp/installers/install_user.sh
 RUN bash /tmp/installers/install_yarn.sh


### PR DESCRIPTION
According to this commit https://github.com/ApolloAuto/apollo/commit/99f621e8ccb55fe773e21d9c0360fedea15c4582, the "install_supervisor.sh" is deleted, but the dev.x86_64.dockerfile is still add this script.   

Should delete the "install_supervisor.sh", the "supervisor" is install in python "py3_requirements.txt" and "py27_requirements.txt"