### PR TITLE
apollo_dev image build:  option for the local_dev tag

### DIFF
--- a/docker/build/build_dev.sh
+++ b/docker/build/build_dev.sh
@@ -17,9 +17,11 @@
 ###############################################################################
 
 # Usage:
-#   ./build_dev.sh ./dev.x86_64.dockerfile
+#   ./build_dev.sh ./dev.x86_64.dockerfile [options]
+# Options:
+#   -l/--local   also tag the newly built image as apolloauto/apollo:local_dev
+#
 DOCKERFILE=$1
-
 
 CONTEXT="$(dirname "${BASH_SOURCE[0]}")"
 
@@ -31,5 +33,15 @@ TAG="${REPO}:dev-18.04-${ARCH}-${TIME}"
 
 # Fail on first error.
 set -e
-docker build -t ${TAG} -f ${DOCKERFILE} ${CONTEXT}
+docker build -t "${TAG}" -f "${DOCKERFILE}" "${CONTEXT}"
+
 echo "Built new image ${TAG}"
+
+if [[ ! -z "$2" ]]; then
+    if [[ "$2" == "-l" ]] || [[ "$2" == "--local" ]]; then
+        LOCAL_DEV_TAG="apolloauto/apollo:local_dev"
+        docker image tag "${TAG}" "${LOCAL_DEV_TAG}"
+        echo "Also tagged as ${LOCAL_DEV_TAG}"
+    fi
+fi
+


### PR DESCRIPTION
add "-l/--local" option to `build_dev.sh` to facilitate local development.
