### PR TITLE
introduce bazel  "--output_user_root" startup option

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,4 @@
+.cache
+docs
+docker
+scripts

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs/demo_guide/*.record
 
 # Bash Environment
 .dev_bash_hist
+
+# bazel cache and others
+.cache/

--- a/apollo.sh
+++ b/apollo.sh
@@ -298,7 +298,8 @@ function warn_proprietary_sw() {
 }
 
 function release() {
-  RELEASE_DIR="${HOME}/.cache/apollo_release"
+  CACHE_DIR="/apollo/.cache"
+  RELEASE_DIR="${CACHE_DIR}/apollo_release"
   if [ -d "${RELEASE_DIR}" ]; then
     rm -rf "${RELEASE_DIR}"
   fi

--- a/apollo_docker.sh
+++ b/apollo_docker.sh
@@ -79,8 +79,8 @@ function start_build_docker() {
 
 function gen_docker() {
   IMG="apolloauto/apollo:run-${MACHINE_ARCH}-20181017_1330"
-  RELEASE_DIR=${HOME}/.cache/apollo_release
-  APOLLO_DIR="${RELEASE_DIR}/apollo"
+  CACHE_ROOT_DIR="${DIR}/.cache"
+  APOLLO_DIR="${CACHE_ROOT_DIR}/apollo_release/apollo"
 
   if [ ! -d "${APOLLO_DIR}" ]; then
     echo "Release directory does not exist!"
@@ -102,7 +102,7 @@ function gen_docker() {
       -d \
       --name apollo_release \
       --net host \
-      -v $HOME/.cache:/root/mnt \
+      -v ${CACHE_ROOT_DIR}:/root/mnt \
       -w /apollo \
       "$IMG"
 
@@ -112,16 +112,11 @@ function gen_docker() {
     RELEASE_TGZ="apollo_release.tar.gz"
     SEC_RELEASE_TGZ="sec_apollo_release.tar.gz"
 
-    if [ -e "$HOME/.cache/$RELEASE_TGZ" ]; then
-      rm $HOME/.cache/$RELEASE_TGZ
-    fi
-
-    if [ -e "$HOME/.cache/$SEC_RELEASE_TGZ" ]; then
-      rm $HOME/.cache/$SEC_RELEASE_TGZ
-    fi
+    [ -e "${CACHE_ROOT_DIR}/${RELEASE_TGZ}" ] && rm -f "${CACHE_ROOT_DIR}/${RELEASE_TGZ}"
+    [ -e "${CACHE_ROOT_DIR}/${SEC_RELEASE_TGZ}" ] && rm -f "${CACHE_ROOT_DIR}/${SEC_RELEASE_TGZ}"
 
     # generate security release package
-    tar czf $HOME/.cache/$RELEASE_TGZ -C $HOME/.cache apollo_release
+    tar czf "${CACHE_ROOT_DIR}/${RELEASE_TGZ}" -C "${CACHE_ROOT_DIR}" apollo_release
     python modules/tools/ota/create_sec_package.py
     docker exec apollo_release cp /root/mnt/${SEC_RELEASE_TGZ} /root
   fi
@@ -162,6 +157,7 @@ case $1 in
     gen_docker
     ;;
   *)
+    # TODO(storypku): fix user account issue
     docker exec -u $USER apollo_dev_$USER bash -c "./apollo.sh $@"
     ;;
 esac

--- a/docker/scripts/cyber_start.sh
+++ b/docker/scripts/cyber_start.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
+APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd -P)"
+CACHE_ROOT_DIR="${APOLLO_ROOT_DIR}/.cache"
 
 INCHINA="no"
 LOCAL_IMAGE="no"
@@ -86,7 +88,6 @@ do
 done
 }
 
-APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 if [ ! -e /apollo ]; then
     sudo ln -sf ${APOLLO_ROOT_DIR} /apollo
@@ -160,8 +161,7 @@ IMG=${DOCKER_REPO}:$VERSION
 
 function local_volumes() {
     # Apollo root and bazel cache dirs are required.
-    volumes="-v $APOLLO_ROOT_DIR:/apollo \
-             -v $HOME/.cache:${DOCKER_HOME}/.cache"
+    volumes="-v $APOLLO_ROOT_DIR:/apollo"
     case "$(uname -s)" in
         Linux)
             case "$(lsb_release -r | cut -f2)" in
@@ -179,8 +179,6 @@ function local_volumes() {
                                 -v /lib/modules:/lib/modules"
             ;;
         Darwin)
-            # MacOS has strict limitations on mapping volumes.
-            chmod -R a+wr ~/.cache/bazel
             ;;
     esac
     echo "${volumes}"
@@ -223,8 +221,8 @@ function main(){
     if [ "$USER" == "root" ];then
         DOCKER_HOME="/root"
     fi
-    if [ ! -d "$HOME/.cache" ];then
-        mkdir "$HOME/.cache"
+    if [ ! -d "${CACHE_ROOT_DIR}" ]; then
+        mkdir "${CACHE_ROOT_DIR}"
     fi
 
     info "Starting docker container \"${APOLLO_CYBER}\" ..."

--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -16,6 +16,9 @@
 # limitations under the License.
 ###############################################################################
 
+APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+CACHE_ROOT_DIR="${APOLLO_ROOT_DIR}/.cache"
+
 LOCAL_IMAGE="no"
 FAST_BUILD_MODE="no"
 FAST_TEST_MODE="no"
@@ -85,6 +88,7 @@ do
   fi
 done
 }
+
 function set_registry_mirrors()
 {
 sed -i '$aDOCKER_OPTS=\"--registry-mirror=http://hub-mirror.c.163.com\"' /etc/default/docker
@@ -92,7 +96,6 @@ sed -i '$i  ,"registry-mirrors": [ "http://hub-mirror.c.163.com"]' /etc/docker/d
 service docker restart
 
 }
-APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd -P )"
 
 if [ "$(readlink -f /apollo)" != "${APOLLO_ROOT_DIR}" ]; then
     sudo ln -snf ${APOLLO_ROOT_DIR} /apollo
@@ -207,8 +210,7 @@ LOCAL_THIRD_PARTY_VOLUME_IMAGE=${DOCKER_REPO}:local_third_party_volume-${ARCH}-l
 function local_volumes() {
     set +x
     # Apollo root and bazel cache dirs are required.
-    volumes="-v $APOLLO_ROOT_DIR:/apollo \
-             -v $HOME/.cache:${DOCKER_HOME}/.cache"
+    volumes="-v $APOLLO_ROOT_DIR:/apollo"
     APOLLO_TELEOP="${APOLLO_ROOT_DIR}/../apollo-teleop"
     if [ -d ${APOLLO_TELEOP} ]; then
         volumes="-v ${APOLLO_TELEOP}:/apollo/modules/teleop ${volumes}"
@@ -231,8 +233,6 @@ function local_volumes() {
                                 -v /lib/modules:/lib/modules"
             ;;
         Darwin)
-            # MacOS has strict limitations on mapping volumes.
-            chmod -R a+wr ~/.cache/bazel
             ;;
     esac
     echo "${volumes}"
@@ -280,7 +280,7 @@ function main(){
     if [ $? == 0 ]; then
         if [[ "$(docker inspect --format='{{.Config.Image}}' $APOLLO_DEV 2> /dev/null)" != "$APOLLO_DEV_IMAGE" ]]; then
             rm -rf $APOLLO_ROOT_DIR/bazel-*
-            rm -rf $HOME/.cache/bazel/*
+            rm -rf ${CACHE_ROOT_DIR}/bazel/*
         fi
         docker stop $APOLLO_DEV 1>/dev/null
         docker rm -v -f $APOLLO_DEV 1>/dev/null
@@ -350,8 +350,8 @@ function main(){
     if [ "$USER" == "root" ];then
         DOCKER_HOME="/root"
     fi
-    if [ ! -d "$HOME/.cache" ];then
-        mkdir "$HOME/.cache"
+    if [ ! -d "${CACHE_ROOT_DIR}" ]; then
+        mkdir "${CACHE_ROOT_DIR}"
     fi
 
     info "Starting docker container \"${APOLLO_DEV}\" ..."

--- a/docker/scripts/release_start.sh
+++ b/docker/scripts/release_start.sh
@@ -18,6 +18,8 @@
 
 
 APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")/../.." && pwd )"
+CACHE_ROOT_DIR="${APOLLO_ROOT_DIR}/.cache"
+
 # the machine type, currently support x86_64, aarch64
 MACHINE_ARCH=$(uname -m)
 
@@ -80,8 +82,8 @@ function main() {
     if [ "$USER" == "root" ];then
         DOCKER_HOME="/root"
     fi
-    if [ ! -d "$HOME/.cache" ];then
-        mkdir "$HOME/.cache"
+    if [ ! -d "${CACHE_ROOT_DIR}" ]; then
+        mkdir "${CACHE_ROOT_DIR}"
     fi
 
     DOCKER_CMD="nvidia-docker"
@@ -96,7 +98,6 @@ function main() {
         -v ${HOME}/data:/apollo/data \
         -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
         -v /etc/localtime:/etc/localtime:ro \
-        -v $HOME/.cache:${DOCKER_HOME}/.cache \
         -w /apollo \
         -e DISPLAY=${display} \
         -e RELEASE_DOCKER=1 \

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -12,6 +12,7 @@ startup --batch_cpu_scheduling
 
 startup --host_jvm_args=-XX:-UseParallelGC
 
+startup --output_user_root=/apollo/.cache/bazel
 # +------------------------------------------------------------+
 # | Test Configurations                                        |
 # +------------------------------------------------------------+


### PR DESCRIPTION
This fixes #issues/11198. We don't put bazel cache in $HOME/.cache outside container; Instead, we take advantage of  bazel's `--output_user_root` startup option (pointing to /apollo/bazel-root inside container, $APOLLO_ROOT/bazel-root outside).  

Although bazel-0.5.3 doesn't support `.bazelignore` file yet, it makes no harm. As soon as we moved to bazel 3.x, `.bazelignore` will come to life!
