### PR TITLE
Octopus: modify planning component to support multi-adc simulation

### DIFF
--- a/cyber/common/global_data.cc
+++ b/cyber/common/global_data.cc
@@ -67,6 +67,8 @@ GlobalData::GlobalData() {
   is_reality_mode_ =
       config_.run_mode_conf().run_mode() == proto::RunMode::MODE_REALITY;
 
+  is_octopus_mode_ = false;
+
   const char* run_mode_val = ::getenv("CYBER_RUN_MODE");
   if (run_mode_val != nullptr) {
     std::string run_mode_str(run_mode_val);
@@ -102,6 +104,14 @@ const std::string& GlobalData::HostName() const { return host_name_; }
 void GlobalData::EnableSimulationMode() { is_reality_mode_ = false; }
 
 void GlobalData::DisableSimulationMode() { is_reality_mode_ = true; }
+
+void GlobalData::EnableOctopusMode() { is_octopus_mode_ = true; }
+
+bool GlobalData::IsOctopusMode() const { return is_octopus_mode_; }
+
+int GlobalData::ADCId() const { return adc_id_; }
+
+void GlobalData::SetADCId(const int& adc_id) { adc_id_ = adc_id; }
 
 bool GlobalData::IsRealityMode() const { return is_reality_mode_; }
 

--- a/cyber/common/global_data.h
+++ b/cyber/common/global_data.h
@@ -58,6 +58,12 @@ class GlobalData {
   void EnableSimulationMode();
   void DisableSimulationMode();
 
+  void EnableOctopusMode();
+  bool IsOctopusMode() const;
+
+  void SetADCId(const int& adc_id);
+  int ADCId() const;
+
   bool IsRealityMode() const;
 
   static uint64_t GenerateHashId(const std::string& name) {
@@ -98,6 +104,10 @@ class GlobalData {
 
   // run mode
   bool is_reality_mode_;
+
+  // used for octopus-engine
+  bool is_octopus_mode_;
+  int adc_id_;
 
   static AtomicHashMap<uint64_t, std::string, 512> node_id_map_;
   static AtomicHashMap<uint64_t, std::string, 256> channel_id_map_;

--- a/modules/planning/planning_component.cc
+++ b/modules/planning/planning_component.cc
@@ -30,6 +30,7 @@
 namespace apollo {
 namespace planning {
 
+using apollo::cyber::GlobalData;
 using apollo::hdmap::HDMapUtil;
 using apollo::perception::TrafficLightDetection;
 using apollo::relative_map::MapMsg;
@@ -56,45 +57,89 @@ bool PlanningComponent::Init() {
 
   planning_base_->Init(config_);
 
-  routing_reader_ = node_->CreateReader<RoutingResponse>(
-      FLAGS_routing_response_topic,
-      [this](const std::shared_ptr<RoutingResponse>& routing) {
-        AINFO << "Received routing data: run routing callback."
-              << routing->header().DebugString();
-        std::lock_guard<std::mutex> lock(mutex_);
-        routing_.CopyFrom(*routing);
-      });
-  traffic_light_reader_ = node_->CreateReader<TrafficLightDetection>(
-      FLAGS_traffic_light_detection_topic,
-      [this](const std::shared_ptr<TrafficLightDetection>& traffic_light) {
-        ADEBUG << "Received traffic light data: run traffic light callback.";
-        std::lock_guard<std::mutex> lock(mutex_);
-        traffic_light_.CopyFrom(*traffic_light);
-      });
+  if (GlobalData::Instance()->IsOctopusMode()) {
+    std::string channel_id =
+        "/" + std::to_string(GlobalData::Instance()->ADCId());
 
-  pad_msg_reader_ = node_->CreateReader<PadMessage>(
-      FLAGS_planning_pad_topic,
-      [this](const std::shared_ptr<PadMessage>& pad_msg) {
-        ADEBUG << "Received pad data: run pad callback.";
-        std::lock_guard<std::mutex> lock(mutex_);
-        pad_msg_.CopyFrom(*pad_msg);
-      });
-
-  if (FLAGS_use_navigation_mode) {
-    relative_map_reader_ = node_->CreateReader<MapMsg>(
-        FLAGS_relative_map_topic,
-        [this](const std::shared_ptr<MapMsg>& map_message) {
-          ADEBUG << "Received relative map data: run relative map callback.";
+    routing_reader_ = node_->CreateReader<RoutingResponse>(
+        FLAGS_routing_response_topic + channel_id,
+        [this](const std::shared_ptr<RoutingResponse>& routing) {
+          AINFO << "Received routing data: run routing callback."
+                << routing->header().DebugString();
           std::lock_guard<std::mutex> lock(mutex_);
-          relative_map_.CopyFrom(*map_message);
+          routing_.CopyFrom(*routing);
         });
+
+    traffic_light_reader_ = node_->CreateReader<TrafficLightDetection>(
+        FLAGS_traffic_light_detection_topic + channel_id,
+        [this](const std::shared_ptr<TrafficLightDetection>& traffic_light) {
+          ADEBUG << "Received traffic light data: run traffic light callback.";
+          std::lock_guard<std::mutex> lock(mutex_);
+          traffic_light_.CopyFrom(*traffic_light);
+        });
+
+    pad_msg_reader_ = node_->CreateReader<PadMessage>(
+        FLAGS_planning_pad_topic + channel_id,
+        [this](const std::shared_ptr<PadMessage>& pad_msg) {
+          ADEBUG << "Received pad data: run pad callback.";
+          std::lock_guard<std::mutex> lock(mutex_);
+          pad_msg_.CopyFrom(*pad_msg);
+        });
+
+    if (FLAGS_use_navigation_mode) {
+      relative_map_reader_ = node_->CreateReader<MapMsg>(
+          FLAGS_relative_map_topic + channel_id,
+          [this](const std::shared_ptr<MapMsg>& map_message) {
+            ADEBUG << "Received relative map data: run relative map callback.";
+            std::lock_guard<std::mutex> lock(mutex_);
+            relative_map_.CopyFrom(*map_message);
+          });
+    }
+    planning_writer_ = node_->CreateWriter<ADCTrajectory>(
+        FLAGS_planning_trajectory_topic + channel_id);
+
+    rerouting_writer_ = node_->CreateWriter<RoutingRequest>(
+        FLAGS_routing_request_topic + channel_id);
+  } else {
+    routing_reader_ = node_->CreateReader<RoutingResponse>(
+        FLAGS_routing_response_topic,
+        [this](const std::shared_ptr<RoutingResponse>& routing) {
+          AINFO << "Received routing data: run routing callback."
+                << routing->header().DebugString();
+          std::lock_guard<std::mutex> lock(mutex_);
+          routing_.CopyFrom(*routing);
+        });
+    traffic_light_reader_ = node_->CreateReader<TrafficLightDetection>(
+        FLAGS_traffic_light_detection_topic,
+        [this](const std::shared_ptr<TrafficLightDetection>& traffic_light) {
+          ADEBUG << "Received traffic light data: run traffic light callback.";
+          std::lock_guard<std::mutex> lock(mutex_);
+          traffic_light_.CopyFrom(*traffic_light);
+        });
+
+    pad_msg_reader_ = node_->CreateReader<PadMessage>(
+        FLAGS_planning_pad_topic,
+        [this](const std::shared_ptr<PadMessage>& pad_msg) {
+          ADEBUG << "Received pad data: run pad callback.";
+          std::lock_guard<std::mutex> lock(mutex_);
+          pad_msg_.CopyFrom(*pad_msg);
+        });
+
+    if (FLAGS_use_navigation_mode) {
+      relative_map_reader_ = node_->CreateReader<MapMsg>(
+          FLAGS_relative_map_topic,
+          [this](const std::shared_ptr<MapMsg>& map_message) {
+            ADEBUG << "Received relative map data: run relative map callback.";
+            std::lock_guard<std::mutex> lock(mutex_);
+            relative_map_.CopyFrom(*map_message);
+          });
+    }
+    planning_writer_ =
+        node_->CreateWriter<ADCTrajectory>(FLAGS_planning_trajectory_topic);
+
+    rerouting_writer_ =
+        node_->CreateWriter<RoutingRequest>(FLAGS_routing_request_topic);
   }
-  planning_writer_ =
-      node_->CreateWriter<ADCTrajectory>(FLAGS_planning_trajectory_topic);
-
-  rerouting_writer_ =
-      node_->CreateWriter<RoutingRequest>(FLAGS_routing_request_topic);
-
   return true;
 }
 


### PR DESCRIPTION
I'm not sure this is a proper approach to change the output channels of octopus dependent components, and if not, I'd like your advice.