### PR TITLE
dreamview times out on system_status

### DIFF
--- a/modules/dreamview/backend/hmi/hmi_worker.cc
+++ b/modules/dreamview/backend/hmi/hmi_worker.cc
@@ -142,6 +142,7 @@ void HMIWorker::Start() {
         status_writer_->Write(*status);
         status->clear_header();
       });
+  ResetComponentStatusTimer();
   thread_future_ = cyber::Async(&HMIWorker::StatusUpdateThreadLoop, this);
 }
 
@@ -259,6 +260,8 @@ void HMIWorker::InitReadersAndWriters() {
   node_->CreateReader<SystemStatus>(
       FLAGS_system_status_topic,
       [this](const std::shared_ptr<SystemStatus>& system_status) {
+        this->ResetComponentStatusTimer();
+
         WLock wlock(status_mutex_);
 
         const bool is_realtime_msg =
@@ -287,12 +290,11 @@ void HMIWorker::InitReadersAndWriters() {
         }
 
         // Check if the status is changed.
-        static size_t last_status_fingerprint = 0;
         const size_t new_fingerprint =
             apollo::common::util::MessageFingerprint(status_);
-        if (last_status_fingerprint != new_fingerprint) {
+        if (last_status_fingerprint_ != new_fingerprint) {
           status_changed_ = true;
-          last_status_fingerprint = new_fingerprint;
+          last_status_fingerprint_ = new_fingerprint;
         }
       });
 
@@ -541,6 +543,7 @@ void HMIWorker::StatusUpdateThreadLoop() {
   while (!stop_) {
     static constexpr int kLoopIntervalMs = 200;
     std::this_thread::sleep_for(std::chrono::milliseconds(kLoopIntervalMs));
+    UpdateComponentStatus();
     bool status_changed = false;
     {
       WLock wlock(status_mutex_);
@@ -562,6 +565,24 @@ void HMIWorker::StatusUpdateThreadLoop() {
     for (const auto handler : status_update_handlers_) {
       handler(status_changed, &status);
     }
+  }
+}
+
+void HMIWorker::ResetComponentStatusTimer() {
+  last_status_received_s_ = cyber::Time::Now().ToSecond();
+  last_status_fingerprint_ = 0;
+}
+
+void HMIWorker::UpdateComponentStatus() {
+  static constexpr uint64_t kSecondsTillComponentReset(2.5);
+  if (cyber::Time::Now().ToSecond() - last_status_received_s_.load() >
+      kSecondsTillComponentReset) {
+    WLock wlock(status_mutex_);
+    for (auto& monitored_component : *status_.mutable_monitored_components()) {
+      monitored_component.second.set_status(ComponentStatus::UNKNOWN);
+      monitored_component.second.set_message("Status not reported by Monitor.");
+    }
+    status_changed_ = true;
   }
 }
 

--- a/modules/dreamview/backend/hmi/hmi_worker.h
+++ b/modules/dreamview/backend/hmi/hmi_worker.h
@@ -16,13 +16,17 @@
 
 #pragma once
 
-#include <boost/thread/locks.hpp>
-#include <boost/thread/shared_mutex.hpp>
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "boost/thread/locks.hpp"
+#include "boost/thread/shared_mutex.hpp"
+
 #include "cyber/cyber.h"
+#include "cyber/time/time.h"
+
 #include "modules/canbus/proto/chassis.pb.h"
 #include "modules/common/proto/drive_event.pb.h"
 #include "modules/control/proto/pad_msg.pb.h"
@@ -90,12 +94,18 @@ class HMIWorker {
   void StartModule(const std::string& module) const;
   void StopModule(const std::string& module) const;
 
+  void ResetComponentStatusTimer();
+  void UpdateComponentStatus();
+
   const HMIConfig config_;
 
   // HMI status maintenance.
   HMIStatus status_;
+  // gcc 4 doesnt support std::atomic<std::chrono::steady_clock::time_point>
+  std::atomic<double> last_status_received_s_;
   HMIMode current_mode_;
   bool status_changed_ = false;
+  size_t last_status_fingerprint_{};
   bool stop_ = false;
   mutable boost::shared_mutex status_mutex_;
   std::future<void> thread_future_;

--- a/modules/dreamview/backend/hmi/hmi_worker.h
+++ b/modules/dreamview/backend/hmi/hmi_worker.h
@@ -101,8 +101,8 @@ class HMIWorker {
 
   // HMI status maintenance.
   HMIStatus status_;
-  // gcc 4 doesnt support std::atomic<std::chrono::steady_clock::time_point>
   std::atomic<double> last_status_received_s_;
+  bool monitor_timed_out_{true};
   HMIMode current_mode_;
   bool status_changed_ = false;
   size_t last_status_fingerprint_{};

--- a/modules/guardian/guardian_component.h
+++ b/modules/guardian/guardian_component.h
@@ -54,6 +54,8 @@ class GuardianComponent : public apollo::cyber::TimerComponent {
   apollo::control::ControlCommand control_cmd_;
   apollo::guardian::GuardianCommand guardian_cmd_;
 
+  double last_status_received_s_{};
+
   std::shared_ptr<apollo::cyber::Reader<apollo::canbus::Chassis>>
       chassis_reader_;
   std::shared_ptr<apollo::cyber::Reader<apollo::control::ControlCommand>>

--- a/modules/monitor/software/summary_monitor.cc
+++ b/modules/monitor/software/summary_monitor.cc
@@ -24,7 +24,7 @@
 DEFINE_string(summary_monitor_name, "SummaryMonitor",
               "Name of the summary monitor.");
 
-DEFINE_double(system_status_publish_interval, 10,
+DEFINE_double(system_status_publish_interval, 1,
               "SystemStatus publish interval.");
 
 namespace apollo {


### PR DESCRIPTION
Since the monitor can crash, it would be nice if there is an indication in dreamview that it wasn't receiving updates.