### PR TITLE
Script: apollo.bashrc split out from apollo_base.sh and bugfix for clang-format.sh

### DIFF
--- a/scripts/apollo.bashrc
+++ b/scripts/apollo.bashrc
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright 2020 The Apollo Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd -P)"
+export APOLLO_ROOT_DIR
+
+BOLD='\033[1m'
+RED='\033[0;31m'
+GREEN='\033[32m'
+WHITE='\033[34m'
+YELLOW='\033[33m'
+NO_COLOR='\033[0m'
+
+function info() {
+  (>&2 echo -e "[${WHITE}${BOLD}INFO${NO_COLOR}] $*")
+}
+
+function error() {
+  (>&2 echo -e "[${RED}ERROR${NO_COLOR}] $*")
+}
+
+function warning() {
+  (>&2 echo -e "${YELLOW}[WARNING] $*${NO_COLOR}")
+}
+
+function ok() {
+  (>&2 echo -e "[${GREEN}${BOLD} OK ${NO_COLOR}] $*")
+}
+
+function print_delim() {
+  echo "=============================================="
+}
+
+function get_now() {
+  echo "$(date +%s)"
+}
+
+function print_time() {
+  END_TIME=$(get_now)
+  ELAPSED_TIME=$(echo "$END_TIME - $START_TIME" | bc -l)
+  MESSAGE="Took ${ELAPSED_TIME} seconds"
+  info "${MESSAGE}"
+}
+
+function success() {
+  print_delim
+  ok "$1"
+  print_time
+  print_delim
+}
+
+function fail() {
+  print_delim
+  error "$1"
+  print_time
+  print_delim
+  exit -1
+}
+
+function file_ext() {
+  local __ext="${1##*.}"
+  if [ "${__ext}" == "$1" ]; then
+    __ext=""
+  fi
+  echo "${__ext}"
+}
+
+function c_family_ext() {
+  local __ext
+  __ext="$(file_ext $1)"
+  for ext in "h" "hxx" "hpp" "cxx" "cc" "cpp" "cu"; do
+    if [ "${ext}" == "${__ext}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+function find_c_cpp_srcs() {
+  find "$@" -type f -name "*.h"   \
+                 -o -name "*.hpp" \
+                 -o -name "*.hxx" \
+                 -o -name "*.cc"  \
+                 -o -name "*.cpp" \
+                 -o -name "*.hxx" \
+                 -o -name "*.cu"
+}

--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -16,60 +16,8 @@
 # limitations under the License.
 ###############################################################################
 
-APOLLO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-
-BOLD='\033[1m'
-RED='\033[0;31m'
-GREEN='\033[32m'
-WHITE='\033[34m'
-YELLOW='\033[33m'
-NO_COLOR='\033[0m'
-
-function info() {
-  (>&2 echo -e "[${WHITE}${BOLD}INFO${NO_COLOR}] $*")
-}
-
-function error() {
-  (>&2 echo -e "[${RED}ERROR${NO_COLOR}] $*")
-}
-
-function warning() {
-  (>&2 echo -e "${YELLOW}[WARNING] $*${NO_COLOR}")
-}
-
-function ok() {
-  (>&2 echo -e "[${GREEN}${BOLD} OK ${NO_COLOR}] $*")
-}
-
-function print_delim() {
-  echo '============================'
-}
-
-function get_now() {
-  echo $(date +%s)
-}
-
-function print_time() {
-  END_TIME=$(get_now)
-  ELAPSED_TIME=$(echo "$END_TIME - $START_TIME" | bc -l)
-  MESSAGE="Took ${ELAPSED_TIME} seconds"
-  info "${MESSAGE}"
-}
-
-function success() {
-  print_delim
-  ok "$1"
-  print_time
-  print_delim
-}
-
-function fail() {
-  print_delim
-  error "$1"
-  print_time
-  print_delim
-  exit -1
-}
+TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd -P)"
+source ${TOP_DIR}/scripts/apollo.bashrc
 
 function check_in_docker() {
   if [ -f /.dockerenv ]; then

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -17,20 +17,50 @@
 ###############################################################################
 
 # Usage:
-#   clang-format.sh </some/path>
+#   clang-format.sh <path/to/src/dir/or/file>
+
+# Fail on error
+set -euo pipefail
+
+TOP_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+. "${TOP_DIR}/scripts/apollo.bashrc"
 
 TARGET=$1
+if [[ -z "${TARGET}" ]]; then
+  echo "No path specified. Exiting..."
+  exit 1
+fi
 
 # Check tool.
-if [ ! -x "$(command -v clang-format)" ]; then
+CLANG_FORMAT_CMD="$(command -v clang-format)"
+
+if [[ -z "${CLANG_FORMAT_CMD}" ]]; then
   echo "Installing clang-format..."
-  sudo apt-get install -y clang-format
+  sudo apt-get -y update && \
+    sudo apt-get -y install clang-format
+  CLANG_FORMAT_CMD="$(command -v clang-format)"
 fi
+
+function clang_format_run() {
+  ${CLANG_FORMAT_CMD} -i -style=Google "$@"
+}
 
 # Format.
 if [ -f "${TARGET}" ]; then
-  clang-format -i -style=Google "${TARGET}"
+  if c_family_ext "${TARGET}"; then
+    clang_format_run "${TARGET}"
+    info "Done formatting ${TARGET}"
+  else
+    warning "Do nothing. ${TARGET} " \
+            "is not c/c++/cuda header/source file."
+  fi
 else
-  clang-format -i -style=Google \
-      $(find "${TARGET}" -type f | grep -e '\.h$' -e '\.cc$')
+  srcs="$(find_c_cpp_srcs ${TARGET})"
+  if [[ -z "${srcs}" ]]; then
+      warning "Do nothing. No c/c++/cuda header/source" \
+              "files found under ${TARGET} ."
+      exit 0
+  fi
+  clang_format_run ${srcs}
+  info "Done formatting c/cpp/cuda source files under ${TARGET}"
 fi


### PR DESCRIPTION
1) `apollo.bashrc` split out from `apollo_base.sh`:  Use the former as a general `.bashrc` file, consisting of functions and enviroment variables for general purpose only.  The later can be used for apollo specific functionalities and settings.
2) Bufix for clang-format.sh: Enhanced check and only lint c/c++/cuda files using clang-format/llvm