### PR TITLE
FILE TEST:delete a copyfile test case

### DIFF
--- a/cyber/common/file_test.cc
+++ b/cyber/common/file_test.cc
@@ -72,7 +72,6 @@ TEST(FileTest, file_utils_test) {
   EXPECT_FALSE(DirectoryExists("message.binary"));
 
   EXPECT_FALSE(CopyFile("not_exists_file", "1.txt"));
-  EXPECT_FALSE(CopyFile("message.binary", "/not_exists_file"));
   EXPECT_TRUE(CopyFile("message.binary", "message.binary.copy"));
 
   std::string current_path = GetCurrentPath();


### PR DESCRIPTION
bazel test as root or non-root will get different result ,all is reasonable.so delete it.