### PR TITLE
[#10818] potential synchronization issue in accessing driving_mode_

### DIFF
--- a/modules/canbus/vehicle/vehicle_controller.cc
+++ b/modules/canbus/vehicle/vehicle_controller.cc
@@ -43,7 +43,7 @@ ErrorCode VehicleController::SetDrivingMode(
   }
 
   // vehicle in emergency mode only response to manual mode to reset.
-  if (driving_mode_ == Chassis::EMERGENCY_MODE &&
+  if (this->driving_mode() == Chassis::EMERGENCY_MODE &&
       driving_mode != Chassis::COMPLETE_MANUAL) {
     AINFO
         << "Vehicle in EMERGENCY_MODE, only response to COMPLETE_MANUAL mode.";
@@ -52,7 +52,7 @@ ErrorCode VehicleController::SetDrivingMode(
   }
 
   // if current mode is same as previous, no need to set.
-  if (driving_mode_ == driving_mode) {
+  if (this->driving_mode() == driving_mode) {
     return ErrorCode::OK;
   }
 
@@ -120,8 +120,8 @@ ErrorCode VehicleController::Update(const ControlCommand &control_command) {
     SetDrivingMode(mode);
   }
 
-  if (driving_mode_ == Chassis::COMPLETE_AUTO_DRIVE ||
-      driving_mode_ == Chassis::AUTO_SPEED_ONLY) {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_SPEED_ONLY) {
     Gear(control_command.gear_location());
     Throttle(control_command.throttle());
     Acceleration(control_command.acceleration());
@@ -130,8 +130,8 @@ ErrorCode VehicleController::Update(const ControlCommand &control_command) {
     SetLimits();
   }
 
-  if (driving_mode_ == Chassis::COMPLETE_AUTO_DRIVE ||
-      driving_mode_ == Chassis::AUTO_STEER_ONLY) {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_STEER_ONLY) {
     const double steering_rate_threshold = 1.0;
     if (control_command.steering_rate() > steering_rate_threshold) {
       Steer(control_command.steering_target(), control_command.steering_rate());
@@ -140,9 +140,9 @@ ErrorCode VehicleController::Update(const ControlCommand &control_command) {
     }
   }
 
-  if ((driving_mode_ == Chassis::COMPLETE_AUTO_DRIVE ||
-       driving_mode_ == Chassis::AUTO_SPEED_ONLY ||
-       driving_mode_ == Chassis::AUTO_STEER_ONLY) &&
+  if ((driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+       driving_mode() == Chassis::AUTO_SPEED_ONLY ||
+       driving_mode() == Chassis::AUTO_STEER_ONLY) &&
       control_command.has_signal()) {
     SetHorn(control_command);
     SetTurningSignal(control_command);


### PR DESCRIPTION
- The member variable driving_mode_ of class VehicleController is accessed
  directly in two functions. However, inside SecurityDogThreadFunc() for
  each specific vehicle controller, this member variable driving_model_
  can be changed if Emergecy() is called.
- There is already a mutex guarded accessor driving_mode() which should be
  used instead.
- fixes #10818