### PR TITLE
Cyber: change argument format of cmd cyber_recorder play -b xxx

### DIFF
--- a/cyber/common/time_conversion.h
+++ b/cyber/common/time_conversion.h
@@ -124,7 +124,7 @@ inline uint64_t StringToUnixSeconds(
 
 inline std::string UnixSecondsToString(
     uint64_t unix_seconds,
-    const std::string& format_str = "%Y-%m-%d %H:%M:%S") {
+    const std::string& format_str = "%Y-%m-%d-%H:%M:%S") {
   std::time_t t = unix_seconds;
   struct tm ptm;
   struct tm* ret = localtime_r(&t, &ptm);

--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -118,11 +118,11 @@ void DisplayUsage(const std::string& binary, const std::string& command,
                   << " rate by FACTOR" << std::endl;
         break;
       case 'b':
-        std::cout << "\t-b, --begin <2018-07-01 00:00:00>\t" << command
+        std::cout << "\t-b, --begin 2018-07-01-00:00:00\t" << command
                   << " the record begin at" << std::endl;
         break;
       case 'e':
-        std::cout << "\t-e, --end <2018-07-01 00:01:00>\t\t" << command
+        std::cout << "\t-e, --end 2018-07-01-00:01:00\t\t" << command
                   << " the record end at" << std::endl;
         break;
       case 's':


### PR DESCRIPTION
can't get a string format from terminal like %Y-%m-%d %H:%M:%S, because space will split it into 2 strings