### PR TITLE
python: fix py_proto name

### DIFF
--- a/cyber/python/cyber_py3/cyber.py
+++ b/cyber/python/cyber_py3/cyber.py
@@ -25,7 +25,7 @@ import sys
 import threading
 import time
 
-from google.protobuf.descriptor_py_pb2 import FileDescriptorProto
+from google.protobuf.descriptor_pb2 import FileDescriptorProto
 
 
 PY_CALLBACK_TYPE = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p)

--- a/cyber/python/cyber_py3/examples/client.py
+++ b/cyber/python/cyber_py3/examples/client.py
@@ -21,7 +21,7 @@
 import time
 
 from cyber_py3 import cyber
-from cyber.proto.unit_test_py_pb2 import ChatterBenchmark
+from cyber.proto.unit_test_pb2 import ChatterBenchmark
 
 
 def test_client_class():

--- a/cyber/python/cyber_py3/examples/listener.py
+++ b/cyber/python/cyber_py3/examples/listener.py
@@ -19,7 +19,7 @@
 """Module for example of listener."""
 
 from cyber_py3 import cyber
-from cyber.proto.unit_test_py_pb2 import ChatterBenchmark
+from cyber.proto.unit_test_pb2 import ChatterBenchmark
 
 
 def callback(data):

--- a/cyber/python/cyber_py3/examples/record.py
+++ b/cyber/python/cyber_py3/examples/record.py
@@ -25,11 +25,11 @@ Run with:
 
 import time
 
-from google.protobuf.descriptor_py_pb2 import FileDescriptorProto
+from google.protobuf.descriptor_pb2 import FileDescriptorProto
 
-from cyber.proto.unit_test_py_pb2 import Chatter
+from cyber.proto.unit_test_pb2 import Chatter
 from cyber.python.cyber_py3 import record
-from modules.common.util.testdata.simple_py_pb2 import SimpleMessage
+from modules.common.util.testdata.simple_pb2 import SimpleMessage
 
 
 MSG_TYPE = "apollo.common.util.test.SimpleMessage"

--- a/cyber/python/cyber_py3/examples/record_channel_info.py
+++ b/cyber/python/cyber_py3/examples/record_channel_info.py
@@ -22,7 +22,7 @@ import sys
 
 from cyber_py3 import cyber
 from cyber_py3 import record
-from cyber.proto import record_py_pb2
+from cyber.proto import record_pb2
 
 
 def print_channel_info(file_path):
@@ -30,7 +30,7 @@ def print_channel_info(file_path):
     channels = freader.get_channellist()
 
     header_msg = freader.get_headerstring()
-    header = record_py_pb2.Header()
+    header = record_pb2.Header()
     header.ParseFromString(header_msg)
 
     print('\n++++++++++++Begin Channel Info Statistics++++++++++++++')

--- a/cyber/python/cyber_py3/examples/service.py
+++ b/cyber/python/cyber_py3/examples/service.py
@@ -19,7 +19,7 @@
 """Module for example of listener."""
 
 from cyber_py3 import cyber
-from cyber.proto.unit_test_py_pb2 import ChatterBenchmark
+from cyber.proto.unit_test_pb2 import ChatterBenchmark
 
 
 def callback(data):

--- a/cyber/python/cyber_py3/examples/talker.py
+++ b/cyber/python/cyber_py3/examples/talker.py
@@ -21,7 +21,7 @@
 import time
 
 from cyber_py3 import cyber
-from cyber.proto.unit_test_py_pb2 import ChatterBenchmark
+from cyber.proto.unit_test_pb2 import ChatterBenchmark
 
 
 def test_talker_class():

--- a/cyber/python/cyber_py3/record.py
+++ b/cyber/python/cyber_py3/record.py
@@ -23,7 +23,7 @@ import importlib
 import os
 import sys
 
-from google.protobuf.descriptor_py_pb2 import FileDescriptorProto
+from google.protobuf.descriptor_pb2 import FileDescriptorProto
 
 
 # init vars

--- a/cyber/python/cyber_py3/test/test_cyber.py
+++ b/cyber/python/cyber_py3/test/test_cyber.py
@@ -22,7 +22,7 @@ import time
 import unittest
 
 from cyber_py3 import cyber
-from modules.common.util.testdata.simple_py_pb2 import SimpleMessage
+from modules.common.util.testdata.simple_pb2 import SimpleMessage
 
 
 class TestCyber(unittest.TestCase):

--- a/cyber/python/cyber_py3/test/test_record.py
+++ b/cyber/python/cyber_py3/test/test_record.py
@@ -20,9 +20,9 @@
 
 import unittest
 
-from cyber.proto import record_py_pb2
+from cyber.proto import record_pb2
 from cyber_py3 import record
-from modules.common.util.testdata.simple_py_pb2 import SimpleMessage
+from modules.common.util.testdata.simple_pb2 import SimpleMessage
 
 
 TEST_RECORD_FILE = "/tmp/test02.record"
@@ -63,7 +63,7 @@ class TestRecord(unittest.TestCase):
         self.assertEqual(1, len(channel_list))
         self.assertEqual(CHAN_1, channel_list[0])
 
-        header = record_py_pb2.Header()
+        header = record_pb2.Header()
         header.ParseFromString(fread.get_headerstring())
         self.assertEqual(1, header.major_version)
         self.assertEqual(0, header.minor_version)

--- a/docker/build/installers/install_python_modules.sh
+++ b/docker/build/installers/install_python_modules.sh
@@ -29,7 +29,8 @@ apt update -y && apt install -y \
     python3-pip \
     python3-psutil \
     python3-scipy \
-    software-properties-common
+    software-properties-common \
+    libasound2-dev
 
 pip3_install -r py3_requirements.txt
 

--- a/modules/tools/control_info/BUILD
+++ b/modules/tools/control_info/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,5 +7,10 @@ py_binary(
     srcs = ["control_info.py"],
     deps = [
         "//cyber/python/cyber_py3:cyber",
+        "//cyber/python/cyber_py3:record",
+        "//modules/canbus/proto:chassis_py_pb2",
+        "//modules/control/proto:control_cmd_py_pb2",
+        "//modules/localization/proto:localization_py_pb2",
+        "//modules/planning/proto:planning_py_pb2",
     ],
 )

--- a/modules/tools/create_map/BUILD
+++ b/modules/tools/create_map/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,20 +14,20 @@ py_binary(
     name = "create_map",
     srcs = ["create_map.py"],
     deps = [
-        "//modules/map/proto:map_py_pb2",
         "//modules/map/proto:map_lane_py_pb2",
+        "//modules/map/proto:map_py_pb2",
         "//modules/map/proto:map_road_py_pb2",
-        "//modules/routing/proto:routing_py_pb2",
         "//modules/routing/proto:poi_py_pb2",
-    ]
+        "//modules/routing/proto:routing_py_pb2",
+    ],
 )
 
 py_binary(
     name = "lane_recorder",
     srcs = ["lane_recorder.py"],
     deps = [
-        "//modules/tools/common:logger",
-        "//modules/localization/proto:localization_py_pb2",
         "//modules/drivers/proto:mobileye_py_pb2",
-    ]
+        "//modules/localization/proto:localization_py_pb2",
+        "//modules/tools/common:logger",
+    ],
 )

--- a/modules/tools/dump_gpsbin/BUILD
+++ b/modules/tools/dump_gpsbin/BUILD
@@ -5,4 +5,9 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "dump_gpsbin",
     srcs = ["dump_gpsbin.py"],
+    deps = [
+        "//cyber/python/cyber_py3:cyber",
+        "//cyber/python/cyber_py3:record",
+        "//modules/drivers/gnss/proto:gnss_py_pb2",
+    ],
 )

--- a/modules/tools/mapshow/BUILD
+++ b/modules/tools/mapshow/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/modules/tools/mapshow/libs/BUILD
+++ b/modules/tools/mapshow/libs/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/modules/tools/mobileye_viewer/location_server.py
+++ b/modules/tools/mobileye_viewer/location_server.py
@@ -32,8 +32,8 @@ from flask import Flask
 from flask import request
 from flask_cors import CORS
 from numpy.polynomial.polynomial import polyval
-from modules.localization.proto import localization_py_pb2
-from modules.drivers.proto import mobileye_py_pb2
+from modules.localization.proto import localization_pb2
+from modules.drivers.proto import mobileye_pb2
 
 # pip install -U flask-cors
 # is currently required in docker

--- a/modules/tools/perception/empty_prediction.py
+++ b/modules/tools/perception/empty_prediction.py
@@ -29,7 +29,7 @@ import simplejson
 from cyber.python.cyber_py3 import cyber
 from cyber.pyhton.cyber_py3 import cyber_time
 
-from modules.prediction.proto.prediction_obstacle_py_pb2 import PredictionObstacles
+from modules.prediction.proto.prediction_obstacle_pb2 import PredictionObstacles
 
 
 def prediction_publisher(prediction_channel, rate):

--- a/modules/tools/perception/extend_prediction.py
+++ b/modules/tools/perception/extend_prediction.py
@@ -26,7 +26,7 @@ import sys
 import numpy
 
 import modules.tools.common.proto_utils as proto_utils
-from modules.prediction.proto.prediction_obstacle_py_pb2 import PredictionObstacles
+from modules.prediction.proto.prediction_obstacle_pb2 import PredictionObstacles
 
 
 def distance(p1, p2):

--- a/modules/tools/perception/replay_perception.py
+++ b/modules/tools/perception/replay_perception.py
@@ -29,9 +29,9 @@ import simplejson
 
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import cyber_time
-from modules.common.proto.geometry_py_pb2 import Point3D
-from modules.perception.proto.perception_obstacle_py_pb2 import PerceptionObstacle
-from modules.perception.proto.perception_obstacle_py_pb2 import PerceptionObstacles
+from modules.common.proto.geometry_pb2 import Point3D
+from modules.perception.proto.perception_obstacle_pb2 import PerceptionObstacle
+from modules.perception.proto.perception_obstacle_pb2 import PerceptionObstacles
 
 
 _s_seq_num = 0

--- a/modules/tools/planning/plot_trajectory/main.py
+++ b/modules/tools/planning/plot_trajectory/main.py
@@ -22,8 +22,8 @@ import matplotlib.pyplot as plt
 
 import modules.tools.common.proto_utils as proto_utils
 from modules.tools.planning.plot_trajectory import mkz_polygon
-from modules.planning.proto.planning_py_pb2 import ADCTrajectory
-from modules.localization.proto.localization_py_pb2 import LocalizationEstimate
+from modules.planning.proto.planning_pb2 import ADCTrajectory
+from modules.localization.proto.localization_pb2 import LocalizationEstimate
 
 
 def plot_trajectory(planning_pb, ax):

--- a/modules/tools/plot_control/plot_control.py
+++ b/modules/tools/plot_control/plot_control.py
@@ -21,7 +21,7 @@ import gflags
 from cyber.python.cyber_py3 import cyber
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
-from modules.control.proto import control_cmd_py_pb2
+from modules.control.proto import control_cmd_pb2
 BRAKE_LINE_DATA = []
 TROTTLE_LINE_DATA = []
 STEERING_LINE_DATA = []
@@ -51,7 +51,7 @@ def listener():
     cyber.init()
     test_node = cyber.Node("control_listener")
     test_node.create_reader("/apollo/control",
-                            control_cmd_py_pb2.ControlCommand, callback)
+                            control_cmd_pb2.ControlCommand, callback)
     test_node.spin()
     cyber.shutdown()
 

--- a/modules/tools/plot_control/realtime_test.py
+++ b/modules/tools/plot_control/realtime_test.py
@@ -23,8 +23,8 @@ import os
 import sys
 
 from cyber.python.cyber_py3 import cyber
-from modules.canbus.proto import chassis_py_pb2
-from modules.localization.proto import localization_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.localization.proto import localization_pb2
 
 
 SmoothParam = 9
@@ -90,6 +90,6 @@ if __name__ == '__main__':
     rttest.acclimit = args.acc
     cyber_node = cyber.Node("RealTimeTest")
     cyber_node.create_reader("/apollo/canbus/chassis",
-                             chassis_py_pb2.Chassis, rttest.chassis_callback)
+                             chassis_pb2.Chassis, rttest.chassis_callback)
     cyber_node.spin()
     cyber.shutdown()

--- a/modules/tools/plot_planning/plot_chassis_acc.py
+++ b/modules/tools/plot_planning/plot_chassis_acc.py
@@ -24,8 +24,8 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 
 from cyber.python.cyber_py3 import cyber
-from modules.canbus.proto import chassis_py_pb2
-from modules.control.proto import control_cmd_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.control.proto import control_cmd_pb2
 
 
 INIT_ACC_DATA = []
@@ -78,7 +78,7 @@ def listener():
     cyber.init()
     test_node = cyber.Node("chassis_acc_listener")
     test_node.create_reader("/apollo/canbus/chassis",
-                            chassis_py_pb2.Chassis, callback)
+                            chassis_pb2.Chassis, callback)
 
 
 def compensate(data_list):

--- a/modules/tools/plot_planning/plot_planning_acc.py
+++ b/modules/tools/plot_planning/plot_planning_acc.py
@@ -24,8 +24,8 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 
 from cyber.python.cyber_py3 import cyber
-from modules.control.proto import control_cmd_py_pb2
-from modules.planning.proto import planning_py_pb2
+from modules.control.proto import control_cmd_pb2
+from modules.planning.proto import planning_pb2
 
 
 LAST_TRAJ_DATA = []
@@ -108,7 +108,7 @@ def listener():
     cyber.init()
     test_node = cyber.Node("planning_acc_listener")
     test_node.create_reader("/apollo/planning",
-                            planning_py_pb2.ADCTrajectory, callback)
+                            planning_pb2.ADCTrajectory, callback)
 
 
 def compensate(data_list):

--- a/modules/tools/plot_planning/plot_planning_speed.py
+++ b/modules/tools/plot_planning/plot_planning_speed.py
@@ -24,8 +24,8 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 
 from cyber.python.cyber_py3 import cyber
-from modules.control.proto import control_cmd_py_pb2
-from modules.planning.proto import planning_py_pb2
+from modules.control.proto import control_cmd_pb2
+from modules.planning.proto import planning_pb2
 
 
 LAST_TRAJ_DATA = []
@@ -91,7 +91,7 @@ def listener():
     cyber.init()
     test_node = cyber.Node("planning_listener")
     test_node.create_reader("/apollo/planning",
-                            planning_py_pb2.ADCTrajectory, callback)
+                            planning_pb2.ADCTrajectory, callback)
 
 
 def compensate(data_list):

--- a/modules/tools/plot_planning/plot_speed_steering.py
+++ b/modules/tools/plot_planning/plot_speed_steering.py
@@ -22,7 +22,7 @@ import sys
 import matplotlib.pyplot as plt
 
 from cyber.python.cyber_py3.record import RecordReader
-from modules.canbus.proto import chassis_py_pb2
+from modules.canbus.proto import chassis_pb2
 
 
 def process(reader):
@@ -34,14 +34,14 @@ def process(reader):
 
     for msg in reader.read_messages():
         if msg.topic == "/apollo/canbus/chassis":
-            chassis = chassis_py_pb2.Chassis()
+            chassis = chassis_pb2.Chassis()
             chassis.ParseFromString(msg.message)
 
             steering_percentage = chassis.steering_percentage
             speed_mps = chassis.speed_mps
             timestamp_sec = chassis.header.timestamp_sec
 
-            if chassis.driving_mode != chassis_py_pb2.Chassis.COMPLETE_AUTO_DRIVE:
+            if chassis.driving_mode != chassis_pb2.Chassis.COMPLETE_AUTO_DRIVE:
                 last_steering_percentage = steering_percentage
                 last_speed_mps = speed_mps
                 last_timestamp_sec = timestamp_sec

--- a/modules/tools/plot_planning/record_reader.py
+++ b/modules/tools/plot_planning/record_reader.py
@@ -17,9 +17,9 @@
 ###############################################################################
 
 from cyber.python.cyber_py3.record import RecordReader
-from modules.canbus.proto import chassis_py_pb2
-from modules.localization.proto import localization_py_pb2
-from modules.planning.proto import planning_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.localization.proto import localization_pb2
+from modules.planning.proto import planning_pb2
 
 
 class RecordItemReader:
@@ -32,19 +32,19 @@ class RecordItemReader:
             if msg.topic not in topics:
                 continue
             if msg.topic == "/apollo/canbus/chassis":
-                chassis = chassis_py_pb2.Chassis()
+                chassis = chassis_pb2.Chassis()
                 chassis.ParseFromString(msg.message)
                 data = {"chassis": chassis}
                 yield data
 
             if msg.topic == "/apollo/localization/pose":
-                location_est = localization_py_pb2.LocalizationEstimate()
+                location_est = localization_pb2.LocalizationEstimate()
                 location_est.ParseFromString(msg.message)
                 data = {"pose": location_est}
                 yield data
 
             if msg.topic == "/apollo/planning":
-                planning = planning_py_pb2.ADCTrajectory()
+                planning = planning_pb2.ADCTrajectory()
                 planning.ParseFromString(msg.message)
                 data = {"planning": planning}
                 yield data

--- a/modules/tools/plot_planning/speed_dsteering_data.py
+++ b/modules/tools/plot_planning/speed_dsteering_data.py
@@ -20,7 +20,7 @@ import sys
 from record_reader import RecordItemReader
 import matplotlib.pyplot as plt
 from cyber.python.cyber_py3.record import RecordReader
-from modules.canbus.proto import chassis_py_pb2
+from modules.canbus.proto import chassis_pb2
 
 
 class SpeedDsteeringData:

--- a/modules/tools/plot_trace/plot_planning_result.py
+++ b/modules/tools/plot_trace/plot_planning_result.py
@@ -26,9 +26,9 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
 
-from modules.canbus.proto import chassis_py_pb2
-from modules.localization.proto import localization_py_pb2
-from modules.planning.proto import planning_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.localization.proto import localization_pb2
+from modules.planning.proto import planning_pb2
 
 
 g_args = None
@@ -56,7 +56,7 @@ def get_debug_paths(planning_pb):
 
 def plot_planning(ax, planning_file):
     with open(planning_file, 'r') as fp:
-        planning_pb = planning_py_pb2.ADCTrajectory()
+        planning_pb = planning_pb2.ADCTrajectory()
         text_format.Merge(fp.read(), planning_pb)
         trajectory = get_3d_trajectory(planning_pb)
         ax.plot(trajectory[0], trajectory[1], trajectory[2],

--- a/modules/tools/plot_trace/plot_trace.py
+++ b/modules/tools/plot_trace/plot_trace.py
@@ -23,8 +23,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from cyber.python.cyber_py3 import cyber
-from modules.canbus.proto import chassis_py_pb2
-from modules.localization.proto import localization_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.localization.proto import localization_pb2
 
 
 GPS_X = list()
@@ -38,7 +38,7 @@ IS_AUTO_MODE = False
 
 def chassis_callback(chassis_data):
     global IS_AUTO_MODE
-    if chassis_data.driving_mode == chassis_py_pb2.Chassis.COMPLETE_AUTO_DRIVE:
+    if chassis_data.driving_mode == chassis_pb2.Chassis.COMPLETE_AUTO_DRIVE:
         IS_AUTO_MODE = True
     else:
         IS_AUTO_MODE = False
@@ -56,9 +56,9 @@ def localization_callback(localization_data):
 
 
 def setup_listener(node):
-    node.create_reader(CHASSIS_TOPIC, chassis_py_pb2.Chassis, chassis_callback)
+    node.create_reader(CHASSIS_TOPIC, chassis_pb2.Chassis, chassis_callback)
     node.create_reader(LOCALIZATION_TOPIC,
-                       localization_py_pb2.LocalizationEstimate,
+                       localization_pb2.LocalizationEstimate,
                        localization_callback)
     while not cyber.is_shutdown():
         time.sleep(0.002)

--- a/modules/tools/prediction/data_pipelines/common/feature_io.py
+++ b/modules/tools/prediction/data_pipelines/common/feature_io.py
@@ -24,8 +24,8 @@ from google.protobuf.internal import decoder
 from google.protobuf.internal import encoder
 import google.protobuf.text_format as text_format
 
-from modules.prediction.proto import feature_py_pb2
-from modules.prediction.proto import offline_features_py_pb2
+from modules.prediction.proto import feature_pb2
+from modules.prediction.proto import offline_features_pb2
 
 
 def readVarint32(stream):
@@ -48,7 +48,7 @@ def load_protobuf(filename):
     """
     read a file in protobuf binary
     """
-    offline_features = offline_features_py_pb2.Features()
+    offline_features = offline_features_pb2.Features()
     with open(filename, 'rb') as file_in:
         offline_features.ParseFromString(file_in.read())
     return offline_features.feature
@@ -64,7 +64,7 @@ def load_label_feature(filename):
             if len(data) < read_bytes:
                 print("Failed to load protobuf")
                 break
-            fea = feature_py_pb2.Feature()
+            fea = feature_pb2.Feature()
             fea.ParseFromString(data)
             features.append(fea)
             size = readVarint32(f)

--- a/modules/tools/prediction/data_pipelines/common/online_to_offline.py
+++ b/modules/tools/prediction/data_pipelines/common/online_to_offline.py
@@ -24,7 +24,7 @@ from google.protobuf.internal import decoder
 from google.protobuf.internal import encoder
 import numpy as np
 
-from modules.prediction.proto import offline_features_py_pb2
+from modules.prediction.proto import offline_features_pb2
 from modules.tools.prediction.data_pipelines.common.bounding_rectangle import BoundingRectangle
 from modules.tools.prediction.data_pipelines.common.configure import parameters
 
@@ -89,7 +89,7 @@ class LabelGenerator(object):
 
     def LoadPBFeatures(self, filepath):
         self.filepath = filepath
-        offline_features = offline_features_py_pb2.Features()
+        offline_features = offline_features_pb2.Features()
         with open(filepath, 'rb') as file_in:
             offline_features.ParseFromString(file_in.read())
         return offline_features.feature
@@ -273,7 +273,7 @@ class LabelGenerator(object):
     '''
 
     def LabelSingleLane(self, period_of_interest=3.0):
-        output_features = offline_features_py_pb2.Features()
+        output_features = offline_features_pb2.Features()
         for obs_id, feature_sequence in self.feature_dict.items():
             feature_seq_len = len(feature_sequence)
             for idx, feature in enumerate(feature_sequence):
@@ -394,7 +394,7 @@ class LabelGenerator(object):
         np.save(self.filepath + '.cruise_label.npy', self.cruise_label_dict)
 
     def LabelTrajectory(self, period_of_interest=3.0):
-        output_features = offline_features_py_pb2.Features()
+        output_features = offline_features_pb2.Features()
         for obs_id, feature_sequence in self.feature_dict.items():
             for idx, feature in enumerate(feature_sequence):
                 # Observe the subsequent Features
@@ -420,7 +420,7 @@ class LabelGenerator(object):
         '''
         label feature trajectory according to real future lane sequence in 7s
         '''
-        output_features = offline_features_py_pb2.Features()
+        output_features = offline_features_pb2.Features()
         for obs_id, feature_sequence in self.feature_dict.items():
             feature_seq_len = len(feature_sequence)
             for i, fea in enumerate(feature_sequence):

--- a/modules/tools/prediction/data_pipelines/cruiseMLP_train.py
+++ b/modules/tools/prediction/data_pipelines/cruiseMLP_train.py
@@ -39,7 +39,7 @@ import torch.optim as optim
 
 from modules.tools.prediction.data_pipelines.common.configure import parameters
 from modules.tools.prediction.data_pipelines.cruise_models import FullyConn_NN, FCNN_CNN1D
-from modules.tools.prediction.data_pipelines.proto.cruise_model_py_pb2 import TensorParameter, InputParameter,\
+from modules.tools.prediction.data_pipelines.proto.cruise_model_pb2 import TensorParameter, InputParameter,\
     Conv1dParameter, DenseParameter, ActivationParameter, MaxPool1dParameter,\
     AvgPool1dParameter, LaneFeatureConvParameter, ObsFeatureFCParameter,\
     ClassifyParameter, RegressParameter, CruiseModelParameter

--- a/modules/tools/prediction/data_pipelines/cruise_models.py
+++ b/modules/tools/prediction/data_pipelines/cruise_models.py
@@ -33,7 +33,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 from modules.tools.prediction.data_pipelines.common.configure import parameters
-from proto.cruise_model_py_pb2 import TensorParameter, InputParameter,\
+from proto.cruise_model_pb2 import TensorParameter, InputParameter,\
     Conv1dParameter, DenseParameter, ActivationParameter, MaxPool1dParameter,\
     AvgPool1dParameter, LaneFeatureConvParameter, ObsFeatureFCParameter,\
     ClassifyParameter, RegressParameter, CruiseModelParameter

--- a/modules/tools/prediction/data_pipelines/data_preprocessing/features_labels_utils.py
+++ b/modules/tools/prediction/data_pipelines/data_preprocessing/features_labels_utils.py
@@ -21,7 +21,7 @@ import h5py
 import numpy as np
 import os
 
-from modules.prediction.proto import offline_features_py_pb2
+from modules.prediction.proto import offline_features_pb2
 
 
 junction_label_label_dim = 12
@@ -35,7 +35,7 @@ that is contained in that file.
 
 def LoadDataForLearning(filepath):
     list_of_data_for_learning = \
-        offline_features_py_pb2.ListDataForLearning()
+        offline_features_pb2.ListDataForLearning()
     with open(filepath, 'rb') as file_in:
         list_of_data_for_learning.ParseFromString(file_in.read())
     return list_of_data_for_learning.data_for_learning

--- a/modules/tools/prediction/data_pipelines/junctionMLP_train.py
+++ b/modules/tools/prediction/data_pipelines/junctionMLP_train.py
@@ -26,8 +26,8 @@ import logging
 import argparse
 import numpy as np
 import tensorflow as tf
-from modules.tools.prediction.data_pipelines.proto import fnn_model_py_pb2
-from fnn_model_py_pb2 import FnnModel, Layer
+from modules.tools.prediction.data_pipelines.proto import fnn_model_pb2
+from fnn_model_pb2 import FnnModel, Layer
 from sklearn.model_selection import train_test_split
 
 dim_input = 7 + 72
@@ -71,13 +71,13 @@ def save_model(model, filename):
         net_layer.layer_input_dim = dim_input
         net_layer.layer_output_dim = dim_output
         if config['activation'] == 'relu':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.RELU
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.RELU
         elif config['activation'] == 'tanh':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.TANH
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.TANH
         elif config['activation'] == 'sigmoid':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.SIGMOID
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.SIGMOID
         elif config['activation'] == 'softmax':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.SOFTMAX
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.SOFTMAX
 
         weights, bias = layer.get_weights()
         net_layer.layer_bias.columns.extend(bias.reshape(-1).tolist())

--- a/modules/tools/prediction/data_pipelines/mlp_train.py
+++ b/modules/tools/prediction/data_pipelines/mlp_train.py
@@ -40,14 +40,14 @@ from keras.utils import np_utils
 from sklearn.model_selection import train_test_split
 import google.protobuf.text_format as text_format
 
-from modules.tools.prediction.data_pipelines.proto import fnn_model_py_pb2
+from modules.tools.prediction.data_pipelines.proto import fnn_model_pb2
 from modules.tools.prediction.data_pipelines.common import log
 from modules.tools.prediction.data_pipelines.common.data_preprocess import load_h5
 from modules.tools.prediction.data_pipelines.common.data_preprocess import down_sample
 from modules.tools.prediction.data_pipelines.common.data_preprocess import train_test_split
 from modules.tools.prediction.data_pipelines.common.configure import parameters
 from modules.tools.prediction.data_pipelines.common.configure import labels
-from fnn_model_py_pb2 import FnnModel, Layer
+from fnn_model_pb2 import FnnModel, Layer
 
 
 # Constants
@@ -245,11 +245,11 @@ def save_model(model, param_norm, filename):
         net_layer.layer_input_dim = dim_input
         net_layer.layer_output_dim = dim_output
         if config['activation'] == 'relu':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.RELU
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.RELU
         elif config['activation'] == 'tanh':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.TANH
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.TANH
         elif config['activation'] == 'sigmoid':
-            net_layer.layer_activation_func = fnn_model_py_pb2.Layer.SIGMOID
+            net_layer.layer_activation_func = fnn_model_pb2.Layer.SIGMOID
 
         weights, bias = layer.get_weights()
         net_layer.layer_bias.columns.extend(bias.reshape(-1).tolist())

--- a/modules/tools/realtime_plot/realtime_plot.py
+++ b/modules/tools/realtime_plot/realtime_plot.py
@@ -27,9 +27,9 @@ import numpy as np
 
 from cyber.python.cyber_py3 import cyber
 from modules.tools.realtime_plot.item import Item
-from modules.canbus.proto.chassis_py_pb2 import Chassis
-from modules.localization.proto.localization_py_pb2 import LocalizationEstimate
-from modules.planning.proto.planning_py_pb2 import ADCTrajectory
+from modules.canbus.proto.chassis_pb2 import Chassis
+from modules.localization.proto.localization_pb2 import LocalizationEstimate
+from modules.planning.proto.planning_pb2 import ADCTrajectory
 from modules.tools.realtime_plot.stitem import Stitem
 from modules.tools.realtime_plot.xyitem import Xyitem
 import modules.tools.common.proto_utils as proto_utils

--- a/modules/tools/record_analyzer/common/error_code_analyzer.py
+++ b/modules/tools/record_analyzer/common/error_code_analyzer.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-from modules.common.proto import error_code_py_pb2
+from modules.common.proto import error_code_pb2
 from modules.tools.record_analyzer.statistical_analyzer import PrintColors
 from modules.tools.record_analyzer.distribution_analyzer import DistributionAnalyzer
 
@@ -31,7 +31,7 @@ class ErrorCodeAnalyzer:
     def put(self, error_code):
         """put"""
         error_code_name = \
-            error_code_py_pb2.ErrorCode.Name(error_code)
+            error_code_pb2.ErrorCode.Name(error_code)
         if error_code_name not in self.error_code_count:
             self.error_code_count[error_code_name] = 1
         else:

--- a/modules/tools/record_analyzer/main.py
+++ b/modules/tools/record_analyzer/main.py
@@ -23,12 +23,12 @@ import matplotlib.pyplot as plt
 
 from cyber.python.cyber_py3.record import RecordReader
 from modules.tools.record_analyzer.lidar_endtoend_analyzer import LidarEndToEndAnalyzer
-from modules.canbus.proto import chassis_py_pb2
-from modules.control.proto import control_cmd_py_pb2
-from modules.drivers.proto import pointcloud_py_pb2
-from modules.perception.proto import perception_obstacle_py_pb2
-from modules.planning.proto import planning_py_pb2
-from modules.prediction.proto import prediction_obstacle_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.control.proto import control_cmd_pb2
+from modules.drivers.proto import pointcloud_pb2
+from modules.perception.proto import perception_obstacle_pb2
+from modules.planning.proto import planning_pb2
+from modules.prediction.proto import prediction_obstacle_pb2
 from modules.tools.record_analyzer.module_control_analyzer import ControlAnalyzer
 from modules.tools.record_analyzer.module_planning_analyzer import PlannigAnalyzer
 
@@ -39,10 +39,10 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
 
     for msg in reader.read_messages():
         if msg.topic == "/apollo/canbus/chassis":
-            chassis = chassis_py_pb2.Chassis()
+            chassis = chassis_pb2.Chassis()
             chassis.ParseFromString(msg.message)
             if chassis.driving_mode == \
-                    chassis_py_pb2.Chassis.COMPLETE_AUTO_DRIVE:
+                    chassis_pb2.Chassis.COMPLETE_AUTO_DRIVE:
                 is_auto_drive = True
             else:
                 is_auto_drive = False
@@ -51,7 +51,7 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
             if (not is_auto_drive and not all_data) or \
                     is_simulation or plot_planning_path or plot_planning_refpath:
                 continue
-            control_cmd = control_cmd_py_pb2.ControlCommand()
+            control_cmd = control_cmd_pb2.ControlCommand()
             control_cmd.ParseFromString(msg.message)
             control_analyzer.put(control_cmd)
             lidar_endtoend_analyzer.put_pb('control', control_cmd)
@@ -59,7 +59,7 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
         if msg.topic == "/apollo/planning":
             if (not is_auto_drive) and (not all_data):
                 continue
-            adc_trajectory = planning_py_pb2.ADCTrajectory()
+            adc_trajectory = planning_pb2.ADCTrajectory()
             adc_trajectory.ParseFromString(msg.message)
             planning_analyzer.put(adc_trajectory)
             lidar_endtoend_analyzer.put_pb('planning', adc_trajectory)
@@ -74,7 +74,7 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
             if ((not is_auto_drive) and (not all_data)) or is_simulation or \
                     plot_planning_path or plot_planning_refpath:
                 continue
-            point_cloud = pointcloud_py_pb2.PointCloud()
+            point_cloud = pointcloud_pb2.PointCloud()
             point_cloud.ParseFromString(msg.message)
             lidar_endtoend_analyzer.put_lidar(point_cloud)
 
@@ -82,7 +82,7 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
             if ((not is_auto_drive) and (not all_data)) or is_simulation or \
                     plot_planning_path or plot_planning_refpath:
                 continue
-            perception = perception_obstacle_py_pb2.PerceptionObstacles()
+            perception = perception_obstacle_pb2.PerceptionObstacles()
             perception.ParseFromString(msg.message)
             lidar_endtoend_analyzer.put_pb('perception', perception)
 
@@ -90,7 +90,7 @@ def process(control_analyzer, planning_analyzer, lidar_endtoend_analyzer,
             if ((not is_auto_drive) and (not all_data)) or is_simulation or \
                     plot_planning_path or plot_planning_refpath:
                 continue
-            prediction = prediction_obstacle_py_pb2.PredictionObstacles()
+            prediction = prediction_obstacle_pb2.PredictionObstacles()
             prediction.ParseFromString(msg.message)
             lidar_endtoend_analyzer.put_pb('prediction', prediction)
 

--- a/modules/tools/record_analyzer/module_planning_analyzer.py
+++ b/modules/tools/record_analyzer/module_planning_analyzer.py
@@ -33,7 +33,7 @@ from modules.tools.record_analyzer.metrics.latency import Latency
 from modules.tools.record_analyzer.metrics.lat_acceleration import LatAcceleration
 from modules.tools.record_analyzer.metrics.lon_acceleration import LonAcceleration
 from modules.tools.record_analyzer.metrics.reference_line import ReferenceLine
-from modules.planning.proto import planning_py_pb2
+from modules.planning.proto import planning_pb2
 from shapely.geometry import LineString, Point
 
 
@@ -73,7 +73,7 @@ class PlannigAnalyzer:
                 adc_trajectory.header.status.error_code)
             self.error_msg_analyzer.put(adc_trajectory.header.status.msg)
 
-            traj_type = planning_py_pb2.ADCTrajectory.TrajectoryType.Name(
+            traj_type = planning_pb2.ADCTrajectory.TrajectoryType.Name(
                 adc_trajectory.trajectory_type)
             self.trajectory_type_dist[traj_type] = \
                 self.trajectory_type_dist.get(traj_type, 0) + 1

--- a/modules/tools/record_analyzer/tools/dump_message.py
+++ b/modules/tools/record_analyzer/tools/dump_message.py
@@ -20,11 +20,11 @@ import argparse
 import sys
 
 from cyber.python.cyber_py3.record import RecordReader
-from modules.canbus.proto import chassis_py_pb2
-from modules.control.proto import control_cmd_py_pb2
-from modules.drivers.proto import pointcloud_py_pb2
-from modules.perception.proto import perception_obstacle_py_pb2
-from modules.planning.proto import planning_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.control.proto import control_cmd_pb2
+from modules.drivers.proto import pointcloud_pb2
+from modules.perception.proto import perception_obstacle_pb2
+from modules.planning.proto import planning_pb2
 
 
 if __name__ == "__main__":
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         if msg.topic == args.message and abs(timestamp - args.timestamp) <= 1:
             if msg.topic == "/apollo/perception/obstacles":
                 perception_obstacles = \
-                    perception_obstacle_py_pb2.PerceptionObstacles()
+                    perception_obstacle_pb2.PerceptionObstacles()
                 perception_obstacles.ParseFromString(msg.message)
                 with open('perception_obstacles.txt', 'w') as f:
                     f.write(str(perception_obstacles))

--- a/modules/tools/record_analyzer/tools/perception_obstacle_sender.py
+++ b/modules/tools/record_analyzer/tools/perception_obstacle_sender.py
@@ -21,7 +21,7 @@ import argparse
 import google.protobuf.text_format as text_format
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import cyber_time
-from modules.perception.proto import perception_obstacle_py_pb2
+from modules.perception.proto import perception_obstacle_pb2
 
 
 def update(perception_obstacles):
@@ -53,9 +53,9 @@ if __name__ == "__main__":
     node = cyber.Node("perception_obstacle_sender")
     perception_pub = node.create_writer(
         "/apollo/perception/obstacles",
-        perception_obstacle_py_pb2.PerceptionObstacles)
+        perception_obstacle_pb2.PerceptionObstacles)
 
-    perception_obstacles = perception_obstacle_py_pb2.PerceptionObstacles()
+    perception_obstacles = perception_obstacle_pb2.PerceptionObstacles()
     with open(args.file, 'r') as f:
         text_format.Merge(f.read(), perception_obstacles)
 

--- a/modules/tools/record_parse_save/parse_camera.py
+++ b/modules/tools/record_parse_save/parse_camera.py
@@ -28,7 +28,7 @@ import sys
 
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import record
-from modules.drivers.proto.sensor_image_py_pb2 import CompressedImage
+from modules.drivers.proto.sensor_image_pb2 import CompressedImage
 
 
 def parse_data(channelname, msg, out_folder):

--- a/modules/tools/record_parse_save/parse_lidar.py
+++ b/modules/tools/record_parse_save/parse_lidar.py
@@ -31,7 +31,7 @@ import sys
 
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import record
-from modules.drivers.proto.pointcloud_py_pb2 import PointCloud
+from modules.drivers.proto.pointcloud_pb2 import PointCloud
 
 
 def parse_data(channelname, msg, out_folder):

--- a/modules/tools/record_parse_save/parse_radar.py
+++ b/modules/tools/record_parse_save/parse_radar.py
@@ -32,7 +32,7 @@ import sys
 
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import record
-from modules.drivers.proto.conti_radar_py_pb2 import ContiRadar
+from modules.drivers.proto.conti_radar_pb2 import ContiRadar
 
 
 class RadarMessageConti408(object):

--- a/modules/tools/record_play/rtk_recorder.py
+++ b/modules/tools/record_play/rtk_recorder.py
@@ -30,8 +30,8 @@ from cyber.python.cyber_py3 import cyber
 from gflags import FLAGS
 
 from modules.tools.common.logger import Logger
-from modules.canbus.proto import chassis_py_pb2
-from modules.localization.proto import localization_py_pb2
+from modules.canbus.proto import chassis_pb2
+from modules.localization.proto import localization_pb2
 
 
 class RtkRecord(object):
@@ -60,8 +60,8 @@ class RtkRecord(object):
         self.write("x,y,z,speed,acceleration,curvature,"
                    "curvature_change_rate,time,theta,gear,s,throttle,brake,steering\n")
 
-        self.localization = localization_py_pb2.LocalizationEstimate()
-        self.chassis = chassis_py_pb2.Chassis()
+        self.localization = localization_pb2.LocalizationEstimate()
+        self.chassis = chassis_pb2.Chassis()
         self.chassis_received = False
 
         self.cars = 0.0
@@ -185,11 +185,11 @@ def main(argv):
     recorder = RtkRecord(record_file)
     atexit.register(recorder.shutdown)
     node.create_reader('/apollo/canbus/chassis',
-                       chassis_py_pb2.Chassis,
+                       chassis_pb2.Chassis,
                        recorder.chassis_callback)
 
     node.create_reader('/apollo/localization/pose',
-                       localization_py_pb2.LocalizationEstimate,
+                       localization_pb2.LocalizationEstimate,
                        recorder.localization_callback)
 
     while not cyber.is_shutdown():

--- a/modules/tools/restore_video_record/restore_video_record.py
+++ b/modules/tools/restore_video_record/restore_video_record.py
@@ -31,7 +31,7 @@ from absl import logging
 import cv2
 
 from cyber.python.cyber_py3.record import RecordReader, RecordWriter
-from modules.drivers.proto.sensor_image_py_pb2 import CompressedImage
+from modules.drivers.proto.sensor_image_pb2 import CompressedImage
 
 
 flags.DEFINE_string('from_record', None, 'The source record file that needs to be restored.')

--- a/modules/tools/routing/debug_passage_region.py
+++ b/modules/tools/routing/debug_passage_region.py
@@ -23,8 +23,8 @@ import matplotlib.pyplot as plt
 
 import modules.tools.common.proto_utils as proto_utils
 import modules.tools.routing.debug_topo as debug_topo
-from modules.routing.proto.routing_py_pb2 import RoutingResponse
-from modules.routing.proto.topo_graph_py_pb2 import Graph
+from modules.routing.proto.routing_pb2 import RoutingResponse
+from modules.routing.proto.topo_graph_pb2 import Graph
 
 
 color_iter = itertools.cycle(

--- a/modules/tools/routing/debug_route.py
+++ b/modules/tools/routing/debug_route.py
@@ -24,7 +24,7 @@ import gflags
 import matplotlib.pyplot as plt
 
 import modules.tools.routing.debug_topo as debug_topo
-import modules.routing.proto.topo_graph_py_pb2 as topo_graph_py_pb2
+import modules.routing.proto.topo_graph_pb2 as topo_graph_pb2
 import util
 
 

--- a/modules/tools/routing/debug_topo.py
+++ b/modules/tools/routing/debug_topo.py
@@ -23,7 +23,7 @@ import sys
 import matplotlib.pyplot as plt
 
 import modules.tools.common.proto_utils as proto_utils
-import modules.routing.proto.topo_graph_py_pb2 as topo_graph_py_pb2
+import modules.routing.proto.topo_graph_pb2 as topo_graph_pb2
 import modules.tools.routing.util as util
 
 
@@ -139,7 +139,7 @@ def plot_node(node, plot_id, color):
 
 def plot_edge(edge, midddle_point_map):
     """plot topology graph edge"""
-    if edge.direction_type == topo_graph_py_pb2.Edge.FORWARD:
+    if edge.direction_type == topo_graph_pb2.Edge.FORWARD:
         return
     # if lane change is allowed, draw an arrow from lane with from_id to lane with to_id
     from_id = edge.from_lane_id

--- a/modules/tools/routing/util.py
+++ b/modules/tools/routing/util.py
@@ -23,9 +23,9 @@ import gflags
 import matplotlib.pyplot as plt
 
 import common.proto_utils as proto_utils
-import modules.map.proto.map_py_pb2 as map_py_pb2
-import modules.routing.proto.topo_graph_py_pb2 as topo_graph_py_pb2
-import modules.routing.proto.routing_py_pb2 as routing_py_pb2
+import modules.map.proto.map_pb2 as map_pb2
+import modules.routing.proto.topo_graph_pb2 as topo_graph_pb2
+import modules.routing.proto.routing_pb2 as routing_pb2
 
 FLAGS = gflags.FLAGS
 gflags.DEFINE_string('map_dir', 'modules/map/data/demo', 'map directory')
@@ -49,14 +49,14 @@ def get_mapdata(map_dir):
     print('Please wait for loading map data...')
     map_data_path = os.path.join(map_dir, 'base_map.bin')
     print('File: %s' % map_data_path)
-    return proto_utils.get_pb_from_bin_file(map_data_path, map_py_pb2.Map())
+    return proto_utils.get_pb_from_bin_file(map_data_path, map_pb2.Map())
 
 
 def get_topodata(map_dir):
     print('Please wait for loading routing topo data...')
     topo_data_path = os.path.join(map_dir, 'routing_map.bin')
     print("File: %s" % topo_data_path)
-    return proto_utils.get_pb_from_bin_file(topo_data_path, topo_graph_py_pb2.Graph())
+    return proto_utils.get_pb_from_bin_file(topo_data_path, topo_graph_pb2.Graph())
 
 
 def get_routingdata():
@@ -65,7 +65,7 @@ def get_routingdata():
         os.path.join(os.path.dirname(__file__), '../../../data/log'))
     route_data_path = os.path.join(log_dir, 'passage_region_debug.bin')
     print("File: %s" % route_data_path)
-    return proto_utils.get_pb_from_text_file(route_data_path, routing_py_pb2.RoutingResponse())
+    return proto_utils.get_pb_from_text_file(route_data_path, routing_pb2.RoutingResponse())
 
 
 def onclick(event):

--- a/modules/tools/sensor_calibration/extract_data.py
+++ b/modules/tools/sensor_calibration/extract_data.py
@@ -33,10 +33,10 @@ from google.protobuf import text_format
 import numpy as np
 
 from cyber.python.cyber_py3.record import RecordReader
-from cyber.proto import record_py_pb2
+from cyber.proto import record_pb2
 from modules.tools.sensor_calibration.configuration_yaml_generator import ConfigYaml
 from modules.tools.sensor_calibration.extract_static_data import get_subfolder_list, select_static_image_pcd
-from modules.tools.sensor_calibration.proto import extractor_config_py_pb2
+from modules.tools.sensor_calibration.proto import extractor_config_pb2
 from modules.tools.sensor_calibration.sensor_msg_extractor import GpsParser, ImageParser, PointCloudParser, PoseParser, ContiRadarParser
 
 
@@ -280,7 +280,7 @@ def validate_record(record_file):
     # Check the validity of a cyber record file according to header info.
     record_reader = RecordReader(record_file)
     header_msg = record_reader.get_headerstring()
-    header = record_py_pb2.Header()
+    header = record_pb2.Header()
     header.ParseFromString(header_msg)
     print("header is {}".format(header))
 
@@ -494,7 +494,7 @@ def main():
                         help="protobuf text format configuration file abosolute path")
     args = parser.parse_args()
 
-    config = extractor_config_py_pb2.DataExtractionConfig()
+    config = extractor_config_pb2.DataExtractionConfig()
     with open(args.config, "r") as f:
         proto_block = f.read()
         text_format.Merge(proto_block, config)

--- a/modules/tools/sensor_calibration/extract_static_data.py
+++ b/modules/tools/sensor_calibration/extract_static_data.py
@@ -33,10 +33,10 @@ from google.protobuf import text_format
 import numpy as np
 
 from cyber.python.cyber_py3.record import RecordReader
-from cyber.proto import record_py_pb2
+from cyber.proto import record_pb2
 from modules.tools.sensor_calibration.configuration_yaml_generator import ConfigYaml
 from modules.tools.sensor_calibration.data_file_object import TimestampFileObject, OdometryFileObject
-from modules.tools.sensor_calibration.proto import extractor_config_py_pb2
+from modules.tools.sensor_calibration.proto import extractor_config_pb2
 
 
 CYBER_PATH = os.environ['CYBER_PATH']

--- a/modules/tools/sensor_calibration/ins_stat_publisher.py
+++ b/modules/tools/sensor_calibration/ins_stat_publisher.py
@@ -27,17 +27,17 @@ import time
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import cyber_time
 
-from modules.drivers.gnss.proto import ins_py_pb2
+from modules.drivers.gnss.proto import ins_pb2
 
 
 class InsStat(object):
     def __init__(self,node):
-        self.insstat_pub = node.create_writer('/apollo/sensor/gnss/ins_stat', ins_py_pb2.InsStat)
+        self.insstat_pub = node.create_writer('/apollo/sensor/gnss/ins_stat', ins_pb2.InsStat)
         self.sequence_num = 0
         self.terminating = False
 
     def publish_statmsg(self):
-        insstat = ins_py_pb2.InsStat()
+        insstat = ins_pb2.InsStat()
         now = cyber_time.Time.now().to_sec()
         insstat.header.timestamp_sec = now
         insstat.header.module_name = "ins_stat"

--- a/modules/tools/sensor_calibration/odom_publisher.py
+++ b/modules/tools/sensor_calibration/odom_publisher.py
@@ -27,13 +27,13 @@ import time
 from cyber.python.cyber_py3 import cyber
 from cyber.python.cyber_py3 import cyber_time
 
-from modules.localization.proto import localization_py_pb2
-from modules.localization.proto import gps_py_pb2
+from modules.localization.proto import localization_pb2
+from modules.localization.proto import gps_pb2
 
 class OdomPublisher(object):
     def __init__(self, node):
-        self.localization = localization_py_pb2.LocalizationEstimate()
-        self.gps_odom_pub = node.create_writer('/apollo/sensor/gnss/odometry', gps_py_pb2.Gps) 
+        self.localization = localization_pb2.LocalizationEstimate()
+        self.gps_odom_pub = node.create_writer('/apollo/sensor/gnss/odometry', gps_pb2.Gps) 
         self.sequence_num = 0
         self.terminating = False
         self.position_x = 0
@@ -64,7 +64,7 @@ class OdomPublisher(object):
         self.linear_velocity_z = self.localization.pose.linear_velocity.z
 
     def publish_odom(self):
-        odom = gps_py_pb2.Gps()
+        odom = gps_pb2.Gps()
         now = cyber_time.Time.now().to_sec()
         odom.header.timestamp_sec = now
         odom.header.module_name = "odometry"
@@ -98,7 +98,7 @@ def main():
     """
     node = cyber.Node('odom_publisher')
     odom = OdomPublisher(node)
-    node.create_reader('/apollo/localization/pose', localization_py_pb2.LocalizationEstimate, odom.localization_callback)
+    node.create_reader('/apollo/localization/pose', localization_pb2.LocalizationEstimate, odom.localization_callback)
     while not cyber.is_shutdown():
         now = cyber_time.Time.now().to_sec()
         odom.publish_odom()

--- a/modules/tools/sensor_calibration/sensor_msg_extractor.py
+++ b/modules/tools/sensor_calibration/sensor_msg_extractor.py
@@ -29,11 +29,11 @@ import pypcd
 import numpy as np
 
 from modules.tools.sensor_calibration.data_file_object import TimestampFileObject, OdometryFileObject
-from modules.drivers.proto import conti_radar_py_pb2
-from modules.drivers.proto import sensor_image_py_pb2
-from modules.drivers.proto import pointcloud_py_pb2
-from modules.localization.proto import gps_py_pb2
-from modules.localization.proto import localization_py_pb2
+from modules.drivers.proto import conti_radar_pb2
+from modules.drivers.proto import sensor_image_pb2
+from modules.drivers.proto import pointcloud_pb2
+from modules.localization.proto import gps_pb2
+from modules.localization.proto import localization_pb2
 
 
 class SensorMessageParser(object):
@@ -92,7 +92,7 @@ class GpsParser(SensorMessageParser):
             self._odomotry_output_file = os.path.join(self._output_path, "odometry")
 
     def _init_parser(self):
-        self._msg_parser = gps_py_pb2.Gps()
+        self._msg_parser = gps_pb2.Gps()
 
     def parse_sensor_message(self, msg):
         """ parse Gps information from GNSS odometry channel"""
@@ -135,7 +135,7 @@ class PoseParser(GpsParser):
     """
 
     def _init_parser(self):
-        self._msg_parser = localization_py_pb2.LocalizationEstimate()
+        self._msg_parser = localization_pb2.LocalizationEstimate()
 
     def parse_sensor_message(self, msg):
         """ parse localization information from localization estimate channel"""
@@ -218,7 +218,7 @@ class PointCloudParser(SensorMessageParser):
         pypcd.save_point_cloud_bin_compressed(pc_meta, pcd_file)
 
     def _init_parser(self):
-        self._msg_parser = pointcloud_py_pb2.PointCloud()
+        self._msg_parser = pointcloud_pb2.PointCloud()
 
     def parse_sensor_message(self, msg):
         """
@@ -253,7 +253,7 @@ class ImageParser(SensorMessageParser):
         self._suffix = suffix
 
     def _init_parser(self):
-        self._msg_parser = sensor_image_py_pb2.Image()
+        self._msg_parser = sensor_image_pb2.Image()
 
     def parse_sensor_message(self, msg):
 
@@ -372,7 +372,7 @@ class ContiRadarParser(SensorMessageParser):
         pypcd.save_point_cloud_bin(pc_meta, pcd_file)
 
     def _init_parser(self):
-        self._msg_parser = conti_radar_py_pb2.ContiRadar()
+        self._msg_parser = conti_radar_pb2.ContiRadar()
 
     def parse_sensor_message(self, msg):
         """


### PR DESCRIPTION
the .py file generated from proto still ends with _pb2 instead of _py_pb2  