### PR TITLE
Docker_dev: Fix eigen issue on one test.

### DIFF
--- a/modules/perception/base/camera.h
+++ b/modules/perception/base/camera.h
@@ -46,6 +46,9 @@ class BaseCameraModel {
 
 class PinholeCameraModel : public BaseCameraModel {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   ~PinholeCameraModel() = default;
 
   Eigen::Vector2f Project(const Eigen::Vector3f& point3d) override;

--- a/modules/perception/base/concurrent_object_pool.h
+++ b/modules/perception/base/concurrent_object_pool.h
@@ -70,7 +70,7 @@ class ConcurrentObjectPool : public BaseObjectPool<ObjectType> {
       queue_.push(obj_ptr);
     });
 #else
-    return std::make_shared<ObjectType>();
+    return std::shared_ptr<ObjectType>(new ObjectType);
 #endif
   }
   // @brief overrided function to get batch of smart pointers
@@ -102,7 +102,7 @@ class ConcurrentObjectPool : public BaseObjectPool<ObjectType> {
     }
 #else
     for (size_t i = 0; i < num; ++i) {
-      data->emplace_back(std::make_shared<ObjectType>());
+      data->emplace_back(new ObjectType);
     }
 #endif
   }
@@ -143,8 +143,8 @@ class ConcurrentObjectPool : public BaseObjectPool<ObjectType> {
 #else
     for (size_t i = 0; i < num; ++i) {
       is_front
-          ? data->emplace_front(std::make_shared<ObjectType>())
-          : data->emplace_back(std::make_shared<ObjectType>());
+          ? data->emplace_front(new ObjectType)
+          : data->emplace_back(new ObjectType);
     }
 #endif
   }
@@ -183,8 +183,8 @@ class ConcurrentObjectPool : public BaseObjectPool<ObjectType> {
 #else
     for (size_t i = 0; i < num; ++i) {
       is_front
-          ? data->emplace_front(std::make_shared<ObjectType>())
-          : data->emplace_back(std::make_shared<ObjectType>());
+          ? data->emplace_front(new ObjectType)
+          : data->emplace_back(new ObjectType);
     }
 #endif
   }

--- a/modules/perception/base/distortion_model.h
+++ b/modules/perception/base/distortion_model.h
@@ -57,6 +57,9 @@ typedef std::shared_ptr<const BaseCameraDistortionModel>
 
 class BrownCameraDistortionModel : public BaseCameraDistortionModel {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   BrownCameraDistortionModel() = default;
   ~BrownCameraDistortionModel() = default;
 

--- a/modules/perception/base/frame.h
+++ b/modules/perception/base/frame.h
@@ -30,6 +30,8 @@ namespace perception {
 namespace base {
 
 struct alignas(16) Frame {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Frame() { sensor2world_pose.setIdentity(); }
 
   void Reset() {

--- a/modules/perception/base/impending_collision_edge.h
+++ b/modules/perception/base/impending_collision_edge.h
@@ -50,7 +50,9 @@ struct ImpendingCollisionEdges {
 
   // sensor to world position
   Eigen::Matrix4d sensor2world_pose = Eigen::Matrix4d::Zero();
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 // TODO(all): to remove
 // typedef std::shared_ptr<ImpendingCollisionEdges> ImpendingCollisionEdgesPtr;

--- a/modules/perception/base/object.h
+++ b/modules/perception/base/object.h
@@ -32,6 +32,8 @@ namespace perception {
 namespace base {
 
 struct alignas(16) Object {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Object();
   std::string ToString() const;
   void Reset();

--- a/modules/perception/base/object_supplement.h
+++ b/modules/perception/base/object_supplement.h
@@ -202,6 +202,8 @@ typedef std::shared_ptr<MotionBuffer> MotionBufferPtr;
 typedef std::shared_ptr<const MotionBuffer> MotionBufferConstPtr;
 
 struct alignas(16) Vehicle3DStatus {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   float yaw_delta;  // azimuth angle change
   float pitch_delta;
   float roll_delta;

--- a/modules/perception/base/omnidirectional_model.h
+++ b/modules/perception/base/omnidirectional_model.h
@@ -30,6 +30,9 @@ namespace base {
 
 class OmnidirectionalCameraDistortionModel : public BaseCameraDistortionModel {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   OmnidirectionalCameraDistortionModel() = default;
   ~OmnidirectionalCameraDistortionModel() = default;
 

--- a/modules/perception/base/point.h
+++ b/modules/perception/base/point.h
@@ -26,7 +26,7 @@ namespace perception {
 namespace base {
 
 template <typename T>
-struct Point {
+struct alignas(16) Point {
   T x = 0;
   T y = 0;
   T z = 0;

--- a/modules/perception/base/point_cloud.h
+++ b/modules/perception/base/point_cloud.h
@@ -32,6 +32,9 @@ namespace base {
 template <class PointT>
 class PointCloud {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   using PointType = PointT;
   // @brief default constructor
   PointCloud() = default;

--- a/modules/perception/camera/app/cipv_camera.h
+++ b/modules/perception/camera/app/cipv_camera.h
@@ -54,6 +54,9 @@ static constexpr uint32_t kMaxNumVirtualLanePoint = 25;
 static constexpr float kAverageFrameRate = 0.05f;
 
 class Cipv {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   // Member functions
  public:
   Cipv(void);

--- a/modules/perception/camera/common/camera_frame.h
+++ b/modules/perception/camera/common/camera_frame.h
@@ -63,7 +63,9 @@ struct CameraFrame {
   std::vector<base::TrafficLightPtr> traffic_lights;
 
   void Reset() {}
-};  // struct CameraFrame
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;  // struct CameraFrame
 
 }  // namespace camera
 }  // namespace perception

--- a/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
+++ b/modules/perception/camera/lib/calibration_service/online_calibration_service/online_calibration_service.cc
@@ -164,8 +164,8 @@ void OnlineCalibrationService::Update(CameraFrame *frame) {
     CalibratorOptions calibrator_options;
     calibrator_options.lane_objects =
         std::make_shared<std::vector<base::LaneLine>>(frame->lane_objects);
-    calibrator_options.camera2world_pose =
-        std::make_shared<Eigen::Affine3d>(frame->camera2world_pose);
+    calibrator_options.camera2world_pose.reset(
+        new Eigen::Affine3d(frame->camera2world_pose));
     calibrator_options.timestamp = &(frame->timestamp);
     float pitch_angle = 0.f;
     bool updated = calibrator_->Calibrate(calibrator_options, &pitch_angle);

--- a/modules/perception/camera/lib/interface/base_obstacle_detector.h
+++ b/modules/perception/camera/lib/interface/base_obstacle_detector.h
@@ -30,7 +30,9 @@ namespace camera {
 struct ObstacleDetectorInitOptions : public BaseInitOptions {
   std::shared_ptr<base::BaseCameraModel> base_camera_model = nullptr;
   Eigen::Matrix3f intrinsics;
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 struct ObstacleDetectorOptions {};
 

--- a/modules/perception/camera/lib/lane/postprocessor/darkSCNN/darkSCNN_lane_postprocessor.h
+++ b/modules/perception/camera/lib/lane/postprocessor/darkSCNN/darkSCNN_lane_postprocessor.h
@@ -35,6 +35,9 @@ namespace camera {
 
 class DarkSCNNLanePostprocessor : public BaseLanePostprocessor {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   DarkSCNNLanePostprocessor() : BaseLanePostprocessor() {}
 
   virtual ~DarkSCNNLanePostprocessor() {}

--- a/modules/perception/camera/lib/motion/plane_motion.h
+++ b/modules/perception/camera/lib/motion/plane_motion.h
@@ -70,7 +70,7 @@ class PlaneMotion {
     buffer_size_ = s;
     // mot_buffer_.reserve(buffer_size_);
     if (mot_buffer_ == nullptr) {
-      mot_buffer_ = std::make_shared<base::MotionBuffer>(buffer_size_);
+      mot_buffer_.reset(new base::MotionBuffer(buffer_size_));
     } else {
       mot_buffer_->set_capacity(buffer_size_);
     }

--- a/modules/perception/camera/lib/obstacle/tracker/common/kalman_filter.h
+++ b/modules/perception/camera/lib/obstacle/tracker/common/kalman_filter.h
@@ -26,6 +26,9 @@ namespace camera {
 
 class KalmanFilterConstVelocity {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   KalmanFilterConstVelocity();
 
   void Init(Eigen::VectorXd);

--- a/modules/perception/camera/lib/obstacle/transformer/multicue/obj_mapper.h
+++ b/modules/perception/camera/lib/obstacle/transformer/multicue/obj_mapper.h
@@ -65,6 +65,9 @@ struct ObjMapperParams {
 
 class ObjMapper {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   ObjMapper() : width_(0), height_(0) {
     memset(k_mat_, 0, sizeof(float) * 9);
     resize_ry_score(params_.nr_bins_ry);

--- a/modules/perception/camera/lib/traffic_light/preprocessor/pose.h
+++ b/modules/perception/camera/lib/traffic_light/preprocessor/pose.h
@@ -29,6 +29,9 @@ namespace camera {
 // @brief Car's Pose
 class CarPose {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   CarPose() = default;
   ~CarPose() = default;
 

--- a/modules/perception/camera/test/camera_lib_calibrator_laneline_laneline_calibrator_test.cc
+++ b/modules/perception/camera/test/camera_lib_calibrator_laneline_laneline_calibrator_test.cc
@@ -198,8 +198,8 @@ TEST(LanelineCalibratorTest, laneline_calibrator_test) {
     CalibratorOptions calibrator_options;
     calibrator_options.lane_objects =
         std::make_shared<std::vector<base::LaneLine>>(frame.lane_objects);
-    calibrator_options.camera2world_pose =
-        std::make_shared<Eigen::Affine3d>(frame.camera2world_pose);
+    calibrator_options.camera2world_pose.reset(
+        new Eigen::Affine3d(frame.camera2world_pose));
     calibrator_options.timestamp = &(frame.timestamp);
     float pitch_angle;
     // blank ego lane
@@ -217,8 +217,8 @@ TEST(LanelineCalibratorTest, laneline_calibrator_test) {
     }
     calibrator_options.lane_objects =
         std::make_shared<std::vector<base::LaneLine>>(frame.lane_objects);
-    calibrator_options.camera2world_pose =
-        std::make_shared<Eigen::Affine3d>(frame.camera2world_pose);
+    calibrator_options.camera2world_pose.reset(
+        new Eigen::Affine3d(frame.camera2world_pose));
     calibrator_options.timestamp = &(frame.timestamp);
     // lack ego right
     EXPECT_FALSE(calibrator.Calibrate(calibrator_options, &pitch_angle));
@@ -240,8 +240,8 @@ TEST(LanelineCalibratorTest, laneline_calibrator_test) {
     // process
     calibrator_options.lane_objects =
         std::make_shared<std::vector<base::LaneLine>>(frame.lane_objects);
-    calibrator_options.camera2world_pose =
-        std::make_shared<Eigen::Affine3d>(frame.camera2world_pose);
+    calibrator_options.camera2world_pose.reset(
+        new Eigen::Affine3d(frame.camera2world_pose));
     calibrator_options.timestamp = &(frame.timestamp);
     update = calibrator.Calibrate(calibrator_options, &pitch_angle);
     if (update) {

--- a/modules/perception/camera/tools/offline/visualizer.h
+++ b/modules/perception/camera/tools/offline/visualizer.h
@@ -33,6 +33,9 @@ namespace camera {
 
 class Visualizer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   bool Init(const std::vector<std::string> &camera_names,
             TransformServer *tf_server);
   bool Init_all_info_single_camera(

--- a/modules/perception/common/geometry/basic_test.cc
+++ b/modules/perception/common/geometry/basic_test.cc
@@ -345,7 +345,7 @@ TEST(GeometryCommonTest, calculate_dist_and_dir_to_boundary) {
   EXPECT_NEAR(distance, 0.f, std::numeric_limits<float>::epsilon());
 }
 
-TEST(GeometryCommonTest, calculate_dist_and_dir_to_boundary_list) {
+TEST(GeometryCommonTest, calculate_dist_and_dir_to_boundary_lists) {
   Eigen::Vector3f pt(0.0, 0.0, 0.0);
   PointCloud<PointF> left, right;
   std::vector<PointCloud<PointF>> left_list, right_list;

--- a/modules/perception/common/graph/secure_matrix.h
+++ b/modules/perception/common/graph/secure_matrix.h
@@ -25,6 +25,9 @@ namespace common {
 template <typename T>
 class SecureMat {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   SecureMat() : height_(0), width_(0) { Reserve(max_height_, max_width_); }
 
   size_t height() { return height_; }

--- a/modules/perception/fusion/base/sensor.cc
+++ b/modules/perception/fusion/base/sensor.cc
@@ -69,7 +69,7 @@ bool Sensor::GetPose(double timestamp, Eigen::Affine3d* pose) const {
 }
 
 void Sensor::AddFrame(const base::FrameConstPtr& frame_ptr) {
-  SensorFramePtr frame = std::make_shared<SensorFrame>(frame_ptr);
+  SensorFramePtr frame(new SensorFrame(frame_ptr));
   if (frames_.size() == kMaxCachedFrameNum) {
     frames_.pop_front();
   }

--- a/modules/perception/fusion/base/sensor_data_manager.cc
+++ b/modules/perception/fusion/base/sensor_data_manager.cc
@@ -52,7 +52,7 @@ void SensorDataManager::AddSensorMeasurements(
       AERROR << "Failed to find sensor " << sensor_id << " in sensor manager.";
       return;
     }
-    sensor_ptr = std::make_shared<Sensor>(Sensor(sensor_info));
+    sensor_ptr.reset(new Sensor(sensor_info));
     sensors_.emplace(sensor_id, sensor_ptr);
   } else {
     sensor_ptr = it->second;

--- a/modules/perception/fusion/base/sensor_frame.cc
+++ b/modules/perception/fusion/base/sensor_frame.cc
@@ -38,7 +38,7 @@ void SensorFrame::Initialize(const base::FrameConstPtr& base_frame_ptr) {
   foreground_objects_.reserve(base_objects.size());
 
   for (const auto& base_obj : base_objects) {
-    SensorObjectPtr obj = std::make_shared<SensorObject>(base_obj, header_);
+    SensorObjectPtr obj(new SensorObject(base_obj, header_));
     if (base_obj->lidar_supplement.is_background) {
       background_objects_.emplace_back(obj);
     } else {

--- a/modules/perception/fusion/base/sensor_frame.h
+++ b/modules/perception/fusion/base/sensor_frame.h
@@ -38,7 +38,9 @@ struct SensorFrameHeader {
   SensorFrameHeader(const base::SensorInfo& info, double ts,
                     const Eigen::Affine3d& pose)
       : sensor_info(info), timestamp(ts), sensor2world_pose(pose) {}
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 class SensorFrame {
  public:

--- a/modules/perception/fusion/common/base_filter.h
+++ b/modules/perception/fusion/common/base_filter.h
@@ -26,6 +26,9 @@ namespace fusion {
 // @brief base filter inference
 class BaseFilter {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   // @brief constructor
   explicit BaseFilter(const std::string name)
       : init_(false), name_(name), states_num_(0) {}

--- a/modules/perception/fusion/common/information_filter.h
+++ b/modules/perception/fusion/common/information_filter.h
@@ -23,6 +23,9 @@ namespace fusion {
 
 class InformationFilter : public BaseFilter {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   InformationFilter();
   ~InformationFilter() = default;
 

--- a/modules/perception/fusion/common/kalman_filter.h
+++ b/modules/perception/fusion/common/kalman_filter.h
@@ -25,6 +25,9 @@ namespace fusion {
 
 class KalmanFilter : public BaseFilter {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   KalmanFilter();
 
   bool Init(const Eigen::VectorXd &initial_belief_states,

--- a/modules/perception/fusion/lib/data_fusion/motion_fusion/kalman_motion_fusion/kalman_motion_fusion.h
+++ b/modules/perception/fusion/lib/data_fusion/motion_fusion/kalman_motion_fusion/kalman_motion_fusion.h
@@ -28,6 +28,9 @@ namespace fusion {
 
 class KalmanMotionFusion : public BaseMotionFusion {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   explicit KalmanMotionFusion(TrackPtr track) : BaseMotionFusion(track) {}
   ~KalmanMotionFusion() = default;
 

--- a/modules/perception/lidar/app/lidar_obstacle_detection.h
+++ b/modules/perception/lidar/app/lidar_obstacle_detection.h
@@ -40,7 +40,9 @@ struct LidarObstacleDetectionInitOptions {
 struct LidarObstacleDetectionOptions {
   std::string sensor_name;
   Eigen::Affine3d sensor2novatel_extrinsics;
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 class LidarObstacleDetection {
  public:

--- a/modules/perception/lidar/app/lidar_obstacle_segmentation.h
+++ b/modules/perception/lidar/app/lidar_obstacle_segmentation.h
@@ -40,7 +40,9 @@ struct LidarObstacleSegmentationInitOptions {
 struct LidarObstacleSegmentationOptions {
   std::string sensor_name;
   Eigen::Affine3d sensor2novatel_extrinsics;
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 class LidarObstacleSegmentation {
  public:

--- a/modules/perception/lidar/common/lidar_frame.h
+++ b/modules/perception/lidar/common/lidar_frame.h
@@ -31,6 +31,8 @@ namespace perception {
 namespace lidar {
 
 struct LidarFrame {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   // point cloud
   std::shared_ptr<base::AttributePointCloud<base::PointF>> cloud;
   // world point cloud

--- a/modules/perception/lidar/common/pcl_util.h
+++ b/modules/perception/lidar/common/pcl_util.h
@@ -37,6 +37,7 @@ struct PCLPointXYZIT {
   float z;
   uint8_t intensity;
   double timestamp;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
 struct PCLPointXYZL {
@@ -44,6 +45,7 @@ struct PCLPointXYZL {
   float y;
   float z;
   uint32_t label;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
 inline bool LoadPCLPCD(const std::string& file_path,

--- a/modules/perception/lidar/lib/pointcloud_preprocessor/pointcloud_preprocessor.h
+++ b/modules/perception/lidar/lib/pointcloud_preprocessor/pointcloud_preprocessor.h
@@ -31,7 +31,9 @@ struct PointCloudPreprocessorInitOptions {
 
 struct PointCloudPreprocessorOptions {
   Eigen::Affine3d sensor2novatel_extrinsics;
-};
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
 
 class PointCloudPreprocessor {
  public:

--- a/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation_test.cc
+++ b/modules/perception/lidar/lib/segmentation/cnnseg/cnn_segmentation_test.cc
@@ -75,7 +75,7 @@ TEST(CNNSegmentationTest, cnn_segmentation_sequence_test) {
       "/apollo/modules/perception/testdata/"
       "lidar/lib/segmentation/cnnseg/";
 
-  auto segmentation = std::make_shared<CNNSegmentation>();
+  auto segmentation = std::shared_ptr<CNNSegmentation>(new CNNSegmentation);
   SegmentationOptions options;
   EXPECT_FALSE(segmentation->Segment(options, nullptr));
   LidarFrame frame_data;
@@ -123,7 +123,7 @@ TEST(CNNSegmentationTest, cnn_segmentation_test) {
       "lidar/lib/segmentation/cnnseg/";
 
   // load pcd data
-  auto pcl_ptr = std::make_shared<base::PointFCloud>();
+  auto pcl_ptr = std::shared_ptr<base::PointFCloud>(new base::PointFCloud);
   std::string filename =
       "/apollo/modules/perception/testdata/lidar/app/data/perception/"
       "lidar/files/0002_00.pcd";
@@ -141,7 +141,7 @@ TEST(CNNSegmentationTest, cnn_segmentation_test) {
   //  }
 
   // test init
-  auto segmentation = std::make_shared<CNNSegmentation>();
+  auto segmentation = std::shared_ptr<CNNSegmentation>(new CNNSegmentation);
   EXPECT_TRUE(segmentation->Init());
 
   // test segment

--- a/modules/perception/lidar/lib/segmentation/ncut/common/lr_classifier.h
+++ b/modules/perception/lidar/lib/segmentation/ncut/common/lr_classifier.h
@@ -35,6 +35,9 @@ namespace lidar {
 
 class LRClassifier {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   LRClassifier() = default;
   ~LRClassifier() {}
   bool init() {

--- a/modules/perception/lidar/lib/segmentation/ncut/ncut_segmentation.cc
+++ b/modules/perception/lidar/lib/segmentation/ncut/ncut_segmentation.cc
@@ -297,7 +297,7 @@ bool NCutSegmentation::Segment(const SegmentationOptions& options,
   // .5.1 outlier
   for (size_t i = 0; i < cloud_outlier.size(); ++i) {
     base::PointFCloudPtr pc = cloud_components[cloud_outlier[i]];
-    base::ObjectPtr obj = std::make_shared<base::Object>();
+    base::ObjectPtr obj(new base::Object);
     obj->lidar_supplement.cloud = *pc;
     _outliers->push_back(obj);
   }

--- a/modules/perception/lidar/lib/tracker/common/tracked_object.h
+++ b/modules/perception/lidar/lib/tracker/common/tracked_object.h
@@ -149,7 +149,9 @@ struct TrackedObject {
   base::SensorInfo sensor_info;
 
   Eigen::Vector3d global_local_offset;
-};  // struct TrackedObject
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;  // struct TrackedObject
 
 typedef std::shared_ptr<TrackedObject> TrackedObjectPtr;
 typedef std::shared_ptr<const TrackedObject> TrackedObjectConstPtr;

--- a/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.h
+++ b/modules/perception/lidar/lib/tracker/multi_lidar_fusion/mlf_engine.h
@@ -35,6 +35,9 @@ namespace lidar {
 
 class MlfEngine : public BaseMultiTargetTracker {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   MlfEngine() = default;
   ~MlfEngine() = default;
 

--- a/modules/perception/onboard/component/camera_perception_viz_message.h
+++ b/modules/perception/onboard/component/camera_perception_viz_message.h
@@ -33,6 +33,9 @@ namespace onboard {
 
 class CameraPerceptionVizMessage {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   CameraPerceptionVizMessage() { type_name_ = "CameraPerceptionVizMessage"; }
   ~CameraPerceptionVizMessage() = default;
 

--- a/modules/perception/onboard/component/fusion_camera_detection_component.cc
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.cc
@@ -603,7 +603,7 @@ int FusionCameraDetectionComponent::InitMotionService() {
       node_->CreateReader(channel_name_local, motion_service_callback);
   // initialize motion buffer
   if (motion_buffer_ == nullptr) {
-    motion_buffer_ = std::make_shared<base::MotionBuffer>(motion_buffer_size_);
+    motion_buffer_.reset(new base::MotionBuffer(motion_buffer_size_));
   } else {
     motion_buffer_->set_capacity(motion_buffer_size_);
   }

--- a/modules/perception/onboard/component/fusion_camera_detection_component.h
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.h
@@ -48,6 +48,9 @@ namespace onboard {
 
 class FusionCameraDetectionComponent : public apollo::cyber::Component<> {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   FusionCameraDetectionComponent() : seq_num_(0) {}
   ~FusionCameraDetectionComponent();
 

--- a/modules/perception/onboard/component/lane_detection_component.cc
+++ b/modules/perception/onboard/component/lane_detection_component.cc
@@ -545,7 +545,7 @@ int LaneDetectionComponent::InitMotionService() {
       node_->CreateReader(channel_name_local, motion_service_callback);
   // initialize motion buffer
   if (mot_buffer_ == nullptr) {
-    mot_buffer_ = std::make_shared<base::MotionBuffer>(motion_buffer_size_);
+    mot_buffer_.reset(new base::MotionBuffer(motion_buffer_size_));
   } else {
     mot_buffer_->set_capacity(motion_buffer_size_);
   }

--- a/modules/perception/onboard/component/lane_detection_component.h
+++ b/modules/perception/onboard/component/lane_detection_component.h
@@ -56,6 +56,9 @@ class LaneDetectionComponent;
 typedef FunctionInfo<LaneDetectionComponent> FunInfoType;
 class LaneDetectionComponent : public apollo::cyber::Component<> {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   LaneDetectionComponent() : seq_num_(0) {}
   ~LaneDetectionComponent();
 

--- a/modules/perception/onboard/component/recognition_component.cc
+++ b/modules/perception/onboard/component/recognition_component.cc
@@ -49,8 +49,7 @@ bool RecognitionComponent::Proc(
         << message->timestamp_ << " current timestamp: "
         << apollo::common::time::Clock::NowInSeconds();
 
-  std::shared_ptr<SensorFrameMessage> out_message =
-      std::make_shared<SensorFrameMessage>();
+  std::shared_ptr<SensorFrameMessage> out_message(new SensorFrameMessage);
 
   if (InternalProc(message, out_message)) {
     writer_->Write(out_message);

--- a/modules/perception/onboard/component/trafficlights_perception_component.cc
+++ b/modules/perception/onboard/component/trafficlights_perception_component.cc
@@ -416,8 +416,7 @@ void TrafficLightsPerceptionComponent::OnReceiveImage(
 
   SyncV2XTrafficLights(&frame_);
 
-  std::shared_ptr<apollo::perception::TrafficLightDetection> out_msg =
-      std::make_shared<apollo::perception::TrafficLightDetection>();
+  std::shared_ptr<TrafficLightDetection> out_msg(new TrafficLightDetection);
   if (!TransformOutputMessage(&frame_, camera_name, &out_msg)) {
     AERROR << "transform_output_message failed, msg_time: "
            << GLOG_TIMESTAMP(msg->measurement_time());
@@ -1112,7 +1111,7 @@ void TrafficLightsPerceptionComponent::SyncV2XTrafficLights(
 }
 
 void TrafficLightsPerceptionComponent::SendSimulationMsg() {
-  auto out_msg = std::make_shared<TrafficLightDetection>();
+  TrafficLightDetection out_msg;
   writer_->Write(out_msg);
 }
 

--- a/modules/perception/radar/app/radar_obstacle_perception.cc
+++ b/modules/perception/radar/app/radar_obstacle_perception.cc
@@ -89,7 +89,7 @@ bool RadarObstaclePerception::Perceive(
          << detect_frame_ptr->objects.size();
   PERCEPTION_PERF_BLOCK_END_WITH_INDICATOR(sensor_name, "roi_filter");
 
-  base::FramePtr tracker_frame_ptr = std::make_shared<base::Frame>();
+  base::FramePtr tracker_frame_ptr(new base::Frame);
   if (!tracker_->Track(*detect_frame_ptr, options.track_options,
                        tracker_frame_ptr)) {
     AERROR << "radar track error";

--- a/modules/perception/radar/lib/detector/conti_ars_detector/conti_ars_detector.cc
+++ b/modules/perception/radar/lib/detector/conti_ars_detector/conti_ars_detector.cc
@@ -53,7 +53,7 @@ void ContiArsDetector::RawObs2Frame(
   ADEBUG << "angular_speed: " << angular_speed;
   ADEBUG << "rotation_radar: " << rotation_radar;
   for (const auto radar_obs : corrected_obstacles.contiobs()) {
-    base::ObjectPtr radar_object = std::make_shared<base::Object>();
+    base::ObjectPtr radar_object(new base::Object);
     radar_object->id = radar_obs.obstacle_id();
     radar_object->track_id = radar_obs.obstacle_id();
     Eigen::Vector4d local_loc(radar_obs.longitude_dist(),

--- a/modules/perception/radar/lib/detector/conti_ars_detector/conti_ars_detector_test.cc
+++ b/modules/perception/radar/lib/detector/conti_ars_detector/conti_ars_detector_test.cc
@@ -54,7 +54,7 @@ TEST(ContiArsDetector, detect) {
   options.car_linear_speed = Eigen::Vector3f(3, 1, 0);
   options.car_angular_speed = Eigen::Vector3f(0, 0, 0);
 
-  auto radar_frame = std::make_shared<base::Frame>();
+  auto radar_frame = std::shared_ptr<base::Frame>(new base::Frame);
   ContiArsDetector detector;
   detector.Init();
   detector.Detect(corrected_obstacles, options, radar_frame);
@@ -82,25 +82,25 @@ TEST(ContiArsDetector, detect) {
   EXPECT_LT(dist_diff, 1.0e-6);
   EXPECT_LT(vel_diff, 1.0e-6);
 
-  auto radar_frame1 = std::make_shared<base::Frame>();
+  auto radar_frame1 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_obstacle_class(CONTI_CAR);
   detector.Detect(corrected_obstacles, options, radar_frame1);
   radar_object = radar_frame1->objects.front();
   EXPECT_EQ(radar_object->type, base::ObjectType::VEHICLE);
 
-  auto radar_frame2 = std::make_shared<base::Frame>();
+  auto radar_frame2 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_obstacle_class(CONTI_PEDESTRIAN);
   detector.Detect(corrected_obstacles, options, radar_frame2);
   radar_object = radar_frame2->objects.front();
   EXPECT_EQ(radar_object->type, base::ObjectType::PEDESTRIAN);
 
-  auto radar_frame3 = std::make_shared<base::Frame>();
+  auto radar_frame3 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_obstacle_class(CONTI_MOTOCYCLE);
   detector.Detect(corrected_obstacles, options, radar_frame3);
   radar_object = radar_frame3->objects.front();
   EXPECT_EQ(radar_object->type, base::ObjectType::BICYCLE);
 
-  auto radar_frame4 = std::make_shared<base::Frame>();
+  auto radar_frame4 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_obstacle_class(CONTI_BICYCLE);
   detector.Detect(corrected_obstacles, options, radar_frame4);
   radar_object = radar_frame4->objects.front();
@@ -169,20 +169,20 @@ TEST(ContiArsDetector, detect) {
   radar_object = radar_frame14->objects.front();
   EXPECT_EQ(radar_object->motion_state, base::MotionState::UNKNOWN);
 
-  auto radar_frame15 = std::make_shared<base::Frame>();
+  auto radar_frame15 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_dynprop(
       CONTI_CROSSING_STATIONARY);
   detector.Detect(corrected_obstacles, options, radar_frame15);
   radar_object = radar_frame15->objects.front();
   EXPECT_EQ(radar_object->motion_state, base::MotionState::STATIONARY);
 
-  auto radar_frame16 = std::make_shared<base::Frame>();
+  auto radar_frame16 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_dynprop(CONTI_CROSSING_MOVING);
   detector.Detect(corrected_obstacles, options, radar_frame16);
   radar_object = radar_frame16->objects.front();
   EXPECT_EQ(radar_object->motion_state, base::MotionState::MOVING);
 
-  auto radar_frame17 = std::make_shared<base::Frame>();
+  auto radar_frame17 = std::shared_ptr<base::Frame>(new base::Frame);
   corrected_obstacles.mutable_contiobs(0)->set_dynprop(CONTI_STOPPED);
   detector.Detect(corrected_obstacles, options, radar_frame17);
   radar_object = radar_frame17->objects.front();

--- a/modules/perception/radar/lib/tracker/common/radar_track.cc
+++ b/modules/perception/radar/lib/tracker/common/radar_track.cc
@@ -40,7 +40,7 @@ RadarTrack::RadarTrack(const base::ObjectPtr& obs, const double timestamp) {
   is_dead_ = false;
 
   // Or use register class instead.
-  filter_ = std::make_shared<AdaptiveKalmanFilter>();
+  filter_.reset(new AdaptiveKalmanFilter);
   filter_->Init(*obs);
 }
 

--- a/modules/perception/radar/lib/tracker/common/radar_track_test.cc
+++ b/modules/perception/radar/lib/tracker/common/radar_track_test.cc
@@ -32,7 +32,7 @@ TEST(RadarTrackTest, radar_track_test) {
   bool use_filter = false;
   RadarTrack::SetUseFilter(use_filter);
 
-  base::ObjectPtr object = std::make_shared<base::Object>();
+  base::ObjectPtr object(new base::Object);
   object->track_id = 100;
   object->center << 10.0, 20.0, 0.0;
   object->velocity << 3.0, 4.0, 0.0;

--- a/modules/perception/radar/lib/tracker/filter/adaptive_kalman_filter.h
+++ b/modules/perception/radar/lib/tracker/filter/adaptive_kalman_filter.h
@@ -22,6 +22,9 @@ namespace perception {
 namespace radar {
 class AdaptiveKalmanFilter : public BaseFilter {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+ public:
   AdaptiveKalmanFilter();
   ~AdaptiveKalmanFilter();
   void Init(const base::Object& object) override;

--- a/modules/perception/tool/benchmark/lidar/util/object.h
+++ b/modules/perception/tool/benchmark/lidar/util/object.h
@@ -69,6 +69,8 @@ SensorType translate_string_to_sensor_type(const std::string& str);
 std::string translate_sensor_type_to_string(const SensorType& type);
 
 struct alignas(16) Object {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Object();
   // shallow copy for copy constructor and assignment
   Object(const Object& rhs);

--- a/modules/perception/tool/benchmark/lidar/util/types.h
+++ b/modules/perception/tool/benchmark/lidar/util/types.h
@@ -39,6 +39,7 @@ struct PointXYZIT {
   float z;
   uint8_t intensity;
   double timestamp;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
 typedef ::pcl::PointCloud<PointXYZIT> PointXYZITCloud;
@@ -50,6 +51,7 @@ struct PointXYZL {
   float y;
   float z;
   uint32_t label;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
 typedef ::pcl::PointCloud<PointXYZL> PointXYZLCloud;
@@ -69,6 +71,7 @@ struct PointXYZIL {
   float z = 0.f;
   float intensity = 0.f;
   uint32_t label = 0;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
 }  // namespace benchmark


### PR DESCRIPTION
This solution works for me :)
1. Firstly we need to keep @storypku 's initial try with EIGEN_MAKE_ALIGNED_OPERATOR_NEW macro, which creates special `new` operator.
2. According to https://stackoverflow.com/questions/48986131/eigen-runtime-assertion-due-to-fixed-size-members , we should NOT use `std::make_shared` to allocate such objects, because it doesn't really call `new`. Instead we should just explicitly call the `new` operator, like `std::shared_ptr<T>(new T)`

I still find lots of `make_shared` usage in perception as well as other modules. Hopefully we can fix most of this issue soon.
