### PR TITLE
[#11584] dddx_bound is set twice for PiecewiseJerkPathOptimizer

### DIFF
--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -278,7 +278,6 @@ bool PiecewiseJerkPathOptimizer::OptimizePath(
   piecewise_jerk_problem.set_dx_bounds(-FLAGS_lateral_derivative_bound_default,
                                        FLAGS_lateral_derivative_bound_default);
   piecewise_jerk_problem.set_ddx_bounds(ddl_bounds);
-  piecewise_jerk_problem.set_dddx_bound(FLAGS_lateral_jerk_bound);
 
   // Estimate lat_acc and jerk boundary from vehicle_params
   const auto& veh_param =


### PR DESCRIPTION
- fixes #11584