### PR TITLE
D-KIT: Update two configuration files of D-KIT

### DIFF
--- a/modules/calibration/data/dev_kit/cancard_params/canbus.conf
+++ b/modules/calibration/data/dev_kit/cancard_params/canbus.conf
@@ -1,0 +1,4 @@
+--flagfile=/apollo/modules/common/data/global_flagfile.txt
+--canbus_conf_file=/apollo/modules/canbus/conf/canbus_conf.pb.txt
+--noenable_chassis_detail_pub
+--noreceive_guardian

--- a/modules/calibration/data/dev_kit/cancard_params/canbus.conf
+++ b/modules/calibration/data/dev_kit/cancard_params/canbus.conf
@@ -1,4 +1,4 @@
 --flagfile=/apollo/modules/common/data/global_flagfile.txt
 --canbus_conf_file=/apollo/modules/canbus/conf/canbus_conf.pb.txt
---noenable_chassis_detail_pub
+--enable_chassis_detail_pub
 --noreceive_guardian

--- a/modules/calibration/data/dev_kit/localization_dag/dag_streaming_rtk_localization.dag
+++ b/modules/calibration/data/dev_kit/localization_dag/dag_streaming_rtk_localization.dag
@@ -1,0 +1,23 @@
+# Define all coms in DAG streaming.
+# In D-KIT, we only support MSF localization, we use this configuration to overwrite the original RTK configuration.
+
+module_config {
+    module_library : "/apollo/bazel-bin/modules/localization/msf/libmsf_localization_component.so"
+
+    components {
+      class_name : "MSFLocalizationComponent"
+      config {
+        name : "msf_localization"
+        flag_file_path : "/apollo/modules/localization/conf/localization.conf"
+        readers: [
+          {
+            channel: "/apollo/sensor/gnss/imu"
+            qos_profile: {
+              depth : 10
+            }
+            pending_queue_size: 50
+          }
+        ]
+      }
+    }
+}

--- a/modules/dreamview/conf/vehicle_data.pb.txt
+++ b/modules/dreamview/conf/vehicle_data.pb.txt
@@ -7,8 +7,8 @@ data_files {
   dest_path: "/apollo/modules/control/conf/control_conf.pb.txt"
 }
 data_files {
-  source_path: "cancard_params/canbus_conf.pb.txt"
-  dest_path: "/apollo/modules/canbus/conf/canbus_conf.pb.txt"
+  source_path: "cancard_params"
+  dest_path: "/apollo/modules/canbus/conf"
 }
 data_files {
   source_path: "dreamview_conf/data_collection_table.pb.txt"
@@ -121,6 +121,10 @@ data_files {
 data_files {
   source_path: "localization_conf"
   dest_path: "/apollo/modules/localization/conf"
+}
+data_files {
+  source_path: "localization_dag"
+  dest_path: "/apollo/modules/localization/dag"
 }
 data_files {
   source_path: "perception_dag"


### PR DESCRIPTION
1. Add canbus.conf in D-KIT configuration files set
2. D-KIT only support MSF localization mode. As some dreamview hmi mode(RTK, Vehicle calibration) use RTK mode, we need to overwrite the dag with MSF mode.