### PR TITLE
Canbus: add a new general DKIT vehicle

### DIFF
--- a/modules/canbus/proto/BUILD
+++ b/modules/canbus/proto/BUILD
@@ -16,6 +16,7 @@ proto_library(
         "ch.proto",
         "chassis.proto",
         "chassis_detail.proto",
+        "devkit.proto",
         "ge3.proto",
         "lexus.proto",
         "transit.proto",
@@ -66,6 +67,11 @@ py_proto(
 py_proto(
     name = "ch_pb2",
     src = "ch.proto",
+)
+
+py_proto(
+    name = "devkit_pb2",
+    src = "devkit.proto",
 )
 
 py_proto(

--- a/modules/canbus/proto/chassis_detail.proto
+++ b/modules/canbus/proto/chassis_detail.proto
@@ -4,12 +4,13 @@ package apollo.canbus;
 
 import "modules/common/configs/proto/vehicle_config.proto";
 import "modules/canbus/proto/chassis.proto";
+import "modules/canbus/proto/ch.proto";
+import "modules/canbus/proto/devkit.proto";
 import "modules/canbus/proto/ge3.proto";
 import "modules/canbus/proto/lexus.proto";
 import "modules/canbus/proto/transit.proto";
 import "modules/canbus/proto/wey.proto";
 import "modules/canbus/proto/zhongyun.proto";
-import "modules/canbus/proto/ch.proto";
 
 message ChassisDetail {
   enum Type {
@@ -40,6 +41,7 @@ message ChassisDetail {
   optional Wey wey = 22;
   optional Zhongyun zhongyun = 23;
   optional Ch ch = 24;
+  optional Devkit devkit = 25;
   // Reserve fields for other vehicles
   optional apollo.common.VehicleID vehicle_id = 101;
 }

--- a/modules/canbus/proto/devkit.proto
+++ b/modules/canbus/proto/devkit.proto
@@ -1,0 +1,305 @@
+syntax = "proto2";
+
+package apollo.canbus;
+
+message Wheelspeed_report_506 {
+// Report Message
+  // [] [0|65.535]
+  optional double rr = 1;
+  // [] [0|65.535]
+  optional double rl = 2;
+  // [] [0|65.535]
+  optional double fr = 3;
+  // [] [0|65.535]
+  optional double fl = 4;
+}
+
+message Ultr_sensor_1_507 {
+// Report Message
+  // [] [0|65535]
+  optional double uiuss9_tof_direct = 1;
+  // [] [0|65535]
+  optional double uiuss8_tof_direct = 2;
+  // [] [0|65535]
+  optional double uiuss11_tof_direct = 3;
+  // [] [0|65535]
+  optional double uiuss10_tof_direct = 4;
+}
+
+message Steering_command_102 {
+// Control Message
+  enum Steer_en_ctrlType {
+    STEER_EN_CTRL_DISABLE = 0;
+    STEER_EN_CTRL_ENABLE = 1;
+  }
+  // [] [0|1]
+  optional Steer_en_ctrlType steer_en_ctrl = 1;
+  // [] [-500|500]
+  optional double steer_angle_target = 2;
+  // [] [0|250]
+  optional int32 steer_angle_spd = 3;
+  // [] [0|255]
+  optional int32 checksum_112 = 4;
+}
+
+message Gear_command_103 {
+// Control Message
+  enum Gear_targetType {
+    GEAR_TARGET_INVALID = 0;
+    GEAR_TARGET_PARK = 1;
+    GEAR_TARGET_REVERSE = 2;
+    GEAR_TARGET_NEUTRAL = 3;
+    GEAR_TARGET_DRIVE = 4;
+  }
+  enum Gear_en_ctrlType {
+    GEAR_EN_CTRL_DISABLE = 0;
+    GEAR_EN_CTRL_ENABLE = 1;
+  }
+  // [] [0|4]
+  optional Gear_targetType gear_target = 1;
+  // [] [0|1]
+  optional Gear_en_ctrlType gear_en_ctrl = 2;
+  // [] [0|255]
+  optional int32 checksum_114 = 3;
+}
+
+message Throttle_command_100 {
+// Control Message
+  enum Throttle_en_ctrlType {
+    THROTTLE_EN_CTRL_DISABLE = 0;
+    THROTTLE_EN_CTRL_ENABLE = 1;
+  }
+  // [] [0|10]
+  optional double throttle_acc = 1;
+  // [] [0|255]
+  optional int32 checksum_110 = 2;
+  // [] [0|100]
+  optional double throttle_pedal_target = 3;
+  // [] [0|1]
+  optional Throttle_en_ctrlType throttle_en_ctrl = 4;
+}
+
+message Brake_command_101 {
+// Control Message
+  enum Brake_en_ctrlType {
+    BRAKE_EN_CTRL_DISABLE = 0;
+    BRAKE_EN_CTRL_ENABLE = 1;
+  }
+  // [] [0|10.23]
+  optional double brake_dec = 1;
+  // [] [0|255]
+  optional int32 checksum_111 = 2;
+  // [] [0|100]
+  optional double brake_pedal_target = 3;
+  // [] [0|1]
+  optional Brake_en_ctrlType brake_en_ctrl = 4;
+}
+
+message Park_command_104 {
+// Control Message
+  enum Park_targetType {
+    PARK_TARGET_RELEASE = 0;
+    PARK_TARGET_PARKING_TRIGGER = 1;
+  }
+  enum Park_en_ctrlType {
+    PARK_EN_CTRL_DISABLE = 0;
+    PARK_EN_CTRL_ENABLE = 1;
+  }
+  // [] [0|255]
+  optional int32 checksum_115 = 1;
+  // [] [0|1]
+  optional Park_targetType park_target = 2;
+  // [] [0|1]
+  optional Park_en_ctrlType park_en_ctrl = 3;
+}
+
+message Ultr_sensor_2_508 {
+// Report Message
+  // [] [0|65535]
+  optional double uiuss9_tof_indirect = 1;
+  // [] [0|65535]
+  optional double uiuss8_tof_indirect = 2;
+  // [] [0|65535]
+  optional double uiuss11_tof_indirect = 3;
+  // [] [0|65535]
+  optional double uiuss10_tof_indirect = 4;
+}
+
+message Ultr_sensor_3_509 {
+// Report Message
+  // [] [0|65535]
+  optional double uiuss5_tof_direct = 1;
+  // [] [0|65535]
+  optional double uiuss4_tof_direct = 2;
+  // [] [0|65535]
+  optional double uiuss3_tof_direct = 3;
+  // [] [0|65535]
+  optional double uiuss2_tof_direct = 4;
+}
+
+message Ultr_sensor_5_511 {
+// Report Message
+  // [] [0|65535]
+  optional double uiuss7_tof_direct = 1;
+  // [] [0|65535]
+  optional double uiuss6_tof_direct = 2;
+  // [] [0|65535]
+  optional double uiuss1_tof_direct = 3;
+  // [] [0|65535]
+  optional double uiuss0_tof_direct = 4;
+}
+
+message Ultr_sensor_4_510 {
+// Report Message
+  // [] [0|65535]
+  optional double uiuss5_tof_indirect = 1;
+  // [] [0|65535]
+  optional double uiuss4_tof_indirect = 2;
+  // [] [0|65535]
+  optional double uiuss3_tof_indirect = 3;
+  // [] [0|65535]
+  optional double uiuss2_tof_indirect = 4;
+}
+
+message Park_report_504 {
+// Report Message
+  enum Parking_actualType {
+    PARKING_ACTUAL_RELEASE = 0;
+    PARKING_ACTUAL_PARKING_TRIGGER = 1;
+  }
+  enum Park_fltType {
+    PARK_FLT_NO_FAULT = 0;
+    PARK_FLT_FAULT = 1;
+  }
+  // [] [0|1]
+  optional Parking_actualType parking_actual = 1;
+  // [] [0|1]
+  optional Park_fltType park_flt = 2;
+}
+
+message Vcu_report_505 {
+// Report Message
+  // [] [-10|10]
+  optional double acc = 1;
+  // [] [0|65.535]
+  optional double speed = 2;
+}
+
+message Steering_report_502 {
+// Report Message
+  enum Steer_flt2Type {
+    STEER_FLT2_NO_FAULT = 0;
+    STEER_FLT2_STEER_SYSTEM_COMUNICATION_FAULT = 1;
+  }
+  enum Steer_flt1Type {
+    STEER_FLT1_NO_FAULT = 0;
+    STEER_FLT1_STEER_SYSTEM_HARDWARE_FAULT = 1;
+  }
+  enum Steer_en_stateType {
+    STEER_EN_STATE_MANUAL = 0;
+    STEER_EN_STATE_AUTO = 1;
+    STEER_EN_STATE_TAKEOVER = 2;
+    STEER_EN_STATE_STANDBY = 3;
+  }
+  // [] [0|0]
+  optional int32 steer_angle_spd_actual = 1;
+  // Steer system communication fault [] [0|1]
+  optional Steer_flt2Type steer_flt2 = 2;
+  // Steer system hardware fault [] [0|1]
+  optional Steer_flt1Type steer_flt1 = 3;
+  // [] [0|2]
+  optional Steer_en_stateType steer_en_state = 4;
+  // [] [-500|500]
+  optional double steer_angle_actual = 5;
+}
+
+message Gear_report_503 {
+// Report Message
+  enum Gear_fltType {
+    GEAR_FLT_NO_FAULT = 0;
+    GEAR_FLT_FAULT = 1;
+  }
+  enum Gear_actualType {
+    GEAR_ACTUAL_INVALID = 0;
+    GEAR_ACTUAL_PARK = 1;
+    GEAR_ACTUAL_REVERSE = 2;
+    GEAR_ACTUAL_NEUTRAL = 3;
+    GEAR_ACTUAL_DRIVE = 4;
+  }
+  // [] [0|1]
+  optional Gear_fltType gear_flt = 1;
+  // [] [0|4]
+  optional Gear_actualType gear_actual = 2;
+}
+
+message Throttle_report_500 {
+// Report Message
+  enum Throttle_flt2Type {
+    THROTTLE_FLT2_NO_FAULT = 0;
+    THROTTLE_FLT2_DRIVE_SYSTEM_COMUNICATION_FAULT = 1;
+  }
+  enum Throttle_flt1Type {
+    THROTTLE_FLT1_NO_FAULT = 0;
+    THROTTLE_FLT1_DRIVE_SYSTEM_HARDWARE_FAULT = 1;
+  }
+  enum Throttle_en_stateType {
+    THROTTLE_EN_STATE_MANUAL = 0;
+    THROTTLE_EN_STATE_AUTO = 1;
+    THROTTLE_EN_STATE_TAKEOVER = 2;
+    THROTTLE_EN_STATE_STANDBY = 3;
+  }
+  // [] [0|100]
+  optional double throttle_pedal_actual = 1;
+  // Drive system communication fault [] [0|1]
+  optional Throttle_flt2Type throttle_flt2 = 2;
+  // Drive system hardware fault [] [0|1]
+  optional Throttle_flt1Type throttle_flt1 = 3;
+  // [] [0|2]
+  optional Throttle_en_stateType throttle_en_state = 4;
+}
+
+message Brake_report_501 {
+// Report Message
+  enum Brake_flt2Type {
+    BRAKE_FLT2_NO_FAULT = 0;
+    BRAKE_FLT2_BRAKE_SYSTEM_COMUNICATION_FAULT = 1;
+  }
+  enum Brake_flt1Type {
+    BRAKE_FLT1_NO_FAULT = 0;
+    BRAKE_FLT1_BRAKE_SYSTEM_HARDWARE_FAULT = 1;
+  }
+  enum Brake_en_stateType {
+    BRAKE_EN_STATE_MANUAL = 0;
+    BRAKE_EN_STATE_AUTO = 1;
+    BRAKE_EN_STATE_TAKEOVER = 2;
+    BRAKE_EN_STATE_STANDBY = 3;
+  }
+  // [] [0|100]
+  optional double brake_pedal_actual = 1;
+  // Brake system communication fault [] [0|1]
+  optional Brake_flt2Type brake_flt2 = 2;
+  // Brake system hardware fault [] [0|1]
+  optional Brake_flt1Type brake_flt1 = 3;
+  // [] [0|2]
+  optional Brake_en_stateType brake_en_state = 4;
+}
+
+message Devkit {
+  optional Wheelspeed_report_506 wheelspeed_report_506 = 1; // report message
+  optional Ultr_sensor_1_507 ultr_sensor_1_507 = 2; // report message
+  optional Steering_command_102 steering_command_102 = 3; // control message
+  optional Gear_command_103 gear_command_103 = 4; // control message
+  optional Throttle_command_100 throttle_command_100 = 5; // control message
+  optional Brake_command_101 brake_command_101 = 6; // control message
+  optional Park_command_104 park_command_104 = 7; // control message
+  optional Ultr_sensor_2_508 ultr_sensor_2_508 = 8; // report message
+  optional Ultr_sensor_3_509 ultr_sensor_3_509 = 9; // report message
+  optional Ultr_sensor_5_511 ultr_sensor_5_511 = 10; // report message
+  optional Ultr_sensor_4_510 ultr_sensor_4_510 = 11; // report message
+  optional Park_report_504 park_report_504 = 12; // report message
+  optional Vcu_report_505 vcu_report_505 = 13; // report message
+  optional Steering_report_502 steering_report_502 = 14; // report message
+  optional Gear_report_503 gear_report_503 = 15; // report message
+  optional Throttle_report_500 throttle_report_500 = 16; // report message
+  optional Brake_report_501 brake_report_501 = 17; // report message
+}

--- a/modules/canbus/testdata/conf/devkit_canbus_conf_test.pb.txt
+++ b/modules/canbus/testdata/conf/devkit_canbus_conf_test.pb.txt
@@ -1,0 +1,13 @@
+vehicle_parameter {
+  brand: DKIT
+  max_enable_fail_attempt: 5
+  driving_mode: COMPLETE_AUTO_DRIVE
+}
+
+can_card_parameter {
+  brand:ESD_CAN
+  type: PCI_CARD
+  channel_id: CHANNEL_ID_ZERO
+}
+
+enable_debug_mode: false

--- a/modules/canbus/vehicle/BUILD
+++ b/modules/canbus/vehicle/BUILD
@@ -39,6 +39,7 @@ cc_library(
     copts = ["-DMODULE_NAME=\\\"canbus\\\""],
     deps = [
         "//modules/canbus/vehicle/ch:ch_vehicle_factory",
+        "//modules/canbus/vehicle/devkit:devkit_vehicle_factory",
         "//modules/canbus/vehicle/ge3:ge3_vehicle_factory",
         "//modules/canbus/vehicle/gem:gem_vehicle_factory",
         "//modules/canbus/vehicle/lexus:lexus_vehicle_factory",

--- a/modules/canbus/vehicle/devkit/BUILD
+++ b/modules/canbus/vehicle/devkit/BUILD
@@ -1,0 +1,86 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "devkit_vehicle_factory",
+    srcs = [
+        "devkit_vehicle_factory.cc",
+    ],
+    hdrs = [
+        "devkit_vehicle_factory.h",
+    ],
+    deps = [
+        ":devkit_controller",
+        ":devkit_message_manager",
+        "//modules/canbus/vehicle:abstract_vehicle_factory",
+    ],
+)
+
+cc_test(
+    name = "devkit_vehicle_factory_test",
+    size = "small",
+    srcs = ["devkit_vehicle_factory_test.cc"],
+    deps = [
+        ":devkit_vehicle_factory",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "devkit_message_manager",
+    srcs = [
+        "devkit_message_manager.cc",
+    ],
+    hdrs = [
+        "devkit_message_manager.h",
+    ],
+    deps = [
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+    ],
+)
+
+cc_test(
+    name = "devkit_message_manager_test",
+    size = "small",
+    srcs = ["devkit_message_manager_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit:devkit_message_manager",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "devkit_controller",
+    srcs = [
+        "devkit_controller.cc",
+    ],
+    hdrs = [
+        "devkit_controller.h",
+    ],
+    deps = [
+        ":devkit_message_manager",
+        "//modules/drivers/canbus/can_comm:can_sender",
+        "//modules/drivers/canbus/common:canbus_common",
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/canbus/vehicle:vehicle_controller_base",
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+    ],
+)
+
+cc_test(
+    name = "devkit_controller_test",
+    size = "small",
+    srcs = ["devkit_controller_test.cc"],
+    data = ["//modules/canbus:canbus_testdata"],
+    deps = [
+        ":devkit_controller",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cpplint()

--- a/modules/canbus/vehicle/devkit/devkit_controller.cc
+++ b/modules/canbus/vehicle/devkit/devkit_controller.cc
@@ -1,0 +1,664 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_controller.h"
+
+#include "cyber/common/log.h"
+#include "modules/canbus/vehicle/devkit/devkit_message_manager.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/common/proto/vehicle_signal.pb.h"
+#include "modules/common/time/time.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::common::ErrorCode;
+using ::apollo::control::ControlCommand;
+using ::apollo::drivers::canbus::ProtocolData;
+
+namespace {
+
+const int32_t kMaxFailAttempt = 10;
+const int32_t CHECK_RESPONSE_STEER_UNIT_FLAG = 1;
+const int32_t CHECK_RESPONSE_SPEED_UNIT_FLAG = 2;
+}  // namespace
+
+ErrorCode DevkitController::Init(
+    const VehicleParameter& params,
+    CanSender<::apollo::canbus::ChassisDetail>* const can_sender,
+    MessageManager<::apollo::canbus::ChassisDetail>* const message_manager) {
+  if (is_initialized_) {
+    AINFO << "DevkitController has already been initiated.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+  vehicle_params_.CopyFrom(
+      common::VehicleConfigHelper::Instance()->GetConfig().vehicle_param());
+
+  params_.CopyFrom(params);
+  if (!params_.has_driving_mode()) {
+    AERROR << "Vehicle conf pb not set driving_mode.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  if (can_sender == nullptr) {
+    return ErrorCode::CANBUS_ERROR;
+  }
+  can_sender_ = can_sender;
+
+  if (message_manager == nullptr) {
+    AERROR << "protocol manager is null.";
+    return ErrorCode::CANBUS_ERROR;
+  }
+  message_manager_ = message_manager;
+
+  // sender part
+  brake_command_101_ = dynamic_cast<Brakecommand101*>(
+      message_manager_->GetMutableProtocolDataById(Brakecommand101::ID));
+  if (brake_command_101_ == nullptr) {
+    AERROR << "Brakecommand101 does not exist in the DevkitMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  gear_command_103_ = dynamic_cast<Gearcommand103*>(
+      message_manager_->GetMutableProtocolDataById(Gearcommand103::ID));
+  if (gear_command_103_ == nullptr) {
+    AERROR << "Gearcommand103 does not exist in the DevkitMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  park_command_104_ = dynamic_cast<Parkcommand104*>(
+      message_manager_->GetMutableProtocolDataById(Parkcommand104::ID));
+  if (park_command_104_ == nullptr) {
+    AERROR << "Parkcommand104 does not exist in the DevkitMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  steering_command_102_ = dynamic_cast<Steeringcommand102*>(
+      message_manager_->GetMutableProtocolDataById(Steeringcommand102::ID));
+  if (steering_command_102_ == nullptr) {
+    AERROR << "Steeringcommand102 does not exist in the DevkitMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  throttle_command_100_ = dynamic_cast<Throttlecommand100*>(
+      message_manager_->GetMutableProtocolDataById(Throttlecommand100::ID));
+  if (throttle_command_100_ == nullptr) {
+    AERROR << "Throttlecommand100 does not exist in the DevkitMessageManager!";
+    return ErrorCode::CANBUS_ERROR;
+  }
+
+  can_sender_->AddMessage(Brakecommand101::ID, brake_command_101_, false);
+  can_sender_->AddMessage(Gearcommand103::ID, gear_command_103_, false);
+  can_sender_->AddMessage(Parkcommand104::ID, park_command_104_, false);
+  can_sender_->AddMessage(Steeringcommand102::ID, steering_command_102_, false);
+  can_sender_->AddMessage(Throttlecommand100::ID, throttle_command_100_, false);
+
+  // need sleep to ensure all messages received
+  AINFO << "DevkitController is initialized.";
+
+  is_initialized_ = true;
+  return ErrorCode::OK;
+}
+
+DevkitController::~DevkitController() {}
+
+bool DevkitController::Start() {
+  if (!is_initialized_) {
+    AERROR << "DevkitController has NOT been initiated.";
+    return false;
+  }
+  const auto& update_func = [this] { SecurityDogThreadFunc(); };
+  thread_.reset(new std::thread(update_func));
+
+  return true;
+}
+
+void DevkitController::Stop() {
+  if (!is_initialized_) {
+    AERROR << "DevkitController stops or starts improperly!";
+    return;
+  }
+
+  if (thread_ != nullptr && thread_->joinable()) {
+    thread_->join();
+    thread_.reset();
+    AINFO << "DevkitController stopped.";
+  }
+}
+
+Chassis DevkitController::chassis() {
+  chassis_.Clear();
+
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+
+  // 21, 22, previously 1, 2
+  if (driving_mode() == Chassis::EMERGENCY_MODE) {
+    set_chassis_error_code(Chassis::NO_ERROR);
+  }
+
+  chassis_.set_driving_mode(driving_mode());
+  chassis_.set_error_code(chassis_error_code());
+
+  // 3
+  chassis_.set_engine_started(true);
+  // 4 engine rpm ch has no engine rpm
+  // chassis_.set_engine_rpm(0);
+  // 5 wheel spd
+  if (chassis_detail.devkit().has_wheelspeed_report_506()) {
+    if (chassis_detail.devkit().wheelspeed_report_506().has_rr()) {
+      chassis_.mutable_wheel_speed()->set_wheel_spd_rr(
+          chassis_detail.devkit().wheelspeed_report_506().rr());
+    }
+    if (chassis_detail.devkit().wheelspeed_report_506().has_rl()) {
+      chassis_.mutable_wheel_speed()->set_wheel_spd_rl(
+          chassis_detail.devkit().wheelspeed_report_506().rl());
+    }
+    if (chassis_detail.devkit().wheelspeed_report_506().has_fr()) {
+      chassis_.mutable_wheel_speed()->set_wheel_spd_fr(
+          chassis_detail.devkit().wheelspeed_report_506().fr());
+    }
+    if (chassis_detail.devkit().wheelspeed_report_506().has_fl()) {
+      chassis_.mutable_wheel_speed()->set_wheel_spd_fl(
+          chassis_detail.devkit().wheelspeed_report_506().fl());
+    }
+  }
+  // 6 speed_mps
+  if (chassis_detail.devkit().has_vcu_report_505() &&
+      chassis_detail.devkit().vcu_report_505().has_speed()) {
+    chassis_.set_speed_mps(
+        static_cast<float>(chassis_detail.devkit().vcu_report_505().speed()));
+  } else {
+    chassis_.set_speed_mps(0);
+  }
+  // 7 no odometer
+  // chassis_.set_odometer_m(0);
+  // 8 no fuel. do not set;
+  // chassis_.set_fuel_range_m(0);
+  // 9 throttle
+  if (chassis_detail.devkit().has_throttle_report_500() &&
+      chassis_detail.devkit()
+          .throttle_report_500()
+          .has_throttle_pedal_actual()) {
+    chassis_.set_throttle_percentage(static_cast<float>(
+        chassis_detail.devkit().throttle_report_500().throttle_pedal_actual()));
+  } else {
+    chassis_.set_throttle_percentage(0);
+  }
+  // 10 brake
+  if (chassis_detail.devkit().has_brake_report_501() &&
+      chassis_detail.devkit().brake_report_501().has_brake_pedal_actual()) {
+    chassis_.set_brake_percentage(static_cast<float>(
+        chassis_detail.devkit().brake_report_501().brake_pedal_actual()));
+  } else {
+    chassis_.set_brake_percentage(0);
+  }
+  // 23, previously 11 gear
+  if (chassis_detail.devkit().has_gear_report_503() &&
+      chassis_detail.devkit().gear_report_503().has_gear_actual()) {
+    Chassis::GearPosition gear_pos = Chassis::GEAR_INVALID;
+
+    if (chassis_detail.devkit().gear_report_503().gear_actual() ==
+        Gear_report_503::GEAR_ACTUAL_INVALID) {
+      gear_pos = Chassis::GEAR_INVALID;
+    }
+    if (chassis_detail.devkit().gear_report_503().gear_actual() ==
+        Gear_report_503::GEAR_ACTUAL_NEUTRAL) {
+      gear_pos = Chassis::GEAR_NEUTRAL;
+    }
+    if (chassis_detail.devkit().gear_report_503().gear_actual() ==
+        Gear_report_503::GEAR_ACTUAL_REVERSE) {
+      gear_pos = Chassis::GEAR_REVERSE;
+    }
+    if (chassis_detail.devkit().gear_report_503().gear_actual() ==
+        Gear_report_503::GEAR_ACTUAL_DRIVE) {
+      gear_pos = Chassis::GEAR_DRIVE;
+    }
+    if (chassis_detail.devkit().gear_report_503().gear_actual() ==
+        Gear_report_503::GEAR_ACTUAL_PARK) {
+      gear_pos = Chassis::GEAR_PARKING;
+    }
+    chassis_.set_gear_location(gear_pos);
+  } else {
+    chassis_.set_gear_location(Chassis::GEAR_NONE);
+  }
+  // 12 steering
+  if (chassis_detail.devkit().has_steering_report_502() &&
+      chassis_detail.devkit().steering_report_502().has_steer_angle_actual()) {
+    chassis_.set_steering_percentage(static_cast<float>(
+        chassis_detail.devkit().steering_report_502().steer_angle_actual() *
+        100.0 / vehicle_params_.max_steer_angle() * M_PI / 180));
+  } else {
+    chassis_.set_steering_percentage(0);
+  }
+  // 13 parking brake
+  if (chassis_detail.devkit().has_park_report_504() &&
+      chassis_detail.devkit().park_report_504().has_parking_actual()) {
+    if (chassis_detail.devkit().park_report_504().parking_actual() ==
+        Park_report_504::PARKING_ACTUAL_PARKING_TRIGGER) {
+      chassis_.set_parking_brake(true);
+    } else {
+      chassis_.set_parking_brake(false);
+    }
+  } else {
+    chassis_.set_parking_brake(false);
+  }
+
+  return chassis_;
+}
+
+void DevkitController::Emergency() {
+  set_driving_mode(Chassis::EMERGENCY_MODE);
+  ResetProtocol();
+}
+
+ErrorCode DevkitController::EnableAutoMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE) {
+    AINFO << "already in COMPLETE_AUTO_DRIVE mode";
+    return ErrorCode::OK;
+  }
+  // set enable
+  brake_command_101_->set_brake_en_ctrl(
+      Brake_command_101::BRAKE_EN_CTRL_ENABLE);
+  throttle_command_100_->set_throttle_en_ctrl(
+      Throttle_command_100::THROTTLE_EN_CTRL_ENABLE);
+  steering_command_102_->set_steer_en_ctrl(
+      Steering_command_102::STEER_EN_CTRL_ENABLE);
+  gear_command_103_->set_gear_en_ctrl(Gear_command_103::GEAR_EN_CTRL_ENABLE);
+  park_command_104_->set_park_en_ctrl(Park_command_104::PARK_EN_CTRL_ENABLE);
+
+  can_sender_->Update();
+  const int32_t flag =
+      CHECK_RESPONSE_STEER_UNIT_FLAG | CHECK_RESPONSE_SPEED_UNIT_FLAG;
+  if (!CheckResponse(flag, true)) {
+    AERROR << "Failed to switch to COMPLETE_AUTO_DRIVE mode.";
+    Emergency();
+    set_chassis_error_code(Chassis::CHASSIS_ERROR);
+    return ErrorCode::CANBUS_ERROR;
+  }
+  set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  AINFO << "Switch to COMPLETE_AUTO_DRIVE mode ok.";
+  return ErrorCode::OK;
+}
+
+ErrorCode DevkitController::DisableAutoMode() {
+  ResetProtocol();
+  can_sender_->Update();
+  set_driving_mode(Chassis::COMPLETE_MANUAL);
+  set_chassis_error_code(Chassis::NO_ERROR);
+  AINFO << "Switch to COMPLETE_MANUAL ok.";
+  return ErrorCode::OK;
+}
+
+ErrorCode DevkitController::EnableSteeringOnlyMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_STEER_ONLY) {
+    set_driving_mode(Chassis::AUTO_STEER_ONLY);
+    AINFO << "Already in AUTO_STEER_ONLY mode.";
+    return ErrorCode::OK;
+  }
+  AFATAL << "SpeedOnlyMode is not supported in devkit!";
+  return ErrorCode::CANBUS_ERROR;
+}
+
+ErrorCode DevkitController::EnableSpeedOnlyMode() {
+  if (driving_mode() == Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() == Chassis::AUTO_SPEED_ONLY) {
+    set_driving_mode(Chassis::AUTO_SPEED_ONLY);
+    AINFO << "Already in AUTO_SPEED_ONLY mode";
+    return ErrorCode::OK;
+  }
+  AFATAL << "SpeedOnlyMode is not supported in devkit!";
+  return ErrorCode::CANBUS_ERROR;
+}
+
+// NEUTRAL, REVERSE, DRIVE
+void DevkitController::Gear(Chassis::GearPosition gear_position) {
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE &&
+      driving_mode() != Chassis::AUTO_SPEED_ONLY) {
+    AINFO << "This drive mode no need to set gear.";
+    return;
+  }
+  switch (gear_position) {
+    case Chassis::GEAR_NEUTRAL: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_NEUTRAL);
+      break;
+    }
+    case Chassis::GEAR_REVERSE: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_REVERSE);
+      break;
+    }
+    case Chassis::GEAR_DRIVE: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_DRIVE);
+      break;
+    }
+    case Chassis::GEAR_PARKING: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_PARK);
+      break;
+    }
+    case Chassis::GEAR_INVALID: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_NEUTRAL);
+      break;
+    }
+    default: {
+      gear_command_103_->set_gear_target(Gear_command_103::GEAR_TARGET_NEUTRAL);
+      break;
+    }
+  }
+}
+
+// brake with pedal
+// pedal:0.00~99.99, unit:%
+void DevkitController::Brake(double pedal) {
+  // double real_value = params_.max_acc() * acceleration / 100;
+  // TODO(All) :  Update brake value based on mode
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE &&
+      driving_mode() != Chassis::AUTO_SPEED_ONLY) {
+    AINFO << "The current drive mode does not need to set brake pedal.";
+    return;
+  }
+  brake_command_101_->set_brake_pedal_target(pedal);
+}
+
+// drive with pedal
+// pedal:0.0~99.9 unit:%
+void DevkitController::Throttle(double pedal) {
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE &&
+      driving_mode() != Chassis::AUTO_SPEED_ONLY) {
+    AINFO << "The current drive mode does not need to set throttle pedal.";
+    return;
+  }
+  throttle_command_100_->set_throttle_pedal_target(pedal);
+}
+
+// confirm the car is driven by acceleration command instead of throttle/brake
+// pedal drive with acceleration/deceleration acc:-7.0 ~ 5.0, unit:m/s^2
+void DevkitController::Acceleration(double acc) {
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE ||
+      driving_mode() != Chassis::AUTO_SPEED_ONLY) {
+    AINFO << "The current drive mode does not need to set acceleration.";
+    return;
+  }
+  // None
+}
+
+// devkit default, -30 ~ 00, left:+, right:-
+// need to be compatible with control module, so reverse
+// steering with default angle speed, 25-250 (default:250)
+// angle:-99.99~0.00~99.99, unit:, left:-, right:+
+void DevkitController::Steer(double angle) {
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE &&
+      driving_mode() != Chassis::AUTO_STEER_ONLY) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  const double real_angle =
+      vehicle_params_.max_steer_angle() / M_PI * 180 * angle / 100.0;
+  steering_command_102_->set_steer_angle_target(real_angle)
+      ->set_steer_angle_spd(250);
+}
+
+// steering with new angle speed
+// angle:-99.99~0.00~99.99, unit:, left:-, right:+
+// angle_spd:25~250, unit:deg/s
+void DevkitController::Steer(double angle, double angle_spd) {
+  if (driving_mode() != Chassis::COMPLETE_AUTO_DRIVE &&
+      driving_mode() != Chassis::AUTO_STEER_ONLY) {
+    AINFO << "The current driving mode does not need to set steer.";
+    return;
+  }
+  const double real_angle =
+      vehicle_params_.max_steer_angle() / M_PI * 180 * angle / 100.0;
+  steering_command_102_->set_steer_angle_target(real_angle)
+      ->set_steer_angle_spd(250);
+}
+
+void DevkitController::SetEpbBreak(const ControlCommand& command) {
+  if (command.parking_brake()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void DevkitController::SetBeam(const ControlCommand& command) {
+  if (command.signal().high_beam()) {
+    // None
+  } else if (command.signal().low_beam()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void DevkitController::SetHorn(const ControlCommand& command) {
+  if (command.signal().horn()) {
+    // None
+  } else {
+    // None
+  }
+}
+
+void DevkitController::SetTurningSignal(const ControlCommand& command) {
+  // Set Turn Signal do not support on devkit
+}
+
+void DevkitController::ResetProtocol() {
+  message_manager_->ResetSendMessages();
+}
+
+bool DevkitController::CheckChassisError() {
+  ChassisDetail chassis_detail;
+  message_manager_->GetSensorData(&chassis_detail);
+  if (!chassis_detail.has_devkit()) {
+    AERROR_EVERY(100) << "ChassisDetail has no devkit vehicle info."
+                      << chassis_detail.DebugString();
+    return false;
+  }
+
+  Devkit devkit = chassis_detail.devkit();
+
+  // steer fault
+  if (devkit.has_steering_report_502()) {
+    if (Steering_report_502::STEER_FLT1_STEER_SYSTEM_HARDWARE_FAULT ==
+        devkit.steering_report_502().steer_flt1()) {
+      return true;
+    }
+    if (Steering_report_502::STEER_FLT2_STEER_SYSTEM_COMUNICATION_FAULT ==
+        devkit.steering_report_502().steer_flt2()) {
+      return true;
+    }
+  }
+  // drive fault
+  if (devkit.has_throttle_report_500()) {
+    if (Throttle_report_500::THROTTLE_FLT1_DRIVE_SYSTEM_HARDWARE_FAULT ==
+        devkit.throttle_report_500().throttle_flt1()) {
+      return true;
+    }
+    if (Throttle_report_500::THROTTLE_FLT2_DRIVE_SYSTEM_COMUNICATION_FAULT ==
+        devkit.throttle_report_500().throttle_flt2()) {
+      return true;
+    }
+  }
+  // brake fault
+  if (devkit.has_brake_report_501()) {
+    if (Brake_report_501::BRAKE_FLT1_BRAKE_SYSTEM_HARDWARE_FAULT ==
+        devkit.brake_report_501().brake_flt1()) {
+      return true;
+    }
+    if (Brake_report_501::BRAKE_FLT2_BRAKE_SYSTEM_COMUNICATION_FAULT ==
+        devkit.brake_report_501().brake_flt2()) {
+      return true;
+    }
+  }
+  // gear fault
+  if (devkit.has_gear_report_503()) {
+    if (Gear_report_503::GEAR_FLT_FAULT ==
+        devkit.gear_report_503().gear_flt()) {
+      return true;
+    }
+  }
+  // park fault
+  if (devkit.has_park_report_504()) {
+    if (Park_report_504::PARK_FLT_FAULT ==
+        devkit.park_report_504().park_flt()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void DevkitController::SecurityDogThreadFunc() {
+  int32_t vertical_ctrl_fail = 0;
+  int32_t horizontal_ctrl_fail = 0;
+
+  if (can_sender_ == nullptr) {
+    AERROR << "Failed to run SecurityDogThreadFunc() because can_sender_ is "
+              "nullptr.";
+    return;
+  }
+  while (!can_sender_->IsRunning()) {
+    std::this_thread::yield();
+  }
+
+  std::chrono::duration<double, std::micro> default_period{50000};
+  int64_t start = 0;
+  int64_t end = 0;
+  while (can_sender_->IsRunning()) {
+    start = absl::ToUnixMicros(::apollo::common::time::Clock::Now());
+    const Chassis::DrivingMode mode = driving_mode();
+    bool emergency_mode = false;
+
+    // 1. horizontal control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_STEER_ONLY) &&
+        CheckResponse(CHECK_RESPONSE_STEER_UNIT_FLAG, false) == false) {
+      ++horizontal_ctrl_fail;
+      if (horizontal_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      horizontal_ctrl_fail = 0;
+    }
+
+    // 2. vertical control check
+    if ((mode == Chassis::COMPLETE_AUTO_DRIVE ||
+         mode == Chassis::AUTO_SPEED_ONLY) &&
+        !CheckResponse(CHECK_RESPONSE_SPEED_UNIT_FLAG, false)) {
+      ++vertical_ctrl_fail;
+      if (vertical_ctrl_fail >= kMaxFailAttempt) {
+        emergency_mode = true;
+        set_chassis_error_code(Chassis::MANUAL_INTERVENTION);
+      }
+    } else {
+      vertical_ctrl_fail = 0;
+    }
+    if (CheckChassisError()) {
+      set_chassis_error_code(Chassis::CHASSIS_ERROR);
+      emergency_mode = true;
+    }
+
+    if (emergency_mode && mode != Chassis::EMERGENCY_MODE) {
+      set_driving_mode(Chassis::EMERGENCY_MODE);
+      message_manager_->ResetSendMessages();
+    }
+    end = absl::ToUnixMicros(::apollo::common::time::Clock::Now());
+    std::chrono::duration<double, std::micro> elapsed{end - start};
+    if (elapsed < default_period) {
+      std::this_thread::sleep_for(default_period - elapsed);
+    } else {
+      AERROR << "Too much time consumption in DevkitController looping process:"
+             << elapsed.count();
+    }
+  }
+}
+
+bool DevkitController::CheckResponse(const int32_t flags, bool need_wait) {
+  int32_t retry_num = 20;
+  ChassisDetail chassis_detail;
+  bool is_eps_online = false;
+  bool is_vcu_online = false;
+  bool is_esp_online = false;
+
+  do {
+    if (message_manager_->GetSensorData(&chassis_detail) != ErrorCode::OK) {
+      AERROR_EVERY(100) << "get chassis detail failed.";
+      return false;
+    }
+    bool check_ok = true;
+    if (flags & CHECK_RESPONSE_STEER_UNIT_FLAG) {
+      is_eps_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_eps_online() &&
+                      chassis_detail.check_response().is_eps_online();
+      check_ok = check_ok && is_eps_online;
+    }
+
+    if (flags & CHECK_RESPONSE_SPEED_UNIT_FLAG) {
+      is_vcu_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_vcu_online() &&
+                      chassis_detail.check_response().is_vcu_online();
+      is_esp_online = chassis_detail.has_check_response() &&
+                      chassis_detail.check_response().has_is_esp_online() &&
+                      chassis_detail.check_response().is_esp_online();
+      check_ok = check_ok && is_vcu_online && is_esp_online;
+    }
+    if (check_ok) {
+      return true;
+    } else {
+      AINFO << "Need to check response again.";
+    }
+    if (need_wait) {
+      --retry_num;
+      std::this_thread::sleep_for(
+          std::chrono::duration<double, std::milli>(20));
+    }
+  } while (need_wait && retry_num);
+
+  AINFO << "check_response fail: is_eps_online:" << is_eps_online
+        << ", is_vcu_online:" << is_vcu_online
+        << ", is_esp_online:" << is_esp_online;
+
+  return false;
+}
+
+void DevkitController::set_chassis_error_mask(const int32_t mask) {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  chassis_error_mask_ = mask;
+}
+
+int32_t DevkitController::chassis_error_mask() {
+  std::lock_guard<std::mutex> lock(chassis_mask_mutex_);
+  return chassis_error_mask_;
+}
+
+Chassis::ErrorCode DevkitController::chassis_error_code() {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  return chassis_error_code_;
+}
+
+void DevkitController::set_chassis_error_code(
+    const Chassis::ErrorCode& error_code) {
+  std::lock_guard<std::mutex> lock(chassis_error_code_mutex_);
+  chassis_error_code_ = error_code;
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_controller.h
+++ b/modules/canbus/vehicle/devkit/devkit_controller.h
@@ -1,0 +1,142 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <thread>
+
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/canbus/vehicle/devkit/protocol/brake_command_101.h"
+#include "modules/canbus/vehicle/devkit/protocol/gear_command_103.h"
+#include "modules/canbus/vehicle/devkit/protocol/park_command_104.h"
+#include "modules/canbus/vehicle/devkit/protocol/steering_command_102.h"
+#include "modules/canbus/vehicle/devkit/protocol/throttle_command_100.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/common/proto/error_code.pb.h"
+#include "modules/control/proto/control_cmd.pb.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class DevkitController final : public VehicleController {
+ public:
+  DevkitController() {}
+
+  virtual ~DevkitController();
+
+  ::apollo::common::ErrorCode Init(
+      const VehicleParameter& params,
+      CanSender<::apollo::canbus::ChassisDetail>* const can_sender,
+      MessageManager<::apollo::canbus::ChassisDetail>* const message_manager)
+      override;
+
+  bool Start() override;
+
+  /**
+   * @brief stop the vehicle controller.
+   */
+  void Stop() override;
+
+  /**
+   * @brief calculate and return the chassis.
+   * @returns a copy of chassis. Use copy here to avoid multi-thread issues.
+   */
+  Chassis chassis() override;
+
+  /**
+   * for test
+   */
+  FRIEND_TEST(DevkitControllerTest, SetDrivingMode);
+  FRIEND_TEST(DevkitControllerTest, Status);
+  FRIEND_TEST(DevkitControllerTest, UpdateDrivingMode);
+
+ private:
+  // main logical function for operation the car enter or exit the auto driving
+  void Emergency() override;
+  ::apollo::common::ErrorCode EnableAutoMode() override;
+  ::apollo::common::ErrorCode DisableAutoMode() override;
+  ::apollo::common::ErrorCode EnableSteeringOnlyMode() override;
+  ::apollo::common::ErrorCode EnableSpeedOnlyMode() override;
+
+  // NEUTRAL, REVERSE, DRIVE
+  void Gear(Chassis::GearPosition state) override;
+
+  // brake with new acceleration
+  // acceleration:0.00~99.99, unit:
+  // acceleration_spd: 60 ~ 100, suggest: 90
+  void Brake(double acceleration) override;
+
+  // drive with old acceleration
+  // gas:0.00~99.99 unit:
+  void Throttle(double throttle) override;
+
+  // drive with acceleration/deceleration
+  // acc:-7.0~5.0 unit:m/s^2
+  void Acceleration(double acc) override;
+
+  // steering with old angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  void Steer(double angle) override;
+
+  // steering with new angle speed
+  // angle:-99.99~0.00~99.99, unit:, left:+, right:-
+  // angle_spd:0.00~99.99, unit:deg/s
+  void Steer(double angle, double angle_spd) override;
+
+  // set Electrical Park Brake
+  void SetEpbBreak(const ::apollo::control::ControlCommand& command) override;
+  void SetBeam(const ::apollo::control::ControlCommand& command) override;
+  void SetHorn(const ::apollo::control::ControlCommand& command) override;
+  void SetTurningSignal(
+      const ::apollo::control::ControlCommand& command) override;
+
+  void ResetProtocol();
+  bool CheckChassisError();
+
+ private:
+  void SecurityDogThreadFunc();
+  virtual bool CheckResponse(const int32_t flags, bool need_wait);
+  void set_chassis_error_mask(const int32_t mask);
+  int32_t chassis_error_mask();
+  Chassis::ErrorCode chassis_error_code();
+  void set_chassis_error_code(const Chassis::ErrorCode& error_code);
+
+ private:
+  // control protocol
+  Brakecommand101* brake_command_101_ = nullptr;
+  Gearcommand103* gear_command_103_ = nullptr;
+  Parkcommand104* park_command_104_ = nullptr;
+  Steeringcommand102* steering_command_102_ = nullptr;
+  Throttlecommand100* throttle_command_100_ = nullptr;
+
+  Chassis chassis_;
+  std::unique_ptr<std::thread> thread_;
+  bool is_chassis_error_ = false;
+
+  std::mutex chassis_error_code_mutex_;
+  Chassis::ErrorCode chassis_error_code_ = Chassis::NO_ERROR;
+
+  std::mutex chassis_mask_mutex_;
+  int32_t chassis_error_mask_ = 0;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_controller_test.cc
+++ b/modules/canbus/vehicle/devkit/devkit_controller_test.cc
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_controller.h"
+
+#include "cyber/common/file.h"
+#include "gtest/gtest.h"
+#include "modules/canbus/proto/canbus_conf.pb.h"
+#include "modules/canbus/proto/chassis.pb.h"
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/canbus/vehicle/devkit/devkit_message_manager.h"
+#include "modules/common/proto/vehicle_signal.pb.h"
+#include "modules/control/proto/control_cmd.pb.h"
+#include "modules/drivers/canbus/can_comm/can_sender.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+using apollo::common::ErrorCode;
+using apollo::common::VehicleSignal;
+using apollo::control::ControlCommand;
+
+class DevkitControllerTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    std::string canbus_conf_file =
+        "modules/canbus/testdata/conf/devkit_canbus_conf_test.pb.txt";
+    cyber::common::GetProtoFromFile(canbus_conf_file, &canbus_conf_);
+    params_ = canbus_conf_.vehicle_parameter();
+    control_cmd_.set_throttle(20.0);
+    control_cmd_.set_brake(0.0);
+    control_cmd_.set_steering_target(10.0);
+    control_cmd_.set_steering_rate(100.0);
+  }
+
+ protected:
+  DevkitController controller_;
+  ControlCommand control_cmd_;
+  VehicleSignal vehicle_signal_;
+  CanSender<::apollo::canbus::ChassisDetail> sender_;
+  DevkitMessageManager msg_manager_;
+  CanbusConf canbus_conf_;
+  VehicleParameter params_;
+};
+
+TEST_F(DevkitControllerTest, Init) {
+  ErrorCode ret = controller_.Init(params_, &sender_, &msg_manager_);
+  EXPECT_EQ(ret, ErrorCode::OK);
+}
+
+TEST_F(DevkitControllerTest, SetDrivingMode) {
+  Chassis chassis;
+  chassis.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(chassis.driving_mode());
+  EXPECT_EQ(controller_.driving_mode(), chassis.driving_mode());
+  EXPECT_EQ(controller_.SetDrivingMode(chassis.driving_mode()), ErrorCode::OK);
+}
+
+TEST_F(DevkitControllerTest, Status) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.Update(control_cmd_), ErrorCode::OK);
+  controller_.SetHorn(control_cmd_);
+  controller_.SetBeam(control_cmd_);
+  controller_.SetTurningSignal(control_cmd_);
+  EXPECT_FALSE(controller_.CheckChassisError());
+}
+
+TEST_F(DevkitControllerTest, UpdateDrivingMode) {
+  controller_.Init(params_, &sender_, &msg_manager_);
+  controller_.set_driving_mode(Chassis::COMPLETE_AUTO_DRIVE);
+  EXPECT_EQ(controller_.SetDrivingMode(Chassis::COMPLETE_MANUAL),
+            ErrorCode::OK);
+  EXPECT_EQ(controller_.SetDrivingMode(Chassis::COMPLETE_AUTO_DRIVE),
+            ErrorCode::CANBUS_ERROR);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_message_manager.cc
+++ b/modules/canbus/vehicle/devkit/devkit_message_manager.cc
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_message_manager.h"
+
+#include "modules/canbus/vehicle/devkit/protocol/brake_command_101.h"
+#include "modules/canbus/vehicle/devkit/protocol/brake_report_501.h"
+#include "modules/canbus/vehicle/devkit/protocol/gear_command_103.h"
+#include "modules/canbus/vehicle/devkit/protocol/gear_report_503.h"
+#include "modules/canbus/vehicle/devkit/protocol/park_command_104.h"
+#include "modules/canbus/vehicle/devkit/protocol/park_report_504.h"
+#include "modules/canbus/vehicle/devkit/protocol/steering_command_102.h"
+#include "modules/canbus/vehicle/devkit/protocol/steering_report_502.h"
+#include "modules/canbus/vehicle/devkit/protocol/throttle_command_100.h"
+#include "modules/canbus/vehicle/devkit/protocol/throttle_report_500.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h"
+#include "modules/canbus/vehicle/devkit/protocol/vcu_report_505.h"
+#include "modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+DevkitMessageManager::DevkitMessageManager() {
+  // Control Messages
+  AddSendProtocolData<Brakecommand101, true>();
+  AddSendProtocolData<Gearcommand103, true>();
+  AddSendProtocolData<Parkcommand104, true>();
+  AddSendProtocolData<Steeringcommand102, true>();
+  AddSendProtocolData<Throttlecommand100, true>();
+
+  // Report Messages
+  AddRecvProtocolData<Brakereport501, true>();
+  AddRecvProtocolData<Gearreport503, true>();
+  AddRecvProtocolData<Parkreport504, true>();
+  AddRecvProtocolData<Steeringreport502, true>();
+  AddRecvProtocolData<Throttlereport500, true>();
+  AddRecvProtocolData<Ultrsensor1507, true>();
+  AddRecvProtocolData<Ultrsensor2508, true>();
+  AddRecvProtocolData<Ultrsensor3509, true>();
+  AddRecvProtocolData<Ultrsensor4510, true>();
+  AddRecvProtocolData<Ultrsensor5511, true>();
+  AddRecvProtocolData<Vcureport505, true>();
+  AddRecvProtocolData<Wheelspeedreport506, true>();
+}
+
+DevkitMessageManager::~DevkitMessageManager() {}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_message_manager.h
+++ b/modules/canbus/vehicle/devkit/devkit_message_manager.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::MessageManager;
+
+class DevkitMessageManager
+    : public MessageManager<::apollo::canbus::ChassisDetail> {
+ public:
+  DevkitMessageManager();
+  virtual ~DevkitMessageManager();
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_message_manager_test.cc
+++ b/modules/canbus/vehicle/devkit/devkit_message_manager_test.cc
@@ -1,0 +1,80 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_message_manager.h"
+
+#include "gtest/gtest.h"
+#include "modules/canbus/vehicle/devkit/protocol/brake_command_101.h"
+#include "modules/canbus/vehicle/devkit/protocol/brake_report_501.h"
+#include "modules/canbus/vehicle/devkit/protocol/gear_command_103.h"
+#include "modules/canbus/vehicle/devkit/protocol/gear_report_503.h"
+#include "modules/canbus/vehicle/devkit/protocol/park_command_104.h"
+#include "modules/canbus/vehicle/devkit/protocol/park_report_504.h"
+#include "modules/canbus/vehicle/devkit/protocol/steering_command_102.h"
+#include "modules/canbus/vehicle/devkit/protocol/steering_report_502.h"
+#include "modules/canbus/vehicle/devkit/protocol/throttle_command_100.h"
+#include "modules/canbus/vehicle/devkit/protocol/throttle_report_500.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h"
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h"
+#include "modules/canbus/vehicle/devkit/protocol/vcu_report_505.h"
+#include "modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class DevkitMessageManagerTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+
+ protected:
+  DevkitMessageManager manager_;
+};
+
+TEST_F(DevkitMessageManagerTest, GetSendProtocols) {
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Brakecommand101::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Gearcommand103::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Parkcommand104::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Steeringcommand102::ID),
+            nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Throttlecommand100::ID),
+            nullptr);
+}
+
+TEST_F(DevkitMessageManagerTest, GetRecvProtocols) {
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Brakereport501::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Gearreport503::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Parkreport504::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Steeringreport502::ID),
+            nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Throttlereport500::ID),
+            nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Ultrsensor1507::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Ultrsensor2508::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Ultrsensor3509::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Ultrsensor4510::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Ultrsensor5511::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Vcureport505::ID), nullptr);
+  EXPECT_NE(manager_.GetMutableProtocolDataById(Wheelspeedreport506::ID),
+            nullptr);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_vehicle_factory.cc
+++ b/modules/canbus/vehicle/devkit/devkit_vehicle_factory.cc
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_vehicle_factory.h"
+
+#include "cyber/common/log.h"
+#include "modules/canbus/vehicle/devkit/devkit_controller.h"
+#include "modules/canbus/vehicle/devkit/devkit_message_manager.h"
+#include "modules/common/util/util.h"
+
+namespace apollo {
+namespace canbus {
+
+std::unique_ptr<VehicleController>
+DevkitVehicleFactory::CreateVehicleController() {
+  return std::unique_ptr<VehicleController>(new devkit::DevkitController());
+}
+
+std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+DevkitVehicleFactory::CreateMessageManager() {
+  return std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>(
+      new devkit::DevkitMessageManager());
+}
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_vehicle_factory.h
+++ b/modules/canbus/vehicle/devkit/devkit_vehicle_factory.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+/**
+ * @file devkit_vehicle_factory.h
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+#include "modules/canbus/vehicle/abstract_vehicle_factory.h"
+#include "modules/canbus/vehicle/vehicle_controller.h"
+#include "modules/drivers/canbus/can_comm/message_manager.h"
+
+/**
+ * @namespace apollo::canbus
+ * @brief apollo::canbus
+ */
+namespace apollo {
+namespace canbus {
+
+/**
+ * @class DevkitVehicleFactory
+ *
+ * @brief this class is inherited from AbstractVehicleFactory. It can be used to
+ * create controller and message manager for devkit vehicle.
+ */
+class DevkitVehicleFactory : public AbstractVehicleFactory {
+ public:
+  /**
+   * @brief destructor
+   */
+  virtual ~DevkitVehicleFactory() = default;
+
+  /**
+   * @brief create devkit vehicle controller
+   * @returns a unique_ptr that points to the created controller
+   */
+  std::unique_ptr<VehicleController> CreateVehicleController() override;
+
+  /**
+   * @brief create devkit message manager
+   * @returns a unique_ptr that points to the created message manager
+   */
+  std::unique_ptr<MessageManager<::apollo::canbus::ChassisDetail>>
+  CreateMessageManager() override;
+};
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/devkit_vehicle_factory_test.cc
+++ b/modules/canbus/vehicle/devkit/devkit_vehicle_factory_test.cc
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/devkit_vehicle_factory.h"
+
+#include "gtest/gtest.h"
+#include "modules/canbus/proto/vehicle_parameter.pb.h"
+
+namespace apollo {
+namespace canbus {
+
+class DevkitVehicleFactoryTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    VehicleParameter parameter;
+    parameter.set_brand(apollo::common::DKIT);
+    devkit_factory_.SetVehicleParameter(parameter);
+  }
+  virtual void TearDown() {}
+
+ protected:
+  DevkitVehicleFactory devkit_factory_;
+};
+
+TEST_F(DevkitVehicleFactoryTest, InitVehicleController) {
+  EXPECT_NE(devkit_factory_.CreateVehicleController(), nullptr);
+}
+
+TEST_F(DevkitVehicleFactoryTest, InitMessageManager) {
+  EXPECT_NE(devkit_factory_.CreateMessageManager(), nullptr);
+}
+
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/BUILD
+++ b/modules/canbus/vehicle/devkit/protocol/BUILD
@@ -1,0 +1,403 @@
+load("//tools:cpplint.bzl", "cpplint")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "canbus_devkit_protocol",
+    deps = [
+        ":brake_command_101",
+        ":brake_report_501",
+        ":gear_command_103",
+        ":gear_report_503",
+        ":park_command_104",
+        ":park_report_504",
+        ":steering_command_102",
+        ":steering_report_502",
+        ":throttle_command_100",
+        ":throttle_report_500",
+        ":ultr_sensor_1_507",
+        ":ultr_sensor_2_508",
+        ":ultr_sensor_3_509",
+        ":ultr_sensor_4_510",
+        ":ultr_sensor_5_511",
+        ":vcu_report_505",
+        ":wheelspeed_report_506",
+    ],
+)
+
+cc_library(
+    name = "brake_command_101",
+    srcs = ["brake_command_101.cc"],
+    hdrs = ["brake_command_101.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "brake_command_101_test",
+    size = "small",
+    srcs = ["brake_command_101_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "brake_report_501",
+    srcs = ["brake_report_501.cc"],
+    hdrs = ["brake_report_501.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "brake_report_501_test",
+    size = "small",
+    srcs = ["brake_report_501_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "gear_command_103",
+    srcs = ["gear_command_103.cc"],
+    hdrs = ["gear_command_103.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "gear_command_103_test",
+    size = "small",
+    srcs = ["gear_command_103_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "gear_report_503",
+    srcs = ["gear_report_503.cc"],
+    hdrs = ["gear_report_503.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "gear_report_503_test",
+    size = "small",
+    srcs = ["gear_report_503_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "park_command_104",
+    srcs = ["park_command_104.cc"],
+    hdrs = ["park_command_104.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "park_command_104_test",
+    size = "small",
+    srcs = ["park_command_104_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "park_report_504",
+    srcs = ["park_report_504.cc"],
+    hdrs = ["park_report_504.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "park_report_504_test",
+    size = "small",
+    srcs = ["park_report_504_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "steering_command_102",
+    srcs = ["steering_command_102.cc"],
+    hdrs = ["steering_command_102.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "steering_command_102_test",
+    size = "small",
+    srcs = ["steering_command_102_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "steering_report_502",
+    srcs = ["steering_report_502.cc"],
+    hdrs = ["steering_report_502.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "steering_report_502_test",
+    size = "small",
+    srcs = ["steering_report_502_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "throttle_command_100",
+    srcs = ["throttle_command_100.cc"],
+    hdrs = ["throttle_command_100.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "throttle_command_100_test",
+    size = "small",
+    srcs = ["throttle_command_100_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "throttle_report_500",
+    srcs = ["throttle_report_500.cc"],
+    hdrs = ["throttle_report_500.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "throttle_report_500_test",
+    size = "small",
+    srcs = ["throttle_report_500_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "ultr_sensor_1_507",
+    srcs = ["ultr_sensor_1_507.cc"],
+    hdrs = ["ultr_sensor_1_507.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ultr_sensor_1_507_test",
+    size = "small",
+    srcs = ["ultr_sensor_1_507_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+
+cc_library(
+    name = "ultr_sensor_2_508",
+    srcs = ["ultr_sensor_2_508.cc"],
+    hdrs = ["ultr_sensor_2_508.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ultr_sensor_2_508_test",
+    size = "small",
+    srcs = ["ultr_sensor_2_508_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "ultr_sensor_3_509",
+    srcs = ["ultr_sensor_3_509.cc"],
+    hdrs = ["ultr_sensor_3_509.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ultr_sensor_3_509_test",
+    size = "small",
+    srcs = ["ultr_sensor_3_509_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "ultr_sensor_4_510",
+    srcs = ["ultr_sensor_4_510.cc"],
+    hdrs = ["ultr_sensor_4_510.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ultr_sensor_4_510_test",
+    size = "small",
+    srcs = ["ultr_sensor_4_510_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "ultr_sensor_5_511",
+    srcs = ["ultr_sensor_5_511.cc"],
+    hdrs = ["ultr_sensor_5_511.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "ultr_sensor_5_511_test",
+    size = "small",
+    srcs = ["ultr_sensor_5_511_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "vcu_report_505",
+    srcs = ["vcu_report_505.cc"],
+    hdrs = ["vcu_report_505.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "vcu_report_505_test",
+    size = "small",
+    srcs = ["vcu_report_505_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "wheelspeed_report_506",
+    srcs = ["wheelspeed_report_506.cc"],
+    hdrs = ["wheelspeed_report_506.h"],
+    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    deps = [
+        "//modules/canbus/proto:canbus_proto",
+        "//modules/drivers/canbus/can_comm:message_manager_base",
+        "//modules/drivers/canbus/common:canbus_common",
+    ],
+)
+
+cc_test(
+    name = "wheelspeed_report_506_test",
+    size = "small",
+    srcs = ["wheelspeed_report_506_test.cc"],
+    deps = [
+        "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cpplint()

--- a/modules/canbus/vehicle/devkit/protocol/brake_command_101.cc
+++ b/modules/canbus/vehicle/devkit/protocol/brake_command_101.cc
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/brake_command_101.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Brakecommand101::ID = 0x101;
+
+// public
+Brakecommand101::Brakecommand101() { Reset(); }
+
+uint32_t Brakecommand101::GetPeriod() const {
+  // TODO(All) :  modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Brakecommand101::UpdateData(uint8_t* data) {
+  set_p_brake_dec(data, brake_dec_);
+  set_p_brake_pedal_target(data, brake_pedal_target_);
+  set_p_brake_en_ctrl(data, brake_en_ctrl_);
+  checksum_111_ =
+      data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6];
+  set_p_checksum_111(data, checksum_111_);
+}
+
+void Brakecommand101::Reset() {
+  // TODO(All) :  you should check this manually
+  brake_dec_ = 0.0;
+  checksum_111_ = 0;
+  brake_pedal_target_ = 0.0;
+  brake_en_ctrl_ = Brake_command_101::BRAKE_EN_CTRL_DISABLE;
+}
+
+Brakecommand101* Brakecommand101::set_brake_dec(double brake_dec) {
+  brake_dec_ = brake_dec;
+  return this;
+}
+
+// config detail: {'name': 'Brake_Dec', 'offset': 0.0, 'precision': 0.01, 'len':
+// 10, 'is_signed_var': False, 'physical_range': '[0|10]', 'bit': 15, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+void Brakecommand101::set_p_brake_dec(uint8_t* data, double brake_dec) {
+  brake_dec = ProtocolData::BoundedValue(0.0, 10.0, brake_dec);
+  int x = brake_dec / 0.010000;
+  uint8_t t = 0;
+
+  t = x & 0x3;
+  Byte to_set0(data + 2);
+  to_set0.set_value(t, 6, 2);
+  x >>= 2;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 1);
+  to_set1.set_value(t, 0, 8);
+}
+
+Brakecommand101* Brakecommand101::set_checksum_111(int checksum_111) {
+  checksum_111_ = checksum_111;
+  return this;
+}
+
+// config detail: {'name': 'CheckSum_111', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Brakecommand101::set_p_checksum_111(uint8_t* data, int checksum_111) {
+  checksum_111 = ProtocolData::BoundedValue(0, 255, checksum_111);
+  int x = checksum_111;
+
+  Byte to_set(data + 7);
+  to_set.set_value(x, 0, 8);
+}
+
+Brakecommand101* Brakecommand101::set_brake_pedal_target(
+    double brake_pedal_target) {
+  brake_pedal_target_ = brake_pedal_target;
+  return this;
+}
+
+// config detail: {'name': 'Brake_Pedal_Target', 'offset': 0.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+// 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+void Brakecommand101::set_p_brake_pedal_target(uint8_t* data,
+                                               double brake_pedal_target) {
+  brake_pedal_target =
+      ProtocolData::BoundedValue(0.0, 100.0, brake_pedal_target);
+  int x = brake_pedal_target / 0.100000;
+  uint8_t t = 0;
+
+  t = x & 0xFF;
+  Byte to_set0(data + 4);
+  to_set0.set_value(t, 0, 8);
+  x >>= 8;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 3);
+  to_set1.set_value(t, 0, 8);
+}
+
+Brakecommand101* Brakecommand101::set_brake_en_ctrl(
+    Brake_command_101::Brake_en_ctrlType brake_en_ctrl) {
+  brake_en_ctrl_ = brake_en_ctrl;
+  return this;
+}
+
+// config detail: {'name': 'Brake_EN_CTRL', 'enum': {0: 'BRAKE_EN_CTRL_DISABLE',
+// 1: 'BRAKE_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+void Brakecommand101::set_p_brake_en_ctrl(
+    uint8_t* data, Brake_command_101::Brake_en_ctrlType brake_en_ctrl) {
+  int x = brake_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 1);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/brake_command_101.h
+++ b/modules/canbus/vehicle/devkit/protocol/brake_command_101.h
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Brakecommand101 : public ::apollo::drivers::canbus::ProtocolData<
+                            ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Brakecommand101();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'Brake_Dec', 'offset': 0.0, 'precision': 0.01,
+  // 'len': 10, 'is_signed_var': False, 'physical_range': '[0|10.00]', 'bit':
+  // 15, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  Brakecommand101* set_brake_dec(double brake_dec);
+
+  // config detail: {'name': 'CheckSum_111', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Brakecommand101* set_checksum_111(int checksum_111);
+
+  // config detail: {'name': 'Brake_Pedal_Target', 'offset': 0.0, 'precision':
+  // 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+  // 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  Brakecommand101* set_brake_pedal_target(double brake_pedal_target);
+
+  // config detail: {'name': 'Brake_EN_CTRL', 'enum': {0:
+  // 'BRAKE_EN_CTRL_DISABLE', 1: 'BRAKE_EN_CTRL_ENABLE'}, 'precision': 1.0,
+  // 'len': 1, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+  // 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Brakecommand101* set_brake_en_ctrl(
+      Brake_command_101::Brake_en_ctrlType brake_en_ctrl);
+
+ private:
+  // config detail: {'name': 'Brake_Dec', 'offset': 0.0, 'precision': 0.01,
+  // 'len': 10, 'is_signed_var': False, 'physical_range': '[0|10]', 'bit':
+  // 15, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_brake_dec(uint8_t* data, double brake_dec);
+
+  // config detail: {'name': 'CheckSum_111', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_checksum_111(uint8_t* data, int checksum_111);
+
+  // config detail: {'name': 'Brake_Pedal_Target', 'offset': 0.0, 'precision':
+  // 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+  // 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_brake_pedal_target(uint8_t* data, double brake_pedal_target);
+
+  // config detail: {'name': 'Brake_EN_CTRL', 'enum': {0:
+  // 'BRAKE_EN_CTRL_DISABLE', 1: 'BRAKE_EN_CTRL_ENABLE'}, 'precision': 1.0,
+  // 'len': 1, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+  // 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_brake_en_ctrl(uint8_t* data,
+                           Brake_command_101::Brake_en_ctrlType brake_en_ctrl);
+
+ private:
+  double brake_dec_;
+  int checksum_111_;
+  double brake_pedal_target_;
+  Brake_command_101::Brake_en_ctrlType brake_en_ctrl_;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/brake_command_101_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/brake_command_101_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/brake_command_101.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Brakecommand101Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Brakecommand101Test, simple) {
+  Brakecommand101 brake;
+  EXPECT_EQ(brake.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78};
+  brake.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01110000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b00110011);
+  EXPECT_EQ(data[3], 0b00000000);
+  EXPECT_EQ(data[4], 0b00000000);
+  EXPECT_EQ(data[5], 0b01110110);
+  EXPECT_EQ(data[6], 0b01110111);
+  EXPECT_EQ(data[7], 0b01000010);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/brake_report_501.cc
+++ b/modules/canbus/vehicle/devkit/protocol/brake_report_501.cc
@@ -1,0 +1,109 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/brake_report_501.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Brakereport501::Brakereport501() {}
+const int32_t Brakereport501::ID = 0x501;
+
+void Brakereport501::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_brake_report_501()->set_brake_pedal_actual(
+      brake_pedal_actual(bytes, length));
+  chassis->mutable_devkit()->mutable_brake_report_501()->set_brake_flt2(
+      brake_flt2(bytes, length));
+  chassis->mutable_devkit()->mutable_brake_report_501()->set_brake_flt1(
+      brake_flt1(bytes, length));
+  chassis->mutable_devkit()->mutable_brake_report_501()->set_brake_en_state(
+      brake_en_state(bytes, length));
+  chassis->mutable_check_response()->set_is_esp_online(
+      brake_en_state(bytes, length) == 1);
+}
+
+// config detail: {'name': 'brake_pedal_actual', 'offset': 0.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+// 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Brakereport501::brake_pedal_actual(const std::uint8_t* bytes,
+                                          int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 4);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+
+// config detail: {'description': 'Brake system communication fault', 'enum':
+// {0: 'BRAKE_FLT2_NO_FAULT', 1: 'BRAKE_FLT2_BRAKE_SYSTEM_COMUNICATION_FAULT'},
+// 'precision': 1.0, 'len': 8, 'name': 'brake_flt2', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Brake_report_501::Brake_flt2Type Brakereport501::brake_flt2(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_report_501::Brake_flt2Type ret =
+      static_cast<Brake_report_501::Brake_flt2Type>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Brake system hardware fault', 'enum': {0:
+// 'BRAKE_FLT1_NO_FAULT', 1: 'BRAKE_FLT1_BRAKE_SYSTEM_HARDWARE_FAULT'},
+// 'precision': 1.0, 'len': 8, 'name': 'brake_flt1', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Brake_report_501::Brake_flt1Type Brakereport501::brake_flt1(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Brake_report_501::Brake_flt1Type ret =
+      static_cast<Brake_report_501::Brake_flt1Type>(x);
+  return ret;
+}
+
+// config detail: {'name': 'brake_en_state', 'enum': {0:
+// 'BRAKE_EN_STATE_MANUAL', 1: 'BRAKE_EN_STATE_AUTO', 2:
+// 'BRAKE_EN_STATE_TAKEOVER', 3: 'BRAKE_EN_STATE_STANDBY'}, 'precision': 1.0,
+// 'len': 2, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|2]',
+// 'bit': 1, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+Brake_report_501::Brake_en_stateType Brakereport501::brake_en_state(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 2);
+
+  Brake_report_501::Brake_en_stateType ret =
+      static_cast<Brake_report_501::Brake_en_stateType>(x);
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/brake_report_501.h
+++ b/modules/canbus/vehicle/devkit/protocol/brake_report_501.h
@@ -1,0 +1,69 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Brakereport501 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Brakereport501();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'Brake_Pedal_Actual', 'offset': 0.0, 'precision':
+  // 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+  // 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double brake_pedal_actual(const std::uint8_t* bytes,
+                            const int32_t length) const;
+
+  // config detail: {'description': 'Brake system communication fault', 'enum':
+  // {0: 'BRAKE_FLT2_NO_FAULT', 1:
+  // 'BRAKE_FLT2_BRAKE_SYSTEM_COMUNICATION_FAULT'}, 'precision': 1.0, 'len': 8,
+  // 'name': 'Brake_FLT2', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Brake_report_501::Brake_flt2Type brake_flt2(const std::uint8_t* bytes,
+                                              const int32_t length) const;
+
+  // config detail: {'description': 'Brake system hardware fault', 'enum': {0:
+  // 'BRAKE_FLT1_NO_FAULT', 1: 'BRAKE_FLT1_BRAKE_SYSTEM_HARDWARE_FAULT'},
+  // 'precision': 1.0, 'len': 8, 'name': 'Brake_FLT1', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Brake_report_501::Brake_flt1Type brake_flt1(const std::uint8_t* bytes,
+                                              const int32_t length) const;
+
+  // config detail: {'name': 'Brake_EN_state', 'enum': {0:
+  // 'BRAKE_EN_STATE_MANUAL', 1: 'BRAKE_EN_STATE_AUTO', 2:
+  // 'BRAKE_EN_STATE_TAKEOVER', 3: 'BRAKE_EN_STATE_STANDBY'}, 'precision': 1.0,
+  // 'len': 2, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|2]',
+  // 'bit': 1, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Brake_report_501::Brake_en_stateType brake_en_state(
+      const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/brake_report_501_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/brake_report_501_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/brake_report_501.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Brakereport501Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Brakereport501Test, General) {
+  uint8_t data[8] = {0x01, 0x00, 0x01, 0x03, 0x52, 0x01, 0x00, 0x01};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Brakereport501 brakereport;
+  brakereport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000001);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000011);
+  EXPECT_EQ(data[4], 0b01010010);
+  EXPECT_EQ(data[5], 0b00000001);
+  EXPECT_EQ(data[6], 0b00000000);
+  EXPECT_EQ(data[7], 0b00000001);
+
+  EXPECT_EQ(cd.devkit().brake_report_501().brake_pedal_actual(), 85);
+  EXPECT_EQ(cd.devkit().brake_report_501().brake_flt2(), 1);
+  EXPECT_EQ(cd.devkit().brake_report_501().brake_flt1(), 0);
+  EXPECT_EQ(cd.devkit().brake_report_501().brake_en_state(), 1);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_command_103.cc
+++ b/modules/canbus/vehicle/devkit/protocol/gear_command_103.cc
@@ -1,0 +1,108 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/gear_command_103.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Gearcommand103::ID = 0x103;
+
+// public
+Gearcommand103::Gearcommand103() { Reset(); }
+
+uint32_t Gearcommand103::GetPeriod() const {
+  // TODO(All) :  modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Gearcommand103::UpdateData(uint8_t* data) {
+  set_p_gear_target(data, gear_target_);
+  set_p_gear_en_ctrl(data, gear_en_ctrl_);
+  checksum_114_ =
+      data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6];
+  set_p_checksum_114(data, checksum_114_);
+}
+
+void Gearcommand103::Reset() {
+  // TODO(All) :  you should check this manually
+  gear_target_ = Gear_command_103::GEAR_TARGET_NEUTRAL;
+  gear_en_ctrl_ = Gear_command_103::GEAR_EN_CTRL_DISABLE;
+  checksum_114_ = 0;
+}
+
+Gearcommand103* Gearcommand103::set_gear_target(
+    Gear_command_103::Gear_targetType gear_target) {
+  gear_target_ = gear_target;
+  return this;
+}
+
+// config detail: {'name': 'Gear_Target', 'enum': {0: 'GEAR_TARGET_INVALID', 1:
+// 'GEAR_TARGET_PARK', 2: 'GEAR_TARGET_REVERSE', 3: 'GEAR_TARGET_NEUTRAL', 4:
+// 'GEAR_TARGET_DRIVE'}, 'precision': 1.0, 'len': 3, 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|4]', 'bit': 10, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+void Gearcommand103::set_p_gear_target(
+    uint8_t* data, Gear_command_103::Gear_targetType gear_target) {
+  int x = gear_target;
+
+  Byte to_set(data + 1);
+  to_set.set_value(x, 0, 3);
+}
+
+Gearcommand103* Gearcommand103::set_gear_en_ctrl(
+    Gear_command_103::Gear_en_ctrlType gear_en_ctrl) {
+  gear_en_ctrl_ = gear_en_ctrl;
+  return this;
+}
+
+// config detail: {'name': 'Gear_EN_CTRL', 'enum': {0: 'GEAR_EN_CTRL_DISABLE',
+// 1: 'GEAR_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+void Gearcommand103::set_p_gear_en_ctrl(
+    uint8_t* data, Gear_command_103::Gear_en_ctrlType gear_en_ctrl) {
+  int x = gear_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 1);
+}
+
+Gearcommand103* Gearcommand103::set_checksum_114(int checksum_114) {
+  checksum_114_ = checksum_114;
+  return this;
+}
+
+// config detail: {'name': 'CheckSum_114', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Gearcommand103::set_p_checksum_114(uint8_t* data, int checksum_114) {
+  checksum_114 = ProtocolData::BoundedValue(0, 255, checksum_114);
+  int x = checksum_114;
+
+  Byte to_set(data + 7);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_command_103.h
+++ b/modules/canbus/vehicle/devkit/protocol/gear_command_103.h
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Gearcommand103 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Gearcommand103();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'Gear_Target', 'enum': {0: 'GEAR_TARGET_INVALID',
+  // 1: 'GEAR_TARGET_PARK', 2: 'GEAR_TARGET_REVERSE', 3: 'GEAR_TARGET_NEUTRAL',
+  // 4: 'GEAR_TARGET_DRIVE'}, 'precision': 1.0, 'len': 3, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|4]', 'bit': 10, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Gearcommand103* set_gear_target(
+      Gear_command_103::Gear_targetType gear_target);
+
+  // config detail: {'name': 'Gear_EN_CTRL', 'enum': {0: 'GEAR_EN_CTRL_DISABLE',
+  // 1: 'GEAR_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Gearcommand103* set_gear_en_ctrl(
+      Gear_command_103::Gear_en_ctrlType gear_en_ctrl);
+
+  // config detail: {'name': 'CheckSum_114', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Gearcommand103* set_checksum_114(int checksum_114);
+
+ private:
+  // config detail: {'name': 'Gear_Target', 'enum': {0: 'GEAR_TARGET_INVALID',
+  // 1: 'GEAR_TARGET_PARK', 2: 'GEAR_TARGET_REVERSE', 3: 'GEAR_TARGET_NEUTRAL',
+  // 4: 'GEAR_TARGET_DRIVE'}, 'precision': 1.0, 'len': 3, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|4]', 'bit': 10, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_gear_target(uint8_t* data,
+                         Gear_command_103::Gear_targetType gear_target);
+
+  // config detail: {'name': 'Gear_EN_CTRL', 'enum': {0: 'GEAR_EN_CTRL_DISABLE',
+  // 1: 'GEAR_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_gear_en_ctrl(uint8_t* data,
+                          Gear_command_103::Gear_en_ctrlType gear_en_ctrl);
+
+  // config detail: {'name': 'CheckSum_114', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_checksum_114(uint8_t* data, int checksum_114);
+
+ private:
+  Gear_command_103::Gear_targetType gear_target_;
+  Gear_command_103::Gear_en_ctrlType gear_en_ctrl_;
+  int checksum_114_;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_command_103_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/gear_command_103_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/gear_command_103.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Gearcommand103Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Gearcommand103Test, simple) {
+  Gearcommand103 gear;
+  EXPECT_EQ(gear.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78};
+  gear.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01110000);
+  EXPECT_EQ(data[1], 0b01110011);
+  EXPECT_EQ(data[2], 0b01110011);
+  EXPECT_EQ(data[3], 0b01110100);
+  EXPECT_EQ(data[4], 0b01110101);
+  EXPECT_EQ(data[5], 0b01110110);
+  EXPECT_EQ(data[6], 0b01110111);
+  EXPECT_EQ(data[7], 0b01110000);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_report_503.cc
+++ b/modules/canbus/vehicle/devkit/protocol/gear_report_503.cc
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/gear_report_503.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Gearreport503::Gearreport503() {}
+const int32_t Gearreport503::ID = 0x503;
+
+void Gearreport503::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_gear_report_503()->set_gear_flt(
+      gear_flt(bytes, length));
+  chassis->mutable_devkit()->mutable_gear_report_503()->set_gear_actual(
+      gear_actual(bytes, length));
+}
+
+// config detail: {'name': 'gear_flt', 'enum': {0: 'GEAR_FLT_NO_FAULT', 1:
+// 'GEAR_FLT_FAULT'}, 'precision': 1.0, 'len': 8, 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Gear_report_503::Gear_fltType Gearreport503::gear_flt(const std::uint8_t* bytes,
+                                                      int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Gear_report_503::Gear_fltType ret =
+      static_cast<Gear_report_503::Gear_fltType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'gear_actual', 'enum': {0: 'GEAR_ACTUAL_INVALID', 1:
+// 'GEAR_ACTUAL_PARK', 2: 'GEAR_ACTUAL_REVERSE', 3: 'GEAR_ACTUAL_NEUTRAL', 4:
+// 'GEAR_ACTUAL_DRIVE'}, 'precision': 1.0, 'len': 3, 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|4]', 'bit': 2, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Gear_report_503::Gear_actualType Gearreport503::gear_actual(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 3);
+
+  Gear_report_503::Gear_actualType ret =
+      static_cast<Gear_report_503::Gear_actualType>(x);
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_report_503.h
+++ b/modules/canbus/vehicle/devkit/protocol/gear_report_503.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Gearreport503 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Gearreport503();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'Gear_FLT', 'enum': {0: 'GEAR_FLT_NO_FAULT', 1:
+  // 'GEAR_FLT_FAULT'}, 'precision': 1.0, 'len': 8, 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Gear_report_503::Gear_fltType gear_flt(const std::uint8_t* bytes,
+                                         const int32_t length) const;
+
+  // config detail: {'name': 'Gear_Actual', 'enum': {0: 'GEAR_ACTUAL_INVALID',
+  // 1: 'GEAR_ACTUAL_PARK', 2: 'GEAR_ACTUAL_REVERSE', 3: 'GEAR_ACTUAL_NEUTRAL',
+  // 4: 'GEAR_ACTUAL_DRIVE'}, 'precision': 1.0, 'len': 3, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|4]', 'bit': 2, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Gear_report_503::Gear_actualType gear_actual(const std::uint8_t* bytes,
+                                               const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/gear_report_503_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/gear_report_503_test.cc
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/gear_report_503.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Gearreport503Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Gearreport503Test, General) {
+  uint8_t data[8] = {0x04, 0x01, 0x01, 0x10, 0x90, 0x01, 0x00, 0x01};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Gearreport503 gearreport;
+  gearreport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000100);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00010000);
+  EXPECT_EQ(data[4], 0b10010000);
+  EXPECT_EQ(data[5], 0b00000001);
+  EXPECT_EQ(data[6], 0b00000000);
+  EXPECT_EQ(data[7], 0b00000001);
+
+  EXPECT_EQ(cd.devkit().gear_report_503().gear_flt(), 1);
+  EXPECT_EQ(cd.devkit().gear_report_503().gear_actual(), 4);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_command_104.cc
+++ b/modules/canbus/vehicle/devkit/protocol/park_command_104.cc
@@ -1,0 +1,107 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/park_command_104.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Parkcommand104::ID = 0x104;
+
+// public
+Parkcommand104::Parkcommand104() { Reset(); }
+
+uint32_t Parkcommand104::GetPeriod() const {
+  // TODO(All) :  modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Parkcommand104::UpdateData(uint8_t* data) {
+  set_p_park_target(data, park_target_);
+  set_p_park_en_ctrl(data, park_en_ctrl_);
+  checksum_115_ =
+      data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6];
+  set_p_checksum_115(data, checksum_115_);
+}
+
+void Parkcommand104::Reset() {
+  // TODO(All) :  you should check this manually
+  checksum_115_ = 0;
+  park_target_ = Park_command_104::PARK_TARGET_RELEASE;
+  park_en_ctrl_ = Park_command_104::PARK_EN_CTRL_DISABLE;
+}
+
+Parkcommand104* Parkcommand104::set_checksum_115(int checksum_115) {
+  checksum_115_ = checksum_115;
+  return this;
+}
+
+// config detail: {'name': 'CheckSum_115', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Parkcommand104::set_p_checksum_115(uint8_t* data, int checksum_115) {
+  checksum_115 = ProtocolData::BoundedValue(0, 255, checksum_115);
+  int x = checksum_115;
+
+  Byte to_set(data + 7);
+  to_set.set_value(x, 0, 8);
+}
+
+Parkcommand104* Parkcommand104::set_park_target(
+    Park_command_104::Park_targetType park_target) {
+  park_target_ = park_target;
+  return this;
+}
+
+// config detail: {'name': 'Park_Target', 'enum': {0: 'PARK_TARGET_RELEASE', 1:
+// 'PARK_TARGET_PARKING_TRIGGER'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 8, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+void Parkcommand104::set_p_park_target(
+    uint8_t* data, Park_command_104::Park_targetType park_target) {
+  int x = park_target;
+
+  Byte to_set(data + 1);
+  to_set.set_value(x, 0, 1);
+}
+
+Parkcommand104* Parkcommand104::set_park_en_ctrl(
+    Park_command_104::Park_en_ctrlType park_en_ctrl) {
+  park_en_ctrl_ = park_en_ctrl;
+  return this;
+}
+
+// config detail: {'name': 'Park_EN_CTRL', 'enum': {0: 'PARK_EN_CTRL_DISABLE',
+// 1: 'PARK_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+void Parkcommand104::set_p_park_en_ctrl(
+    uint8_t* data, Park_command_104::Park_en_ctrlType park_en_ctrl) {
+  int x = park_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 1);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_command_104.h
+++ b/modules/canbus/vehicle/devkit/protocol/park_command_104.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Parkcommand104 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Parkcommand104();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'CheckSum_115', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Parkcommand104* set_checksum_115(int checksum_115);
+
+  // config detail: {'name': 'Park_Target', 'enum': {0: 'PARK_TARGET_RELEASE',
+  // 1: 'PARK_TARGET_PARKING_TRIGGER'}, 'precision': 1.0, 'len': 1,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 8,
+  // 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Parkcommand104* set_park_target(
+      Park_command_104::Park_targetType park_target);
+
+  // config detail: {'name': 'Park_EN_CTRL', 'enum': {0: 'PARK_EN_CTRL_DISABLE',
+  // 1: 'PARK_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Parkcommand104* set_park_en_ctrl(
+      Park_command_104::Park_en_ctrlType park_en_ctrl);
+
+ private:
+  // config detail: {'name': 'CheckSum_115', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_checksum_115(uint8_t* data, int checksum_115);
+
+  // config detail: {'name': 'Park_Target', 'enum': {0: 'PARK_TARGET_RELEASE',
+  // 1: 'PARK_TARGET_PARKING_TRIGGER'}, 'precision': 1.0, 'len': 1,
+  // 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 8,
+  // 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_park_target(uint8_t* data,
+                         Park_command_104::Park_targetType park_target);
+
+  // config detail: {'name': 'Park_EN_CTRL', 'enum': {0: 'PARK_EN_CTRL_DISABLE',
+  // 1: 'PARK_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  void set_p_park_en_ctrl(uint8_t* data,
+                          Park_command_104::Park_en_ctrlType park_en_ctrl);
+
+ private:
+  int checksum_115_;
+  Park_command_104::Park_targetType park_target_;
+  Park_command_104::Park_en_ctrlType park_en_ctrl_;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_command_104_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/park_command_104_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/park_command_104.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Parkcommand104Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Parkcommand104Test, simple) {
+  Parkcommand104 park;
+  EXPECT_EQ(park.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78};
+  park.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01110000);
+  EXPECT_EQ(data[1], 0b01110010);
+  EXPECT_EQ(data[2], 0b01110011);
+  EXPECT_EQ(data[3], 0b01110100);
+  EXPECT_EQ(data[4], 0b01110101);
+  EXPECT_EQ(data[5], 0b01110110);
+  EXPECT_EQ(data[6], 0b01110111);
+  EXPECT_EQ(data[7], 0b01110001);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_report_504.cc
+++ b/modules/canbus/vehicle/devkit/protocol/park_report_504.cc
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/park_report_504.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Parkreport504::Parkreport504() {}
+const int32_t Parkreport504::ID = 0x504;
+
+void Parkreport504::Parse(const std::uint8_t* bytes, int32_t length,
+                          ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_park_report_504()->set_parking_actual(
+      parking_actual(bytes, length));
+  chassis->mutable_devkit()->mutable_park_report_504()->set_park_flt(
+      park_flt(bytes, length));
+}
+
+// config detail: {'name': 'parking_actual', 'enum': {0:
+// 'PARKING_ACTUAL_RELEASE', 1: 'PARKING_ACTUAL_PARKING_TRIGGER'},
+// 'precision': 1.0, 'len': 1, 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Park_report_504::Parking_actualType Parkreport504::parking_actual(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 1);
+
+  Park_report_504::Parking_actualType ret =
+      static_cast<Park_report_504::Parking_actualType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'park_flt', 'enum': {0: 'PARK_FLT_NO_FAULT', 1:
+// 'PARK_FLT_FAULT'}, 'precision': 1.0, 'len': 8, 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Park_report_504::Park_fltType Parkreport504::park_flt(const std::uint8_t* bytes,
+                                                      int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Park_report_504::Park_fltType ret =
+      static_cast<Park_report_504::Park_fltType>(x);
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_report_504.h
+++ b/modules/canbus/vehicle/devkit/protocol/park_report_504.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2019 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Parkreport504 : public ::apollo::drivers::canbus::ProtocolData<
+                          ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Parkreport504();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'Parking_actual', 'enum': {0:
+  // 'PARKING_ACTUAL_RELEASE', 1: 'PARKING_ACTUAL_PARKING_TRIGGER'},
+  // 'precision': 1.0, 'len': 1, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Park_report_504::Parking_actualType parking_actual(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'Park_FLT', 'enum': {0: 'PARK_FLT_NO_FAULT', 1:
+  // 'PARK_FLT_FAULT'}, 'precision': 1.0, 'len': 8, 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Park_report_504::Park_fltType park_flt(const std::uint8_t* bytes,
+                                         const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/park_report_504_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/park_report_504_test.cc
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/park_report_504.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Parkreport504Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Parkreport504Test, General) {
+  uint8_t data[8] = {0x04, 0x01, 0x01, 0x10, 0x90, 0x01, 0x00, 0x01};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Parkreport504 parkreport;
+  parkreport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000100);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00010000);
+  EXPECT_EQ(data[4], 0b10010000);
+  EXPECT_EQ(data[5], 0b00000001);
+  EXPECT_EQ(data[6], 0b00000000);
+  EXPECT_EQ(data[7], 0b00000001);
+
+  EXPECT_EQ(cd.devkit().park_report_504().parking_actual(), 0);
+  EXPECT_EQ(cd.devkit().park_report_504().park_flt(), 1);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_command_102.cc
+++ b/modules/canbus/vehicle/devkit/protocol/steering_command_102.cc
@@ -1,0 +1,135 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/steering_command_102.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Steeringcommand102::ID = 0x102;
+
+// public
+Steeringcommand102::Steeringcommand102() { Reset(); }
+
+uint32_t Steeringcommand102::GetPeriod() const {
+  // TODO(All) :  modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Steeringcommand102::UpdateData(uint8_t* data) {
+  set_p_steer_en_ctrl(data, steer_en_ctrl_);
+  set_p_steer_angle_target(data, steer_angle_target_);
+  set_p_steer_angle_spd(data, steer_angle_spd_);
+  checksum_112_ =
+      data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6];
+  set_p_checksum_112(data, checksum_112_);
+}
+
+void Steeringcommand102::Reset() {
+  // TODO(All) :  you should check this manually
+  steer_en_ctrl_ = Steering_command_102::STEER_EN_CTRL_DISABLE;
+  steer_angle_target_ = 0.0;
+  steer_angle_spd_ = 0;
+  checksum_112_ = 0;
+}
+
+Steeringcommand102* Steeringcommand102::set_steer_en_ctrl(
+    Steering_command_102::Steer_en_ctrlType steer_en_ctrl) {
+  steer_en_ctrl_ = steer_en_ctrl;
+  return this;
+}
+
+// config detail: {'name': 'Steer_EN_CTRL', 'enum': {0: 'STEER_EN_CTRL_DISABLE',
+// 1: 'STEER_EN_CTRL_ENABLE'}, 'precision': 1.0, 'len': 1, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+void Steeringcommand102::set_p_steer_en_ctrl(
+    uint8_t* data, Steering_command_102::Steer_en_ctrlType steer_en_ctrl) {
+  int x = steer_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 1);
+}
+
+Steeringcommand102* Steeringcommand102::set_steer_angle_target(
+    double steer_angle_target) {
+  steer_angle_target_ = steer_angle_target;
+  return this;
+}
+
+// config detail: {'name': 'Steer_ANGLE_Target', 'offset': -500.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[-500|500]',
+// 'bit': 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+void Steeringcommand102::set_p_steer_angle_target(uint8_t* data,
+                                                  double steer_angle_target) {
+  steer_angle_target =
+      ProtocolData::BoundedValue(-500.0, 500.0, steer_angle_target);
+  int x = (steer_angle_target - -500.000000) / 0.100000;
+  uint8_t t = 0;
+
+  t = x & 0xFF;
+  Byte to_set0(data + 4);
+  to_set0.set_value(t, 0, 8);
+  x >>= 8;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 3);
+  to_set1.set_value(t, 0, 8);
+}
+
+Steeringcommand102* Steeringcommand102::set_steer_angle_spd(
+    int steer_angle_spd) {
+  steer_angle_spd_ = steer_angle_spd;
+  return this;
+}
+
+// config detail: {'name': 'Steer_ANGLE_SPD', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|250]', 'bit': 15,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Steeringcommand102::set_p_steer_angle_spd(uint8_t* data,
+                                               int steer_angle_spd) {
+  steer_angle_spd = ProtocolData::BoundedValue(0, 250, steer_angle_spd);
+  int x = steer_angle_spd;
+
+  Byte to_set(data + 1);
+  to_set.set_value(x, 0, 8);
+}
+
+Steeringcommand102* Steeringcommand102::set_checksum_112(int checksum_112) {
+  checksum_112_ = checksum_112;
+  return this;
+}
+
+// config detail: {'name': 'CheckSum_112', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Steeringcommand102::set_p_checksum_112(uint8_t* data, int checksum_112) {
+  checksum_112 = ProtocolData::BoundedValue(0, 255, checksum_112);
+  int x = checksum_112;
+
+  Byte to_set(data + 7);
+  to_set.set_value(x, 0, 8);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_command_102.h
+++ b/modules/canbus/vehicle/devkit/protocol/steering_command_102.h
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Steeringcommand102 : public ::apollo::drivers::canbus::ProtocolData<
+                               ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Steeringcommand102();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'Steer_EN_CTRL', 'enum': {0:
+  // 'STEER_EN_CTRL_DISABLE', 1: 'STEER_EN_CTRL_ENABLE'}, 'precision': 1.0,
+  // 'len': 1, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+  // 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Steeringcommand102* set_steer_en_ctrl(
+      Steering_command_102::Steer_en_ctrlType steer_en_ctrl);
+
+  // config detail: {'name': 'Steer_ANGLE_Target', 'offset': -500.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[-500|500]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Steeringcommand102* set_steer_angle_target(double steer_angle_target);
+
+  // config detail: {'name': 'Steer_ANGLE_SPD', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|250]', 'bit': 15,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Steeringcommand102* set_steer_angle_spd(int steer_angle_spd);
+
+  // config detail: {'name': 'CheckSum_112', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Steeringcommand102* set_checksum_112(int checksum_112);
+
+ private:
+  // config detail: {'name': 'Steer_EN_CTRL', 'enum': {0:
+  // 'STEER_EN_CTRL_DISABLE', 1: 'STEER_EN_CTRL_ENABLE'}, 'precision': 1.0,
+  // 'len': 1, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+  // 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_steer_en_ctrl(
+      uint8_t* data, Steering_command_102::Steer_en_ctrlType steer_en_ctrl);
+
+  // config detail: {'name': 'Steer_ANGLE_Target', 'offset': -500.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[-500|500]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_steer_angle_target(uint8_t* data, double steer_angle_target);
+
+  // config detail: {'name': 'Steer_ANGLE_SPD', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|250]', 'bit': 15,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_steer_angle_spd(uint8_t* data, int steer_angle_spd);
+
+  // config detail: {'name': 'CheckSum_112', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_checksum_112(uint8_t* data, int checksum_112);
+
+ private:
+  Steering_command_102::Steer_en_ctrlType steer_en_ctrl_;
+  double steer_angle_target_;
+  int steer_angle_spd_;
+  int checksum_112_;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_command_102_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/steering_command_102_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/steering_command_102.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Steeringcommand102Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Steeringcommand102Test, simple) {
+  Steeringcommand102 steer;
+  EXPECT_EQ(steer.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78};
+  steer.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01110000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b01110011);
+  EXPECT_EQ(data[3], 0b00010011);
+  EXPECT_EQ(data[4], 0b10001000);
+  EXPECT_EQ(data[5], 0b01110110);
+  EXPECT_EQ(data[6], 0b01110111);
+  EXPECT_EQ(data[7], 0b10011001);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_report_502.cc
+++ b/modules/canbus/vehicle/devkit/protocol/steering_report_502.cc
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/steering_report_502.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Steeringreport502::Steeringreport502() {}
+const int32_t Steeringreport502::ID = 0x502;
+
+void Steeringreport502::Parse(const std::uint8_t* bytes, int32_t length,
+                              ChassisDetail* chassis) const {
+  chassis->mutable_devkit()
+      ->mutable_steering_report_502()
+      ->set_steer_angle_spd_actual(steer_angle_spd_actual(bytes, length));
+  chassis->mutable_devkit()->mutable_steering_report_502()->set_steer_flt2(
+      steer_flt2(bytes, length));
+  chassis->mutable_devkit()->mutable_steering_report_502()->set_steer_flt1(
+      steer_flt1(bytes, length));
+  chassis->mutable_devkit()->mutable_steering_report_502()->set_steer_en_state(
+      steer_en_state(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_steering_report_502()
+      ->set_steer_angle_actual(steer_angle_actual(bytes, length));
+  chassis->mutable_check_response()->set_is_eps_online(
+      steer_en_state(bytes, length) == 1);
+}
+
+// config detail: {'name': 'steer_angle_spd_actual', 'offset': 0.0,
+// 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'physical_range':
+// '[0|0]', 'bit': 55, 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+int Steeringreport502::steer_angle_spd_actual(const std::uint8_t* bytes,
+                                              int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'description': 'Steer system communication fault', 'enum':
+// {0: 'STEER_FLT2_NO_FAULT', 1: 'STEER_FLT2_STEER_SYSTEM_COMUNICATION_FAULT'},
+// 'precision': 1.0, 'len': 8, 'name': 'steer_flt2', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Steering_report_502::Steer_flt2Type Steeringreport502::steer_flt2(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Steering_report_502::Steer_flt2Type ret =
+      static_cast<Steering_report_502::Steer_flt2Type>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Steer system hardware fault', 'enum': {0:
+// 'STEER_FLT1_NO_FAULT', 1: 'STEER_FLT1_STEER_SYSTEM_HARDWARE_FAULT'},
+// 'precision': 1.0, 'len': 8, 'name': 'steer_flt1', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Steering_report_502::Steer_flt1Type Steeringreport502::steer_flt1(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Steering_report_502::Steer_flt1Type ret =
+      static_cast<Steering_report_502::Steer_flt1Type>(x);
+  return ret;
+}
+
+// config detail: {'name': 'steer_en_state', 'enum': {0:
+// 'STEER_EN_STATE_MANUAL', 1: 'STEER_EN_STATE_AUTO', 2:
+// 'STEER_EN_STATE_TAKEOVER', 3: 'STEER_EN_STATE_STANDBY'}, 'precision': 1.0,
+// 'len': 2, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|2]',
+// 'bit': 1, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+// 'STEER_EN_STATE_MANUAL', 1: 'STEER_EN_STATE_AUTO', 2:
+// 'STEER_EN_STATE_TAKEOVER'}, 'precision': 1.0, 'len': 2, 'is_signed_var':
+// False, 'offset': 0.0, 'physical_range': '[0|2]', 'bit': 1, 'type': 'enum',
+// 'order': 'motorola', 'physical_unit': ''}
+Steering_report_502::Steer_en_stateType Steeringreport502::steer_en_state(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 2);
+
+  Steering_report_502::Steer_en_stateType ret =
+      static_cast<Steering_report_502::Steer_en_stateType>(x);
+  return ret;
+}
+
+// config detail: {'name': 'steer_angle_actual', 'offset': -500.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[-500|500]',
+// 'bit': 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Steeringreport502::steer_angle_actual(const std::uint8_t* bytes,
+                                             int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 4);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.100000 + -500.000000;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_report_502.h
+++ b/modules/canbus/vehicle/devkit/protocol/steering_report_502.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Steeringreport502 : public ::apollo::drivers::canbus::ProtocolData<
+                              ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Steeringreport502();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'Steer_ANGLE_SPD_Actual', 'offset': 0.0,
+  // 'precision': 1.0, 'len': 8, 'is_signed_var': False, 'physical_range':
+  // '[0|0]', 'bit': 55, 'type': 'int', 'order': 'motorola', 'physical_unit':
+  // ''}
+  int steer_angle_spd_actual(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'description': 'Steer system communication fault', 'enum':
+  // {0: 'STEER_FLT2_NO_FAULT', 1:
+  // 'STEER_FLT2_STEER_SYSTEM_COMUNICATION_FAULT'}, 'precision': 1.0, 'len': 8,
+  // 'name': 'Steer_FLT2', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Steering_report_502::Steer_flt2Type steer_flt2(const std::uint8_t* bytes,
+                                                 const int32_t length) const;
+
+  // config detail: {'description': 'Steer system hardware fault', 'enum': {0:
+  // 'STEER_FLT1_NO_FAULT', 1: 'STEER_FLT1_STEER_SYSTEM_HARDWARE_FAULT'},
+  // 'precision': 1.0, 'len': 8, 'name': 'Steer_FLT1', 'is_signed_var': False,
+  // 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Steering_report_502::Steer_flt1Type steer_flt1(const std::uint8_t* bytes,
+                                                 const int32_t length) const;
+
+  // config detail: {'name': 'Steer_EN_state', 'enum': {0:
+  // 'STEER_EN_STATE_MANUAL', 1: 'STEER_EN_STATE_AUTO', 2:
+  // 'STEER_EN_STATE_TAKEOVER', 3: 'STEER_EN_STATE_STANDBY'}, 'precision': 1.0,
+  // 'len': 2, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|2]',
+  // 'bit': 1, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+  Steering_report_502::Steer_en_stateType steer_en_state(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'Steer_ANGLE_Actual', 'offset': -500.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[-500|500]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  double steer_angle_actual(const std::uint8_t* bytes,
+                            const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/steering_report_502_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/steering_report_502_test.cc
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/steering_report_502.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Steeringreport502Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Steeringreport502Test, General) {
+  uint8_t data[8] = {0x04, 0x01, 0x01, 0x14, 0x1E, 0x03, 0x04, 0x05};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Steeringreport502 steeringreport;
+  steeringreport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000100);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00010100);
+  EXPECT_EQ(data[4], 0b00011110);
+  EXPECT_EQ(data[5], 0b00000011);
+  EXPECT_EQ(data[6], 0b00000100);
+  EXPECT_EQ(data[7], 0b00000101);
+
+  EXPECT_EQ(cd.devkit().steering_report_502().steer_angle_spd_actual(), 4);
+  EXPECT_EQ(cd.devkit().steering_report_502().steer_flt2(), 1);
+  EXPECT_EQ(cd.devkit().steering_report_502().steer_flt1(), 1);
+  EXPECT_EQ(cd.devkit().steering_report_502().steer_en_state(), 0);
+  EXPECT_EQ(cd.devkit().steering_report_502().steer_angle_actual(), 15);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_command_100.cc
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_command_100.cc
@@ -1,0 +1,142 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/throttle_command_100.h"
+
+#include "modules/drivers/canbus/common/byte.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+const int32_t Throttlecommand100::ID = 0x100;
+
+// public
+Throttlecommand100::Throttlecommand100() { Reset(); }
+
+uint32_t Throttlecommand100::GetPeriod() const {
+  // TODO(All) :  modify every protocol's period manually
+  static const uint32_t PERIOD = 20 * 1000;
+  return PERIOD;
+}
+
+void Throttlecommand100::UpdateData(uint8_t* data) {
+  set_p_throttle_acc(data, throttle_acc_);
+  set_p_throttle_pedal_target(data, throttle_pedal_target_);
+  set_p_throttle_en_ctrl(data, throttle_en_ctrl_);
+  checksum_110_ =
+      data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6];
+  set_p_checksum_110(data, checksum_110_);
+}
+
+void Throttlecommand100::Reset() {
+  // TODO(All) :  you should check this manually
+  throttle_acc_ = 0.0;
+  checksum_110_ = 0;
+  throttle_pedal_target_ = 0.0;
+  throttle_en_ctrl_ = Throttle_command_100::THROTTLE_EN_CTRL_DISABLE;
+}
+
+Throttlecommand100* Throttlecommand100::set_throttle_acc(double throttle_acc) {
+  throttle_acc_ = throttle_acc;
+  return this;
+}
+
+// config detail: {'name': 'Throttle_Acc', 'offset': 0.0, 'precision': 0.01,
+// 'len': 10, 'is_signed_var': False, 'physical_range': '[0|10]', 'bit': 15,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+void Throttlecommand100::set_p_throttle_acc(uint8_t* data,
+                                            double throttle_acc) {
+  throttle_acc = ProtocolData::BoundedValue(0.0, 10.0, throttle_acc);
+  int x = throttle_acc / 0.010000;
+  uint8_t t = 0;
+
+  t = x & 0x3;
+  Byte to_set0(data + 2);
+  to_set0.set_value(t, 6, 2);
+  x >>= 2;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 1);
+  to_set1.set_value(t, 0, 8);
+}
+
+Throttlecommand100* Throttlecommand100::set_checksum_110(int checksum_110) {
+  checksum_110_ = checksum_110;
+  return this;
+}
+
+// config detail: {'name': 'CheckSum_110', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+void Throttlecommand100::set_p_checksum_110(uint8_t* data, int checksum_110) {
+  checksum_110 = ProtocolData::BoundedValue(0, 255, checksum_110);
+  int x = checksum_110;
+
+  Byte to_set(data + 7);
+  to_set.set_value(x, 0, 8);
+}
+
+Throttlecommand100* Throttlecommand100::set_throttle_pedal_target(
+    double throttle_pedal_target) {
+  throttle_pedal_target_ = throttle_pedal_target;
+  return this;
+}
+
+// config detail: {'name': 'Throttle_Pedal_Target', 'offset': 0.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+// 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+void Throttlecommand100::set_p_throttle_pedal_target(
+    uint8_t* data, double throttle_pedal_target) {
+  throttle_pedal_target =
+      ProtocolData::BoundedValue(0.0, 100.0, throttle_pedal_target);
+  int x = throttle_pedal_target / 0.100000;
+  uint8_t t = 0;
+
+  t = x & 0xFF;
+  Byte to_set0(data + 4);
+  to_set0.set_value(t, 0, 8);
+  x >>= 8;
+
+  t = x & 0xFF;
+  Byte to_set1(data + 3);
+  to_set1.set_value(t, 0, 8);
+}
+
+Throttlecommand100* Throttlecommand100::set_throttle_en_ctrl(
+    Throttle_command_100::Throttle_en_ctrlType throttle_en_ctrl) {
+  throttle_en_ctrl_ = throttle_en_ctrl;
+  return this;
+}
+
+// config detail: {'name': 'Throttle_EN_CTRL', 'enum': {0:
+// 'THROTTLE_EN_CTRL_DISABLE', 1: 'THROTTLE_EN_CTRL_ENABLE'}, 'precision': 1.0,
+// 'len': 1, 'is_signed_var': False, 'offset': 0.0, 'physical_range': '[0|1]',
+// 'bit': 0, 'type': 'enum', 'order': 'motorola', 'physical_unit': ''}
+void Throttlecommand100::set_p_throttle_en_ctrl(
+    uint8_t* data,
+    Throttle_command_100::Throttle_en_ctrlType throttle_en_ctrl) {
+  int x = throttle_en_ctrl;
+
+  Byte to_set(data + 0);
+  to_set.set_value(x, 0, 1);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_command_100.h
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_command_100.h
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Throttlecommand100 : public ::apollo::drivers::canbus::ProtocolData<
+                               ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+
+  Throttlecommand100();
+
+  uint32_t GetPeriod() const override;
+
+  void UpdateData(uint8_t* data) override;
+
+  void Reset() override;
+
+  // config detail: {'name': 'Throttle_Acc', 'offset': 0.0, 'precision': 0.01,
+  // 'len': 10, 'is_signed_var': False, 'physical_range': '[0|10]', 'bit': 15,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  Throttlecommand100* set_throttle_acc(double throttle_acc);
+
+  // config detail: {'name': 'CheckSum_110', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  Throttlecommand100* set_checksum_110(int checksum_110);
+
+  // config detail: {'name': 'Throttle_Pedal_Target', 'offset': 0.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[0|100]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Throttlecommand100* set_throttle_pedal_target(double throttle_pedal_target);
+
+  // config detail: {'name': 'Throttle_EN_CTRL', 'enum': {0:
+  // 'THROTTLE_EN_CTRL_DISABLE', 1: 'THROTTLE_EN_CTRL_ENABLE'},
+  // 'precision': 1.0, 'len': 1, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Throttlecommand100* set_throttle_en_ctrl(
+      Throttle_command_100::Throttle_en_ctrlType throttle_en_ctrl);
+
+ private:
+  // config detail: {'name': 'Throttle_Acc', 'offset': 0.0, 'precision': 0.005,
+  // 'len': 10, 'is_signed_var': False, 'physical_range': '[0|5.115]', 'bit':
+  // 15, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_throttle_acc(uint8_t* data, double throttle_acc);
+
+  // config detail: {'name': 'CheckSum_110', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|255]', 'bit': 63,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': ''}
+  void set_p_checksum_110(uint8_t* data, int checksum_110);
+
+  // config detail: {'name': 'Throttle_Pedal_Target', 'offset': 0.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[0|100]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_throttle_pedal_target(uint8_t* data, double throttle_pedal_target);
+
+  // config detail: {'name': 'Throttle_EN_CTRL', 'enum': {0:
+  // 'THROTTLE_EN_CTRL_DISABLE', 1: 'THROTTLE_EN_CTRL_ENABLE'},
+  // 'precision': 1.0, 'len': 1, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 0, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  void set_p_throttle_en_ctrl(
+      uint8_t* data,
+      Throttle_command_100::Throttle_en_ctrlType throttle_en_ctrl);
+
+ private:
+  double throttle_acc_;
+  int checksum_110_;
+  double throttle_pedal_target_;
+  Throttle_command_100::Throttle_en_ctrlType throttle_en_ctrl_;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_command_100_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_command_100_test.cc
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/throttle_command_100.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Throttlecommand100Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Throttlecommand100Test, simple) {
+  Throttlecommand100 throttle;
+  EXPECT_EQ(throttle.GetPeriod(), 20 * 1000);
+  uint8_t data[8] = {0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78};
+  throttle.UpdateData(data);
+  EXPECT_EQ(data[0], 0b01110000);
+  EXPECT_EQ(data[1], 0b00000000);
+  EXPECT_EQ(data[2], 0b00110011);
+  EXPECT_EQ(data[3], 0b00000000);
+  EXPECT_EQ(data[4], 0b00000000);
+  EXPECT_EQ(data[5], 0b01110110);
+  EXPECT_EQ(data[6], 0b01110111);
+  EXPECT_EQ(data[7], 0b01000010);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_report_500.cc
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_report_500.cc
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/throttle_report_500.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Throttlereport500::Throttlereport500() {}
+const int32_t Throttlereport500::ID = 0x500;
+
+void Throttlereport500::Parse(const std::uint8_t* bytes, int32_t length,
+                              ChassisDetail* chassis) const {
+  chassis->mutable_devkit()
+      ->mutable_throttle_report_500()
+      ->set_throttle_pedal_actual(throttle_pedal_actual(bytes, length));
+  chassis->mutable_devkit()->mutable_throttle_report_500()->set_throttle_flt2(
+      throttle_flt2(bytes, length));
+  chassis->mutable_devkit()->mutable_throttle_report_500()->set_throttle_flt1(
+      throttle_flt1(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_throttle_report_500()
+      ->set_throttle_en_state(throttle_en_state(bytes, length));
+  chassis->mutable_check_response()->set_is_vcu_online(
+      throttle_en_state(bytes, length) == 1);
+}
+
+// config detail: {'name': 'throttle_pedal_actual', 'offset': 0.0, 'precision':
+// 0.1, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit':
+// 31, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Throttlereport500::throttle_pedal_actual(const std::uint8_t* bytes,
+                                                int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 4);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.100000;
+  return ret;
+}
+
+// config detail: {'description': 'Drive system communication fault', 'enum':
+// {0: 'THROTTLE_FLT2_NO_FAULT', 1:
+// 'THROTTLE_FLT2_DRIVE_SYSTEM_COMUNICATION_FAULT'}, 'precision': 1.0, 'len': 8,
+// 'name': 'throttle_flt2', 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Throttle_report_500::Throttle_flt2Type Throttlereport500::throttle_flt2(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Throttle_report_500::Throttle_flt2Type ret =
+      static_cast<Throttle_report_500::Throttle_flt2Type>(x);
+  return ret;
+}
+
+// config detail: {'description': 'Drive system hardware fault', 'enum': {0:
+// 'THROTTLE_FLT1_NO_FAULT', 1: 'THROTTLE_FLT1_DRIVE_SYSTEM_HARDWARE_FAULT'},
+// 'precision': 1.0, 'len': 8, 'name': 'throttle_flt1', 'is_signed_var': False,
+// 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum', 'order':
+// 'motorola', 'physical_unit': ''}
+Throttle_report_500::Throttle_flt1Type Throttlereport500::throttle_flt1(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  Throttle_report_500::Throttle_flt1Type ret =
+      static_cast<Throttle_report_500::Throttle_flt1Type>(x);
+  return ret;
+}
+
+// config detail: {'name': 'throttle_en_state', 'enum': {0:
+// 'THROTTLE_EN_STATE_MANUAL', 1: 'THROTTLE_EN_STATE_AUTO', 2:
+// 'THROTTLE_EN_STATE_TAKEOVER', 3: 'THROTTLE_EN_STATE_STANDBY'},
+// 'precision': 1.0, 'len': 2, 'is_signed_var': False, 'offset': 0.0,
+// 'physical_range': '[0|2]', 'bit': 1, 'type': 'enum', 'order': 'motorola',
+// 'physical_unit': ''}
+Throttle_report_500::Throttle_en_stateType Throttlereport500::throttle_en_state(
+    const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 2);
+
+  Throttle_report_500::Throttle_en_stateType ret =
+      static_cast<Throttle_report_500::Throttle_en_stateType>(x);
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_report_500.h
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_report_500.h
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Throttlereport500 : public ::apollo::drivers::canbus::ProtocolData<
+                              ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Throttlereport500();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'Throttle_Pedal_Actual', 'offset': 0.0,
+  // 'precision': 0.1, 'len': 16, 'is_signed_var': False, 'physical_range':
+  // '[0|100]', 'bit': 31, 'type': 'double', 'order': 'motorola',
+  // 'physical_unit': ''}
+  double throttle_pedal_actual(const std::uint8_t* bytes,
+                               const int32_t length) const;
+
+  // config detail: {'description': 'Drive system communication fault', 'enum':
+  // {0: 'THROTTLE_FLT2_NO_FAULT', 1:
+  // 'THROTTLE_FLT2_DRIVE_SYSTEM_COMUNICATION_FAULT'}, 'precision': 1.0, 'len':
+  // 8, 'name': 'Throttle_FLT2', 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|1]', 'bit': 23, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Throttle_report_500::Throttle_flt2Type throttle_flt2(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'description': 'Drive system hardware fault', 'enum': {0:
+  // 'THROTTLE_FLT1_NO_FAULT', 1: 'THROTTLE_FLT1_DRIVE_SYSTEM_HARDWARE_FAULT'},
+  // 'precision': 1.0, 'len': 8, 'name': 'Throttle_FLT1', 'is_signed_var':
+  // False, 'offset': 0.0, 'physical_range': '[0|1]', 'bit': 15, 'type': 'enum',
+  // 'order': 'motorola', 'physical_unit': ''}
+  Throttle_report_500::Throttle_flt1Type throttle_flt1(
+      const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'Throttle_EN_state', 'enum': {0:
+  // 'THROTTLE_EN_STATE_MANUAL', 1: 'THROTTLE_EN_STATE_AUTO', 2:
+  // 'THROTTLE_EN_STATE_TAKEOVER', 3: 'THROTTLE_EN_STATE_STANDBY'},
+  // 'precision': 1.0, 'len': 2, 'is_signed_var': False, 'offset': 0.0,
+  // 'physical_range': '[0|2]', 'bit': 1, 'type': 'enum', 'order': 'motorola',
+  // 'physical_unit': ''}
+  Throttle_report_500::Throttle_en_stateType throttle_en_state(
+      const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/throttle_report_500_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/throttle_report_500_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/throttle_report_500.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Throttlereport500Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Throttlereport500Test, General) {
+  uint8_t data[8] = {0x07, 0x01, 0x01, 0x02, 0x8A, 0x03, 0x04, 0x05};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Throttlereport500 throttlereport;
+  throttlereport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000111);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000010);
+  EXPECT_EQ(data[4], 0b10001010);
+  EXPECT_EQ(data[5], 0b00000011);
+  EXPECT_EQ(data[6], 0b00000100);
+  EXPECT_EQ(data[7], 0b00000101);
+
+  EXPECT_EQ(cd.devkit().throttle_report_500().throttle_pedal_actual(), 65);
+  EXPECT_EQ(cd.devkit().throttle_report_500().throttle_flt2(), 1);
+  EXPECT_EQ(cd.devkit().throttle_report_500().throttle_flt1(), 1);
+  EXPECT_EQ(cd.devkit().throttle_report_500().throttle_en_state(), 3);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.cc
@@ -1,0 +1,115 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ultrsensor1507::Ultrsensor1507() {}
+const int32_t Ultrsensor1507::ID = 0x507;
+
+void Ultrsensor1507::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_ultr_sensor_1_507()->set_uiuss9_tof_direct(
+      uiuss9_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_1_507()->set_uiuss8_tof_direct(
+      uiuss8_tof_direct(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_1_507()
+      ->set_uiuss11_tof_direct(uiuss11_tof_direct(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_1_507()
+      ->set_uiuss10_tof_direct(uiuss10_tof_direct(bytes, length));
+}
+
+// config detail: {'name': 'uiuss9_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': 'cm'}
+double Ultrsensor1507::uiuss9_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss8_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': 'cm'}
+double Ultrsensor1507::uiuss8_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss11_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': 'cm'}
+double Ultrsensor1507::uiuss11_tof_direct(const std::uint8_t* bytes,
+                                          int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss10_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': 'cm'}
+double Ultrsensor1507::uiuss10_tof_direct(const std::uint8_t* bytes,
+                                          int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Ultrsensor1507 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ultrsensor1507();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'uiUSS9_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss9_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS8_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss8_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS11_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss11_tof_direct(const std::uint8_t* bytes,
+                            const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS10_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss10_tof_direct(const std::uint8_t* bytes,
+                            const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_1_507.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Ultrsensor1507Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ultrsensor1507Test, General) {
+  uint8_t data[8] = {0xE2, 0x95, 0x06, 0x58, 0x08, 0xD6, 0x02, 0x44};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ultrsensor1507 ultrsensor1;
+  ultrsensor1.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b11100010);
+  EXPECT_EQ(data[1], 0b10010101);
+  EXPECT_EQ(data[2], 0b00000110);
+  EXPECT_EQ(data[3], 0b01011000);
+  EXPECT_EQ(data[4], 0b00001000);
+  EXPECT_EQ(data[5], 0b11010110);
+  EXPECT_EQ(data[6], 0b00000010);
+  EXPECT_EQ(data[7], 0b01000100);
+
+  EXPECT_EQ(cd.devkit().ultr_sensor_1_507().uiuss9_tof_direct(), 28);
+  EXPECT_EQ(cd.devkit().ultr_sensor_1_507().uiuss8_tof_direct(), 1000);
+  EXPECT_EQ(cd.devkit().ultr_sensor_1_507().uiuss11_tof_direct(), 10);
+  EXPECT_EQ(cd.devkit().ultr_sensor_1_507().uiuss10_tof_direct(), 39);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.cc
@@ -1,0 +1,117 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ultrsensor2508::Ultrsensor2508() {}
+const int32_t Ultrsensor2508::ID = 0x508;
+
+void Ultrsensor2508::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_2_508()
+      ->set_uiuss9_tof_indirect(uiuss9_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_2_508()
+      ->set_uiuss8_tof_indirect(uiuss8_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_2_508()
+      ->set_uiuss11_tof_indirect(uiuss11_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_2_508()
+      ->set_uiuss10_tof_indirect(uiuss10_tof_indirect(bytes, length));
+}
+
+// config detail: {'name': 'uiuss9_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor2508::uiuss9_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss8_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor2508::uiuss8_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss11_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor2508::uiuss11_tof_indirect(const std::uint8_t* bytes,
+                                            int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss10_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor2508::uiuss10_tof_indirect(const std::uint8_t* bytes,
+                                            int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Ultrsensor2508 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ultrsensor2508();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'uiUSS9_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss9_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS8_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss8_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS11_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss11_tof_indirect(const std::uint8_t* bytes,
+                              const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS10_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss10_tof_indirect(const std::uint8_t* bytes,
+                              const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_2_508.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Ultrsensor2508Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ultrsensor2508Test, General) {
+  uint8_t data[8] = {0xE2, 0x95, 0x06, 0x58, 0x08, 0xD6, 0x02, 0x44};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ultrsensor2508 ultrsensor2;
+  ultrsensor2.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b11100010);
+  EXPECT_EQ(data[1], 0b10010101);
+  EXPECT_EQ(data[2], 0b00000110);
+  EXPECT_EQ(data[3], 0b01011000);
+  EXPECT_EQ(data[4], 0b00001000);
+  EXPECT_EQ(data[5], 0b11010110);
+  EXPECT_EQ(data[6], 0b00000010);
+  EXPECT_EQ(data[7], 0b01000100);
+
+  EXPECT_EQ(cd.devkit().ultr_sensor_2_508().uiuss9_tof_indirect(), 28);
+  EXPECT_EQ(cd.devkit().ultr_sensor_2_508().uiuss8_tof_indirect(), 1000);
+  EXPECT_EQ(cd.devkit().ultr_sensor_2_508().uiuss11_tof_indirect(), 10);
+  EXPECT_EQ(cd.devkit().ultr_sensor_2_508().uiuss10_tof_indirect(), 39);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.cc
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ultrsensor3509::Ultrsensor3509() {}
+const int32_t Ultrsensor3509::ID = 0x509;
+
+void Ultrsensor3509::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_ultr_sensor_3_509()->set_uiuss5_tof_direct(
+      uiuss5_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_3_509()->set_uiuss4_tof_direct(
+      uiuss4_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_3_509()->set_uiuss3_tof_direct(
+      uiuss3_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_3_509()->set_uiuss2_tof_direct(
+      uiuss2_tof_direct(bytes, length));
+}
+
+// config detail: {'name': 'uiuss5_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor3509::uiuss5_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss4_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor3509::uiuss4_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss3_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor3509::uiuss3_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss2_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor3509::uiuss2_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Ultrsensor3509 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ultrsensor3509();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'uiUSS5_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss5_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS4_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss4_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS3_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss3_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS2_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss2_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_3_509.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Ultrsensor3509Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ultrsensor3509Test, General) {
+  uint8_t data[8] = {0xE2, 0x95, 0x06, 0x58, 0x08, 0xD6, 0x02, 0x44};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ultrsensor3509 ultrsensor3;
+  ultrsensor3.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b11100010);
+  EXPECT_EQ(data[1], 0b10010101);
+  EXPECT_EQ(data[2], 0b00000110);
+  EXPECT_EQ(data[3], 0b01011000);
+  EXPECT_EQ(data[4], 0b00001000);
+  EXPECT_EQ(data[5], 0b11010110);
+  EXPECT_EQ(data[6], 0b00000010);
+  EXPECT_EQ(data[7], 0b01000100);
+
+  EXPECT_EQ(cd.devkit().ultr_sensor_3_509().uiuss5_tof_direct(), 10);
+  EXPECT_EQ(cd.devkit().ultr_sensor_3_509().uiuss4_tof_direct(), 39);
+  EXPECT_EQ(cd.devkit().ultr_sensor_3_509().uiuss3_tof_direct(), 28);
+  EXPECT_EQ(cd.devkit().ultr_sensor_3_509().uiuss2_tof_direct(), 1000);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.cc
@@ -1,0 +1,117 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ultrsensor4510::Ultrsensor4510() {}
+const int32_t Ultrsensor4510::ID = 0x510;
+
+void Ultrsensor4510::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_4_510()
+      ->set_uiuss5_tof_indirect(uiuss5_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_4_510()
+      ->set_uiuss4_tof_indirect(uiuss4_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_4_510()
+      ->set_uiuss3_tof_indirect(uiuss3_tof_indirect(bytes, length));
+  chassis->mutable_devkit()
+      ->mutable_ultr_sensor_4_510()
+      ->set_uiuss2_tof_indirect(uiuss2_tof_indirect(bytes, length));
+}
+
+// config detail: {'name': 'uiuss5_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor4510::uiuss5_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss4_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor4510::uiuss4_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss3_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor4510::uiuss3_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss2_tof_indirect', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor4510::uiuss2_tof_indirect(const std::uint8_t* bytes,
+                                           int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Ultrsensor4510 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ultrsensor4510();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'uiUSS5_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss5_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS4_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss4_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS3_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 23, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss3_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS2_ToF_Indirect', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss2_tof_indirect(const std::uint8_t* bytes,
+                             const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_4_510.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Ultrsensor4510Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ultrsensor4510Test, General) {
+  uint8_t data[8] = {0xE2, 0x95, 0x06, 0x58, 0x08, 0xD6, 0x02, 0x44};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ultrsensor4510 ultrsensor4;
+  ultrsensor4.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b11100010);
+  EXPECT_EQ(data[1], 0b10010101);
+  EXPECT_EQ(data[2], 0b00000110);
+  EXPECT_EQ(data[3], 0b01011000);
+  EXPECT_EQ(data[4], 0b00001000);
+  EXPECT_EQ(data[5], 0b11010110);
+  EXPECT_EQ(data[6], 0b00000010);
+  EXPECT_EQ(data[7], 0b01000100);
+
+  EXPECT_EQ(cd.devkit().ultr_sensor_4_510().uiuss5_tof_indirect(), 10);
+  EXPECT_EQ(cd.devkit().ultr_sensor_4_510().uiuss4_tof_indirect(), 39);
+  EXPECT_EQ(cd.devkit().ultr_sensor_4_510().uiuss3_tof_indirect(), 28);
+  EXPECT_EQ(cd.devkit().ultr_sensor_4_510().uiuss2_tof_indirect(), 1000);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.cc
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Ultrsensor5511::Ultrsensor5511() {}
+const int32_t Ultrsensor5511::ID = 0x511;
+
+void Ultrsensor5511::Parse(const std::uint8_t* bytes, int32_t length,
+                           ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_ultr_sensor_5_511()->set_uiuss7_tof_direct(
+      uiuss7_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_5_511()->set_uiuss6_tof_direct(
+      uiuss6_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_5_511()->set_uiuss1_tof_direct(
+      uiuss1_tof_direct(bytes, length));
+  chassis->mutable_devkit()->mutable_ultr_sensor_5_511()->set_uiuss0_tof_direct(
+      uiuss0_tof_direct(bytes, length));
+}
+
+// config detail: {'name': 'uiuss7_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor5511::uiuss7_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss6_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor5511::uiuss6_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss1_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 16, 'type': 'double', 'order': 'intel', 'physical_unit': ''}
+double Ultrsensor5511::uiuss1_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 3);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 2);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+
+// config detail: {'name': 'uiuss0_tof_direct', 'offset': 0.0, 'precision':
+// 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+// 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Ultrsensor5511::uiuss0_tof_direct(const std::uint8_t* bytes,
+                                         int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x / 58;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Ultrsensor5511 : public ::apollo::drivers::canbus::ProtocolData<
+                           ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Ultrsensor5511();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'uiUSS7_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 55, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss7_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS6_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 39, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss6_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS1_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 16, 'type': 'double', 'order': 'intel', 'physical_unit': ''}
+  double uiuss1_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+
+  // config detail: {'name': 'uiUSS0_ToF_Direct', 'offset': 0.0, 'precision':
+  // 0.01724, 'len': 16, 'is_signed_var': False, 'physical_range': '[0|65535]',
+  // 'bit': 7, 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double uiuss0_tof_direct(const std::uint8_t* bytes,
+                           const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/ultr_sensor_5_511.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Ultrsensor5511Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Ultrsensor5511Test, General) {
+  uint8_t data[8] = {0xE2, 0x95, 0x06, 0x58, 0x08, 0xD6, 0x02, 0x44};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Ultrsensor5511 ultrsensor5;
+  ultrsensor5.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b11100010);
+  EXPECT_EQ(data[1], 0b10010101);
+  EXPECT_EQ(data[2], 0b00000110);
+  EXPECT_EQ(data[3], 0b01011000);
+  EXPECT_EQ(data[4], 0b00001000);
+  EXPECT_EQ(data[5], 0b11010110);
+  EXPECT_EQ(data[6], 0b00000010);
+  EXPECT_EQ(data[7], 0b01000100);
+
+  EXPECT_EQ(cd.devkit().ultr_sensor_5_511().uiuss7_tof_direct(), 10);
+  EXPECT_EQ(cd.devkit().ultr_sensor_5_511().uiuss6_tof_direct(), 39);
+  EXPECT_EQ(cd.devkit().ultr_sensor_5_511().uiuss1_tof_direct(), 388);
+  EXPECT_EQ(cd.devkit().ultr_sensor_5_511().uiuss0_tof_direct(), 1000);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505.cc
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505.cc
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/vcu_report_505.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Vcureport505::Vcureport505() {}
+const int32_t Vcureport505::ID = 0x505;
+
+void Vcureport505::Parse(const std::uint8_t* bytes, int32_t length,
+                         ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_vcu_report_505()->set_acc(
+      acc(bytes, length));
+  chassis->mutable_devkit()->mutable_vcu_report_505()->set_speed(
+      speed(bytes, length));
+}
+
+// config detail: {'name': 'acc', 'offset': 0.0, 'precision': 0.01, 'len': 12,
+// 'is_signed_var': True, 'physical_range': '[-10|10]', 'bit': 7, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+double Vcureport505::acc(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(4, 4);
+  x <<= 4;
+  x |= t;
+
+  x <<= 20;
+  x >>= 20;
+
+  double ret = x * 0.010000;
+  return ret;
+}
+
+// config detail: {'name': 'speed', 'offset': 0.0, 'precision': 0.001, 'len':
+// 16, 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 23,
+// 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+double Vcureport505::speed(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505.h
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Vcureport505 : public ::apollo::drivers::canbus::ProtocolData<
+                         ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Vcureport505();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'ACC', 'offset': 0.0, 'precision': 0.01, 'len': 12,
+  // 'is_signed_var': True, 'physical_range': '[-10|10]', 'bit': 7, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': ''}
+  double acc(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'SPEED', 'offset': 0.0, 'precision': 0.001, 'len':
+  // 16, 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 23,
+  // 'type': 'double', 'order': 'motorola', 'physical_unit': ''}
+  double speed(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505_test.cc
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/vcu_report_505.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Vcureport505Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Vcureport505Test, General) {
+  uint8_t data[8] = {0x07, 0x01, 0x01, 0x02, 0x8A, 0x03, 0x04, 0x05};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Vcureport505 vcureport;
+  vcureport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000111);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000010);
+  EXPECT_EQ(data[4], 0b10001010);
+  EXPECT_EQ(data[5], 0b00000011);
+  EXPECT_EQ(data[6], 0b00000100);
+  EXPECT_EQ(data[7], 0b00000101);
+
+  EXPECT_EQ(cd.devkit().vcu_report_505().acc(), 1.12);
+  EXPECT_EQ(cd.devkit().vcu_report_505().speed(), 0.258);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.cc
+++ b/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.cc
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h"
+
+#include "glog/logging.h"
+#include "modules/drivers/canbus/common/byte.h"
+#include "modules/drivers/canbus/common/canbus_consts.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+using ::apollo::drivers::canbus::Byte;
+
+Wheelspeedreport506::Wheelspeedreport506() {}
+const int32_t Wheelspeedreport506::ID = 0x506;
+
+void Wheelspeedreport506::Parse(const std::uint8_t* bytes, int32_t length,
+                                ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_wheelspeed_report_506()->set_rr(
+      rr(bytes, length));
+  chassis->mutable_devkit()->mutable_wheelspeed_report_506()->set_rl(
+      rl(bytes, length));
+  chassis->mutable_devkit()->mutable_wheelspeed_report_506()->set_fr(
+      fr(bytes, length));
+  chassis->mutable_devkit()->mutable_wheelspeed_report_506()->set_fl(
+      fl(bytes, length));
+}
+
+// config detail: {'name': 'rr', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+// 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 55, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+double Wheelspeedreport506::rr(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 6);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 7);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+
+// config detail: {'name': 'rl', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+// 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 39, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+double Wheelspeedreport506::rl(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 4);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 5);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+
+// config detail: {'name': 'fr', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+// 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 23, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+double Wheelspeedreport506::fr(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 2);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 3);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+
+// config detail: {'name': 'fl', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+// 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 7, 'type':
+// 'double', 'order': 'motorola', 'physical_unit': ''}
+double Wheelspeedreport506::fl(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 0);
+  int32_t x = t0.get_byte(0, 8);
+
+  Byte t1(bytes + 1);
+  int32_t t = t1.get_byte(0, 8);
+  x <<= 8;
+  x |= t;
+
+  double ret = x * 0.001000;
+  return ret;
+}
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h
+++ b/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#pragma once
+
+#include "modules/canbus/proto/chassis_detail.pb.h"
+#include "modules/drivers/canbus/can_comm/protocol_data.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+
+class Wheelspeedreport506 : public ::apollo::drivers::canbus::ProtocolData<
+                                ::apollo::canbus::ChassisDetail> {
+ public:
+  static const int32_t ID;
+  Wheelspeedreport506();
+  void Parse(const std::uint8_t* bytes, int32_t length,
+             ChassisDetail* chassis) const override;
+
+ private:
+  // config detail: {'name': 'RR', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+  // 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 55, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': ''}
+  double rr(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'RL', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+  // 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 39, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': ''}
+  double rl(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'FR', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+  // 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 23, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': ''}
+  double fr(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'name': 'FL', 'offset': 0.0, 'precision': 0.001, 'len': 16,
+  // 'is_signed_var': False, 'physical_range': '[0|65.535]', 'bit': 7, 'type':
+  // 'double', 'order': 'motorola', 'physical_unit': ''}
+  double fl(const std::uint8_t* bytes, const int32_t length) const;
+};
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506_test.cc
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/canbus/vehicle/devkit/protocol/wheelspeed_report_506.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace canbus {
+namespace devkit {
+class Wheelspeedreport506Test : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+};
+
+TEST_F(Wheelspeedreport506Test, General) {
+  uint8_t data[8] = {0x07, 0x01, 0x01, 0x02, 0x8A, 0x03, 0x04, 0x05};
+  int32_t length = 8;
+  ChassisDetail cd;
+  Wheelspeedreport506 wheelspeedreport;
+  wheelspeedreport.Parse(data, length, &cd);
+
+  EXPECT_EQ(data[0], 0b00000111);
+  EXPECT_EQ(data[1], 0b00000001);
+  EXPECT_EQ(data[2], 0b00000001);
+  EXPECT_EQ(data[3], 0b00000010);
+  EXPECT_EQ(data[4], 0b10001010);
+  EXPECT_EQ(data[5], 0b00000011);
+  EXPECT_EQ(data[6], 0b00000100);
+  EXPECT_EQ(data[7], 0b00000101);
+
+  EXPECT_EQ(cd.devkit().wheelspeed_report_506().rr(), 1.029);
+  EXPECT_EQ(cd.devkit().wheelspeed_report_506().rl(), 35.331);
+  EXPECT_EQ(cd.devkit().wheelspeed_report_506().fr(), 0.258);
+  EXPECT_EQ(cd.devkit().wheelspeed_report_506().fl(), 1.793);
+}
+
+}  // namespace devkit
+}  // namespace canbus
+}  // namespace apollo

--- a/modules/canbus/vehicle/vehicle_factory.cc
+++ b/modules/canbus/vehicle/vehicle_factory.cc
@@ -15,8 +15,10 @@
  *****************************************************************************/
 
 #include "modules/canbus/vehicle/vehicle_factory.h"
+
 #include "modules/canbus/proto/vehicle_parameter.pb.h"
 #include "modules/canbus/vehicle/ch/ch_vehicle_factory.h"
+#include "modules/canbus/vehicle/devkit/devkit_vehicle_factory.h"
 #include "modules/canbus/vehicle/ge3/ge3_vehicle_factory.h"
 #include "modules/canbus/vehicle/gem/gem_vehicle_factory.h"
 #include "modules/canbus/vehicle/lexus/lexus_vehicle_factory.h"
@@ -52,6 +54,9 @@ void VehicleFactory::RegisterVehicleFactory() {
   });
   Register(apollo::common::CH,
            []() -> AbstractVehicleFactory * { return new ChVehicleFactory(); });
+  Register(apollo::common::DKIT, []() -> AbstractVehicleFactory * {
+    return new DevkitVehicleFactory();
+  });
 }
 
 std::unique_ptr<AbstractVehicleFactory> VehicleFactory::CreateVehicle(

--- a/modules/canbus/vehicle/vehicle_factory_test.cc
+++ b/modules/canbus/vehicle/vehicle_factory_test.cc
@@ -17,7 +17,6 @@
 #include "modules/canbus/vehicle/vehicle_factory.h"
 
 #include "gtest/gtest.h"
-
 #include "modules/canbus/proto/vehicle_parameter.pb.h"
 
 namespace apollo {

--- a/modules/common/configs/proto/vehicle_config.proto
+++ b/modules/common/configs/proto/vehicle_config.proto
@@ -34,6 +34,7 @@ enum VehicleBrand {
   WEY = 5;
   ZHONGYUN = 6;
   CH = 7;
+  DKIT = 8;
 }
 
 message VehicleID {


### PR DESCRIPTION
Canbus: add a new general DKIT vehicle canbus  code easily to be adaptive for developers. 
The code has been tested, lint, checked.