### PR TITLE
Drivers: fix bug of hermes_can unit test 

### DIFF
--- a/modules/drivers/canbus/can_client/hermes_can/hermes_can_client.h
+++ b/modules/drivers/canbus/can_client/hermes_can/hermes_can_client.h
@@ -106,7 +106,7 @@ class HermesCanClient : public CanClient {
   void SetInited(bool init);
 
  private:
-  bool _is_init;
+  bool _is_init = false;
   bcan_hdl_t _dev_handler;
   CANCardParameter::CANChannelId _card_port;
   bcan_msg_t _send_frames[MAX_CAN_SEND_FRAME_LEN];

--- a/modules/drivers/canbus/can_client/hermes_can/hermes_can_client_test.cc
+++ b/modules/drivers/canbus/can_client/hermes_can/hermes_can_client_test.cc
@@ -29,11 +29,11 @@ TEST(HermesCanClient, init) {
   CANCardParameter param;
   param.set_brand(CANCardParameter::HERMES_CAN);
   param.set_channel_id(CANCardParameter::CHANNEL_ID_ZERO);
-  std::unique_ptr<HermesCanClient> hermes_can =
-      std::unique_ptr<HermesCanClient>(new HermesCanClient());
-  EXPECT_TRUE(hermes_can.get()->Init(param));
-  EXPECT_EQ(hermes_can.get()->Start(), ErrorCode::CAN_CLIENT_ERROR_BASE);
-  // EXPECT_EQ(hermes_can.get()->Start(), ErrorCode::OK);
+  HermesCanClient hermes_can;
+  EXPECT_TRUE(hermes_can.Init(param));
+  EXPECT_EQ(hermes_can.Start(), ErrorCode::CAN_CLIENT_ERROR_BASE);
+  // EXPECT_EQ(hermes_can.Start(), ErrorCode::OK);
+  hermes_can.Stop();
 }
 
 TEST(HermesCanClient, send) {
@@ -86,8 +86,8 @@ TEST(HermesCanClient, receiver) {
 }  // namespace drivers
 }  // namespace apollo
 
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  int ret = RUN_ALL_TESTS();
-  return ret;
-}
+// int main(int argc, char **argv) {
+//   ::testing::InitGoogleTest(&argc, argv);
+//   int ret = RUN_ALL_TESTS();
+//   return ret;
+// }


### PR DESCRIPTION
By correcting the flag used in destructor.

Cherry-picked from PR for master.


