### PR TITLE
Bazel: Enable apollo_config.sh --noninteractive by default

### DIFF
--- a/modules/localization/msf/local_map/lossless_map/BUILD
+++ b/modules/localization/msf/local_map/lossless_map/BUILD
@@ -31,8 +31,7 @@ filegroup(
 
 cc_test(
     name = "localization_msf_local_map_pool_test",
-    size = "medium",
-    timeout = "moderate",
+    size = "small",
     srcs = ["map_pool_test.cc"],
     copts = [
         "-fno-access-control",
@@ -50,8 +49,7 @@ cc_test(
 
 cc_test(
     name = "localization_msf_lossless_map_config_test",
-    size = "medium",
-    timeout = "moderate",
+    size = "small",
     srcs = ["lossless_map_config_test.cc"],
     data = [":localization_msf_local_map_test_data"],
     deps = [

--- a/scripts/apollo_config.sh
+++ b/scripts/apollo_config.sh
@@ -45,13 +45,13 @@ function config_interactive() {
 function config() {
     local stage="${STAGE}"
     if [ $# -eq 0 ]; then
-        config_interactive
+        config_noninteractive
     else
         local mode="$1" ; shift
-        if [[ "${mode}" == "--noninteractive" ]]; then
-            config_noninteractive "$@"
+        if [[ "${mode}" == "--interactive" || "${mode}" == "-i" ]]; then
+            config_interactive "$@"
         else
-            config_interactive
+            config_noninteractive
         fi
     fi
 }


### PR DESCRIPTION
And fix bazel test warnings.
