### PR TITLE
Perception:add a gflag to make height files could be specified in function SetCameraHeight

### DIFF
--- a/modules/common/configs/config_gflags.cc
+++ b/modules/common/configs/config_gflags.cc
@@ -77,3 +77,7 @@ DEFINE_bool(state_transform_to_com_drive, true,
             "rear-axis to center of mass, during forward driving");
 DEFINE_bool(multithread_run, false,
             "multi-thread run flag mainly used by simulation");
+DEFINE_string(
+    lidar_height_filename,
+    "velodyne128_height.yaml",
+    "lidar height file");

--- a/modules/common/configs/config_gflags.h
+++ b/modules/common/configs/config_gflags.h
@@ -51,3 +51,4 @@ DECLARE_bool(reverse_heading_vehicle_state);
 DECLARE_bool(state_transform_to_com_reverse);
 DECLARE_bool(state_transform_to_com_drive);
 DECLARE_bool(multithread_run);
+DECLARE_string(lidar_height_filename);

--- a/modules/perception/onboard/component/fusion_camera_detection_component.cc
+++ b/modules/perception/onboard/component/fusion_camera_detection_component.cc
@@ -71,7 +71,7 @@ bool SetCameraHeight(const std::string &sensor_name,
   float camera_offset = 0.0f;
   try {
     YAML::Node lidar_height =
-        YAML::LoadFile(params_dir + "/" + "velodyne128_height.yaml");
+        YAML::LoadFile(params_dir + "/" + FLAGS_lidar_height_filename);
     base_h = lidar_height["vehicle"]["parameters"]["height"].as<float>();
     AINFO << base_h;
     YAML::Node camera_ex =


### PR DESCRIPTION
1、add a gflag to make height files could be specified as other lidar_height_files rather than "velodyne128_height.yaml“ only in function SetCameraHeight