### PR TITLE
Bazel: test:unit_test no longer implies '-c dbg'

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -83,7 +83,7 @@ test --test_env=LD_LIBRARY_PATH
 # By default prints output only from failed tests.
 test --test_output=errors
 
-test:unit_test -c dbg --test_verbose_timeout_warnings
+test:unit_test --test_verbose_timeout_warnings
 
 test:coverage --copt=--coverage
 test:coverage --cxxopt=--coverage


### PR DESCRIPTION
Since our bazel configuration default to `--config=dbg`, and consider that `unit_test` can be run in `dbg` or `opt` mode. So we'd better make the two (`--config=unit_test` and `-c dbg`) options independent.