### PR TITLE
Support USE_SIM_TIME mode in CyberRT

### DIFF
--- a/cyber/BUILD
+++ b/cyber/BUILD
@@ -7,7 +7,7 @@ cc_library(
     name = "cyber",
     linkstatic = False,
     deps = [
-        "//cyber:cyber_core",
+        ":init",
     ],
 )
 
@@ -23,7 +23,7 @@ cc_binary(
     linkopts = ["-pthread"],
     linkstatic = False,
     deps = [
-        ":cyber_core",
+        ":init",
         "//cyber/proto:dag_conf_cc_proto",
     ],
 )
@@ -47,11 +47,13 @@ cc_library(
     srcs = ["init.cc"],
     hdrs = ["init.h"],
     deps = [
+        "//cyber:cyber_core",
         "//cyber:state",
         "//cyber/logger:async_logger",
         "//cyber/node",
         "//cyber/sysmo",
         "//cyber/timer:timing_wheel",
+        "//cyber/proto:clock_cc_proto",
     ],
 )
 
@@ -62,7 +64,6 @@ cc_library(
     linkopts = ["-lrt"],
     deps = [
         "//cyber:binary",
-        "//cyber:init",
         "//cyber:state",
         "//cyber/base",
         "//cyber/blocker:blocker_manager",

--- a/cyber/class_loader/BUILD
+++ b/cyber/class_loader/BUILD
@@ -17,7 +17,6 @@ cc_library(
         "utility/class_loader_utility.h",
     ],
     deps = [
-        "//cyber:init",
         "//cyber/common:log",
         "@poco//:PocoFoundation",
     ],

--- a/cyber/class_loader/class_loader_test.cc
+++ b/cyber/class_loader/class_loader_test.cc
@@ -20,11 +20,11 @@
 #include <thread>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 #include "cyber/class_loader/class_loader_manager.h"
 #include "cyber/class_loader/test/base.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
+#include "gtest/gtest.h"
 
 const char LIBRARY_1[] =
     "/apollo/bazel-bin/cyber/class_loader/test/libplugin1.so";

--- a/cyber/cyber.h
+++ b/cyber/cyber.h
@@ -23,7 +23,6 @@
 
 #include "cyber/common/log.h"
 #include "cyber/component/component.h"
-#include "cyber/init.h"
 #include "cyber/node/node.h"
 #include "cyber/task/task.h"
 #include "cyber/time/time.h"

--- a/cyber/examples/listener.cc
+++ b/cyber/examples/listener.cc
@@ -15,6 +15,7 @@
  *****************************************************************************/
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/examples/proto/examples.pb.h"
 
 void MessageCallback(

--- a/cyber/examples/paramserver.cc
+++ b/cyber/examples/paramserver.cc
@@ -15,6 +15,7 @@
  *****************************************************************************/
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/parameter/parameter_client.h"
 #include "cyber/parameter/parameter_server.h"
 

--- a/cyber/examples/record.cc
+++ b/cyber/examples/record.cc
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/message/raw_message.h"
 #include "cyber/proto/record.pb.h"
 #include "cyber/record/record_message.h"

--- a/cyber/examples/service.cc
+++ b/cyber/examples/service.cc
@@ -16,6 +16,7 @@
 
 #include "cyber/cyber.h"
 #include "cyber/examples/proto/examples.pb.h"
+#include "cyber/init.h"
 
 using apollo::cyber::examples::proto::Driver;
 

--- a/cyber/examples/talker.cc
+++ b/cyber/examples/talker.cc
@@ -16,6 +16,7 @@
 
 #include "cyber/cyber.h"
 #include "cyber/examples/proto/examples.pb.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
 #include "cyber/time/time.h"
 

--- a/cyber/init.cc
+++ b/cyber/init.cc
@@ -19,15 +19,19 @@
 #include <libgen.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <csignal>
 #include <cstdio>
 #include <ctime>
+#include <memory>
 #include <string>
 
 #include "cyber/binary.h"
 #include "cyber/common/global_data.h"
+#include "cyber/cyber.h"
 #include "cyber/data/data_dispatcher.h"
 #include "cyber/logger/async_logger.h"
+#include "cyber/proto/clock.pb.h"
 #include "cyber/scheduler/scheduler.h"
 #include "cyber/service_discovery/topology_manager.h"
 #include "cyber/sysmo/sysmo.h"
@@ -46,6 +50,8 @@ namespace {
 bool g_atexit_registered = false;
 std::mutex g_mutex;
 logger::AsyncLogger* async_logger = nullptr;
+
+std::unique_ptr<apollo::cyber::Node> clock_node;
 
 void InitLogger(const char* binary_name) {
   const char* slash = strrchr(binary_name, '/');
@@ -68,9 +74,7 @@ void InitLogger(const char* binary_name) {
   async_logger->Start();
 }
 
-void StopLogger() {
-  delete async_logger;
-}
+void StopLogger() { delete async_logger; }
 
 }  // namespace
 
@@ -104,6 +108,24 @@ bool Init(const char* binary_name) {
     g_atexit_registered = true;
   }
   SetState(STATE_INITIALIZED);
+
+  const char* use_sim_time = ::getenv("USE_SIM_TIME");
+  if (use_sim_time != nullptr) {
+    std::string use_sim_time_str(use_sim_time);
+    if (use_sim_time_str == "true") {
+      clock_node = apollo::cyber::CreateNode("cyber_clock_node" +
+                                             std::to_string(getpid()));
+
+      auto cb =
+          [](const std::shared_ptr<const apollo::cyber::proto::Clock>& msg) {
+            if (msg->has_clock()) {
+              Time::SetSimTime(Time(msg->clock()));
+            }
+          };
+
+      clock_node->CreateReader<apollo::cyber::proto::Clock>("/clock", cb);
+    }
+  }
   return true;
 }
 

--- a/cyber/io/BUILD
+++ b/cyber/io/BUILD
@@ -50,7 +50,7 @@ cc_test(
     srcs = ["poller_test.cc"],
     deps = [
         ":poller",
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -69,7 +69,7 @@ cc_binary(
     name = "tcp_echo_client",
     srcs = ["example/tcp_echo_client.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
     ],
 )
 
@@ -77,7 +77,7 @@ cc_binary(
     name = "tcp_echo_server",
     srcs = ["example/tcp_echo_server.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
     ],
 )
 
@@ -85,7 +85,7 @@ cc_binary(
     name = "udp_echo_client",
     srcs = ["example/udp_echo_client.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
     ],
 )
 
@@ -93,7 +93,7 @@ cc_binary(
     name = "udp_echo_server",
     srcs = ["example/udp_echo_server.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
     ],
 )
 

--- a/cyber/proto/BUILD
+++ b/cyber/proto/BUILD
@@ -349,3 +349,22 @@ py_proto_library(
     ],
 )
 
+cc_proto_library(
+    name = "clock_cc_proto",
+    deps = [
+        ":clock_proto",
+    ],
+)
+
+proto_library(
+    name = "clock_proto",
+    srcs = ["clock.proto"],
+)
+
+py_proto_library(
+    name = "clock_py_pb2",
+    deps = [
+        ":clock_proto",
+    ],
+)
+

--- a/cyber/proto/clock.proto
+++ b/cyber/proto/clock.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package apollo.cyber.proto;
+
+message Clock {
+  required uint64 clock = 1;
+}
+

--- a/cyber/python/internal/BUILD
+++ b/cyber/python/internal/BUILD
@@ -17,7 +17,7 @@ cc_library(
     srcs = ["py_cyber.cc"],
     hdrs = ["py_cyber.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],
@@ -48,7 +48,7 @@ cc_library(
     srcs = ["py_record.cc"],
     hdrs = ["py_record.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/message:py_message",
         "//cyber/record",
         "@local_config_python//:python_headers",
@@ -82,7 +82,7 @@ cc_library(
     srcs = ["py_time.cc"],
     hdrs = ["py_time.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@fastrtps",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
@@ -103,7 +103,7 @@ cc_library(
     srcs = ["py_timer.cc"],
     hdrs = ["py_timer.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],
@@ -124,7 +124,7 @@ cc_library(
     hdrs = ["py_parameter.h"],
     deps = [
         ":py_cyber",
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],

--- a/cyber/scheduler/scheduler_choreo_test.cc
+++ b/cyber/scheduler/scheduler_choreo_test.cc
@@ -19,6 +19,7 @@
 
 #include "cyber/common/global_data.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/scheduler/policy/choreography_context.h"
 #include "cyber/scheduler/policy/classic_context.h"
 #include "cyber/scheduler/policy/scheduler_choreography.h"

--- a/cyber/scheduler/scheduler_classic_test.cc
+++ b/cyber/scheduler/scheduler_classic_test.cc
@@ -19,6 +19,7 @@
 #include "cyber/base/for_each.h"
 #include "cyber/common/global_data.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/scheduler/policy/classic_context.h"
 #include "cyber/scheduler/policy/scheduler_classic.h"
 #include "cyber/scheduler/processor.h"

--- a/cyber/task/BUILD
+++ b/cyber/task/BUILD
@@ -16,7 +16,7 @@ cc_test(
     size = "small",
     srcs = ["task_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cyber/time/time.cc
+++ b/cyber/time/time.cc
@@ -30,6 +30,9 @@ using std::chrono::high_resolution_clock;
 using std::chrono::steady_clock;
 using std::chrono::system_clock;
 
+static bool g_use_sim_time(false);
+static Time g_sim_time(0);
+
 const Time Time::MAX = Time(std::numeric_limits<uint64_t>::max());
 const Time Time::MIN = Time(1);
 
@@ -54,7 +57,14 @@ Time& Time::operator=(const Time& other) {
   return *this;
 }
 
+void Time::SetSimTime(const Time& sim_time) {
+  g_sim_time = sim_time;
+  g_use_sim_time = true;
+}
+
 Time Time::Now() {
+  if (g_use_sim_time) return g_sim_time;
+
   auto now = high_resolution_clock::now();
   auto nano_time_point =
       std::chrono::time_point_cast<std::chrono::nanoseconds>(now);

--- a/cyber/time/time.h
+++ b/cyber/time/time.h
@@ -49,6 +49,12 @@ class Time {
   static Time MonoTime();
 
   /**
+   * @brief This is for USE_SIM_TIME mode only.
+   * It sets the timestamp as the sim_time value.
+   */
+  static void SetSimTime(const Time& sim_time);
+
+  /**
    * @brief Sleep Until time.
    *
    * @param time the Time object.

--- a/cyber/transport/BUILD
+++ b/cyber/transport/BUILD
@@ -37,7 +37,7 @@ cc_test(
     size = "small",
     srcs = ["transport_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -157,7 +157,7 @@ cc_test(
     size = "small",
     srcs = ["dispatcher/rtps_dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -183,7 +183,7 @@ cc_test(
     size = "small",
     srcs = ["dispatcher/shm_dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
@@ -531,7 +531,7 @@ cc_test(
     size = "small",
     srcs = ["transceiver/hybrid_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -542,7 +542,7 @@ cc_test(
     size = "small",
     srcs = ["transceiver/intra_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
@@ -553,7 +553,7 @@ cc_test(
     size = "small",
     srcs = ["transceiver/rtps_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -564,7 +564,7 @@ cc_test(
     size = "small",
     srcs = ["transceiver/shm_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -575,7 +575,7 @@ cc_test(
     size = "small",
     srcs = ["shm/condition_notifier_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:init",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -181,6 +181,10 @@ while [ $# -gt 0 ] ; do
         ;;
     -y)
         ;;
+    -s|--use_sim_time)
+	USE_SIM_TIME=true
+	info "CyberRT uses simulation time if available"
+	;;
     stop)
         stop_containers
         exit 0
@@ -410,6 +414,7 @@ function main() {
         -e USE_GPU=$USE_GPU \
         -e NVIDIA_VISIBLE_DEVICES=all \
         -e NVIDIA_DRIVER_CAPABILITIES=compute,video,graphics,utility \
+	-e USE_SIM_TIME=$USE_SIM_TIME \
         $(local_volumes) \
         --net host \
         -w /apollo \

--- a/modules/canbus/tools/canbus_tester.cc
+++ b/modules/canbus/tools/canbus_tester.cc
@@ -19,8 +19,8 @@
 #include "cyber/common/file.h"
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
-
 #include "gflags/gflags.h"
 #include "modules/canbus/common/canbus_gflags.h"
 #include "modules/common/adapters/adapter_gflags.h"

--- a/modules/common/time/time.h
+++ b/modules/common/time/time.h
@@ -26,14 +26,14 @@
 #include <atomic>
 #include <chrono>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "cyber/common/log.h"
 #include "cyber/common/macros.h"
 #include "cyber/time/time.h"
-
-#include "cyber/common/log.h"
 #include "modules/common/configs/config_gflags.h"
 
 /**
@@ -113,7 +113,7 @@ class Clock {
    * @brief This is for mock clock mode only. It will set the timestamp
    * for the mock clock.
    */
-  static void SetNow(const absl::Time &now) {
+  static void SetNow(const absl::Time& now) {
     auto clock = Instance();
     if (clock->mode_ != ClockMode::MOCK) {
       AFATAL << "Cannot set now when clock mode is not MOCK!";
@@ -147,6 +147,14 @@ class Clock {
 
 inline Clock::Clock() {
   mode_ = FLAGS_use_cyber_time ? ClockMode::CYBER : ClockMode::SYSTEM;
+  // Force to use Cyber time is USE_SIM_TIME is set
+  const char* use_sim_time = ::getenv("USE_SIM_TIME");
+  if (use_sim_time != nullptr) {
+    std::string use_sim_time_str(use_sim_time);
+    if (use_sim_time_str == "true") {
+      mode_ = ClockMode::CYBER;
+    }
+  }
 }
 
 // Measure run time of a code block, mostly for debugging purpose.

--- a/modules/control/control_component_test.cc
+++ b/modules/control/control_component_test.cc
@@ -21,8 +21,8 @@
 #include "cyber/common/file.h"
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "gtest/gtest.h"
-
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/control/common/control_gflags.h"
 #include "modules/control/proto/control_conf.pb.h"

--- a/modules/drivers/canbus/can_comm/can_receiver.h
+++ b/modules/drivers/canbus/can_comm/can_receiver.h
@@ -32,9 +32,8 @@
 
 #include "cyber/common/macros.h"
 #include "cyber/cyber.h"
-
+#include "cyber/init.h"
 #include "modules/common/proto/error_code.pb.h"
-
 #include "modules/drivers/canbus/can_client/can_client.h"
 #include "modules/drivers/canbus/can_comm/message_manager.h"
 #include "modules/drivers/canbus/common/canbus_consts.h"

--- a/modules/localization/rtk/rtk_localization.cc
+++ b/modules/localization/rtk/rtk_localization.cc
@@ -404,14 +404,12 @@ bool RTKLocalization::InterpolateIMU(const CorrectedImu &imu1,
     AERROR << "imu1 and imu2 has no header or no timestamp_sec in header";
     return false;
   }
-  if (timestamp_sec - imu1.header().timestamp_sec() <
-      std::numeric_limits<double>::min()) {
+  if (timestamp_sec < imu1.header().timestamp_sec()) {
     AERROR << "[InterpolateIMU1]: the given time stamp[" << timestamp_sec
            << "] is older than the 1st message["
            << imu1.header().timestamp_sec() << "]";
     *imu_msg = imu1;
-  } else if (timestamp_sec - imu2.header().timestamp_sec() >
-             std::numeric_limits<double>::min()) {
+  } else if (timestamp_sec > imu2.header().timestamp_sec()) {
     AERROR << "[InterpolateIMU2]: the given time stamp[" << timestamp_sec
            << "] is newer than the 2nd message["
            << imu2.header().timestamp_sec() << "]";

--- a/modules/map/relative_map/tools/navigation_dummy.cc
+++ b/modules/map/relative_map/tools/navigation_dummy.cc
@@ -14,12 +14,12 @@
  * limitations under the License.
  *****************************************************************************/
 
-#include "gflags/gflags.h"
-
 #include "cyber/common/file.h"
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
+#include "gflags/gflags.h"
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/common/util/message_util.h"
 #include "modules/map/relative_map/proto/navigation.pb.h"

--- a/modules/map/relative_map/tools/navigator.cc
+++ b/modules/map/relative_map/tools/navigator.cc
@@ -19,17 +19,17 @@
 #include <thread>
 #include <vector>
 
-#include "nlohmann/json.hpp"
-
 #include "cyber/common/file.h"
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/common/util/message_util.h"
 #include "modules/map/relative_map/common/relative_map_gflags.h"
 #include "modules/map/relative_map/proto/navigation.pb.h"
 #include "modules/map/relative_map/proto/navigator_config.pb.h"
+#include "nlohmann/json.hpp"
 
 using apollo::cyber::Rate;
 using apollo::relative_map::NavigationInfo;

--- a/modules/map/tools/map_datachecker/client/main.cc
+++ b/modules/map/tools/map_datachecker/client/main.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *****************************************************************************/
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/map/tools/map_datachecker/client/client.h"
 #include "modules/map/tools/map_datachecker/client/client_gflags.h"
 

--- a/modules/map/tools/map_datachecker/server/main.cc
+++ b/modules/map/tools/map_datachecker/server/main.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *****************************************************************************/
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/map/tools/map_datachecker/server/worker.h"
 
 int main(int argc, char** argv) {

--- a/modules/map/tools/map_datachecker/server/worker.cc
+++ b/modules/map/tools/map_datachecker/server/worker.cc
@@ -17,9 +17,9 @@
 
 #include <memory>
 
-#include "grpc++/grpc++.h"
-
 #include "cyber/cyber.h"
+#include "cyber/init.h"
+#include "grpc++/grpc++.h"
 #include "modules/map/tools/map_datachecker/server/worker_agent.h"
 #include "modules/map/tools/map_datachecker/server/worker_cyber_node.h"
 #include "modules/map/tools/map_datachecker/server/worker_gflags.h"

--- a/modules/perception/lidar/tools/exporter/msg_exporter_main.cc
+++ b/modules/perception/lidar/tools/exporter/msg_exporter_main.cc
@@ -20,6 +20,7 @@
 #include "absl/strings/str_split.h"
 #include "cyber/common/log.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/perception/lidar/tools/exporter/msg_exporter.h"
 
 namespace apollo {

--- a/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
@@ -5,7 +5,7 @@ module_config {
     class_name : "SegmentationComponent"
     config {
       name: "Velodyne128Segmentation"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_segmentation_conf_lgsvl.pb.txt"
+      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_segmentation_conf.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
           channel: "/apollo/sensor/lidar128/compensator/PointCloud2"

--- a/modules/planning/integration_tests/planning_test_base.h
+++ b/modules/planning/integration_tests/planning_test_base.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 
+#include "cyber/init.h"
 #include "gtest/gtest.h"
 #include "modules/planning/proto/traffic_rule_config.pb.h"
 

--- a/modules/routing/tools/routing_cast.cc
+++ b/modules/routing/tools/routing_cast.cc
@@ -15,6 +15,7 @@
  *****************************************************************************/
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/common/util/message_util.h"

--- a/modules/routing/tools/routing_dump.cc
+++ b/modules/routing/tools/routing_dump.cc
@@ -15,6 +15,7 @@
  *****************************************************************************/
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/planning/proto/planning.pb.h"
 

--- a/modules/routing/tools/routing_tester.cc
+++ b/modules/routing/tools/routing_tester.cc
@@ -16,8 +16,8 @@
 
 #include "cyber/common/file.h"
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "cyber/time/rate.h"
-
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/routing/proto/routing.pb.h"
 

--- a/modules/tools/visualizer/channel_reader.h
+++ b/modules/tools/visualizer/channel_reader.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 
 class MainWindow;
 

--- a/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_client_test.cc
+++ b/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_client_test.cc
@@ -22,6 +22,7 @@
 #include "modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_client.h"
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "gtest/gtest.h"
 
 namespace apollo {

--- a/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_server.h
+++ b/modules/v2x/v2x_proxy/obu_interface/grpc_interface/grpc_server.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/v2x/proto/v2x_service_obu_to_car.grpc.pb.h"
 
 namespace apollo {

--- a/modules/v2x/v2x_proxy/os_interface/os_interface.h
+++ b/modules/v2x/v2x_proxy/os_interface/os_interface.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "cyber/cyber.h"
+#include "cyber/init.h"
 #include "modules/common/adapters/adapter_gflags.h"
 #include "modules/localization/proto/localization.pb.h"
 #include "modules/perception/proto/perception_obstacle.pb.h"


### PR DESCRIPTION
ROS can use simulation time from /clock topic (http://wiki.ros.org/Clock).

This PR adds the same ability to CyberRT. It is an important feature to run simulator together with Apollo.

Starting Apollo docker with "dev_start.sh -s", CyberRT will try to use value from /clock as Now(), and Apollo will use CyberRT time (which is from /clock).