### PR TITLE
Add a clock proto to Cyber.

### DIFF
--- a/cyber/proto/BUILD
+++ b/cyber/proto/BUILD
@@ -349,3 +349,22 @@ py_proto_library(
     ],
 )
 
+cc_proto_library(
+    name = "clock_cc_proto",
+    deps = [
+        ":clock_proto",
+    ],
+)
+
+proto_library(
+    name = "clock_proto",
+    srcs = ["clock.proto"],
+)
+
+py_proto_library(
+    name = "clock_py_pb2",
+    deps = [
+        ":clock_proto",
+    ],
+)
+

--- a/cyber/proto/clock.proto
+++ b/cyber/proto/clock.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package apollo.cyber.proto;
+
+message Clock {
+  required uint64 clock = 1;
+}
+


### PR DESCRIPTION
This will be used in a follow-up PR to
enable sim_time support for CyberRT.