### PR TITLE
Docker: Fix "user exists" test

### DIFF
--- a/scripts/docker_start_user.sh
+++ b/scripts/docker_start_user.sh
@@ -55,7 +55,7 @@ function setup_user_account_if_not_exist() {
     local uid="$2"
     local group_name="$3"
     local gid="$4"
-    if grep -q "${user_name}" /etc/passwd; then
+    if grep -q "^${user_name}:" /etc/passwd; then
         echo "User ${user_name} already exist. Skip setting user account."
         return
     fi


### PR DESCRIPTION
The grep of ${user_name} in /etc/password will succeed for some user names such as "dev" even if the "dev" user does not exist (due to finding "dev" elsewhere in /etc/password). This will skip calling _create_user_account which will in turn cause dev_into.sh to fail since docker does not like getting a user name. Passing $UID instead of $USER to "docker exec" in dev_into.sh works but then the prompt is wrong because the user doesn't exist.

Fixing the grep to only look at the start of each line (up to ":") in /etc/passwd fixes this, causes the account to actually get created, and allows (docker and) dev_into.sh script to work as expected. Tested several times with user "dev" (where the bug was discovered) and with another non-"dev" user.