### PR TITLE
cyber: MockTime mode support

### DIFF
--- a/cyber/BUILD
+++ b/cyber/BUILD
@@ -48,9 +48,12 @@ cc_library(
     hdrs = ["init.h"],
     deps = [
         "//cyber:state",
+        "//cyber/common:file",
         "//cyber/logger:async_logger",
         "//cyber/node",
+        "//cyber/proto:clock_cc_proto",
         "//cyber/sysmo",
+        "//cyber/time:clock",
         "//cyber/timer:timing_wheel",
     ],
 )

--- a/cyber/common/global_data.cc
+++ b/cyber/common/global_data.cc
@@ -24,7 +24,6 @@
 
 #include <climits>
 #include <cstdlib>
-
 #include <functional>
 
 #include "cyber/common/environment.h"
@@ -65,6 +64,7 @@ GlobalData::GlobalData() {
 
   const auto& run_mode_conf = config_.run_mode_conf();
   run_mode_ = run_mode_conf.run_mode();
+  clock_mode_ = run_mode_conf.clock_mode();
 }
 
 GlobalData::~GlobalData() {}
@@ -94,12 +94,14 @@ void GlobalData::EnableSimulationMode() {
   run_mode_ = RunMode::MODE_SIMULATION;
 }
 
-void GlobalData::DisableSimulationMode() {
-  run_mode_ = RunMode::MODE_REALITY;
-}
+void GlobalData::DisableSimulationMode() { run_mode_ = RunMode::MODE_REALITY; }
 
 bool GlobalData::IsRealityMode() const {
   return run_mode_ == RunMode::MODE_REALITY;
+}
+
+bool GlobalData::IsMockTimeMode() const {
+  return clock_mode_ == ClockMode::MODE_MOCK;
 }
 
 void GlobalData::InitHostInfo() {

--- a/cyber/common/global_data.cc
+++ b/cyber/common/global_data.cc
@@ -21,8 +21,10 @@
 #include <netdb.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <climits>
 #include <cstdlib>
+
 #include <functional>
 
 #include "cyber/common/environment.h"
@@ -38,12 +40,12 @@ AtomicHashMap<uint64_t, std::string, 256> GlobalData::service_id_map_;
 AtomicHashMap<uint64_t, std::string, 256> GlobalData::task_id_map_;
 
 namespace {
-const char* empty_str_ = "";
+const std::string& kEmptyString = "";
 std::string program_path() {
   char path[PATH_MAX];
   auto len = readlink("/proc/self/exe", path, sizeof(path));
   if (len == -1) {
-    return empty_str_;
+    return kEmptyString;
   }
   path[len] = '\0';
   return std::string(path);
@@ -181,7 +183,7 @@ std::string GlobalData::GetNodeById(uint64_t id) {
   if (node_id_map_.Get(id, &node_name)) {
     return *node_name;
   }
-  return empty_str_;
+  return kEmptyString;
 }
 
 uint64_t GlobalData::RegisterChannel(const std::string& channel) {
@@ -204,7 +206,7 @@ std::string GlobalData::GetChannelById(uint64_t id) {
   if (channel_id_map_.Get(id, &channel)) {
     return *channel;
   }
-  return empty_str_;
+  return kEmptyString;
 }
 
 uint64_t GlobalData::RegisterService(const std::string& service) {
@@ -227,7 +229,7 @@ std::string GlobalData::GetServiceById(uint64_t id) {
   if (service_id_map_.Get(id, &service)) {
     return *service;
   }
-  return empty_str_;
+  return kEmptyString;
 }
 
 uint64_t GlobalData::RegisterTaskName(const std::string& task_name) {
@@ -250,7 +252,7 @@ std::string GlobalData::GetTaskNameById(uint64_t id) {
   if (task_id_map_.Get(id, &task_name)) {
     return *task_name;
   }
-  return empty_str_;
+  return kEmptyString;
 }
 
 }  // namespace common

--- a/cyber/common/global_data.cc
+++ b/cyber/common/global_data.cc
@@ -63,13 +63,8 @@ GlobalData::GlobalData() {
     process_group_ = "cyber_default_" + std::to_string(process_id_);
   }
 
-  is_reality_mode_ =
-      config_.run_mode_conf().run_mode() == proto::RunMode::MODE_REALITY;
-
-  auto run_mode = GetEnv("CYBER_RUN_MODE");
-  if (!run_mode.empty() && run_mode == "simulation") {
-    is_reality_mode_ = false;
-  }
+  const auto& run_mode_conf = config_.run_mode_conf();
+  run_mode_ = run_mode_conf.run_mode();
 }
 
 GlobalData::~GlobalData() {}
@@ -95,11 +90,17 @@ const std::string& GlobalData::HostIp() const { return host_ip_; }
 
 const std::string& GlobalData::HostName() const { return host_name_; }
 
-void GlobalData::EnableSimulationMode() { is_reality_mode_ = false; }
+void GlobalData::EnableSimulationMode() {
+  run_mode_ = RunMode::MODE_SIMULATION;
+}
 
-void GlobalData::DisableSimulationMode() { is_reality_mode_ = true; }
+void GlobalData::DisableSimulationMode() {
+  run_mode_ = RunMode::MODE_REALITY;
+}
 
-bool GlobalData::IsRealityMode() const { return is_reality_mode_; }
+bool GlobalData::IsRealityMode() const {
+  return run_mode_ == RunMode::MODE_REALITY;
+}
 
 void GlobalData::InitHostInfo() {
   char host_name[1024];

--- a/cyber/common/global_data.h
+++ b/cyber/common/global_data.h
@@ -33,6 +33,7 @@ namespace common {
 
 using ::apollo::cyber::base::AtomicHashMap;
 using ::apollo::cyber::proto::CyberConfig;
+using ::apollo::cyber::proto::RunMode;
 
 class GlobalData {
  public:
@@ -97,7 +98,7 @@ class GlobalData {
   std::string sched_name_ = "CYBER_DEFAULT";
 
   // run mode
-  bool is_reality_mode_;
+  RunMode run_mode_;
 
   static AtomicHashMap<uint64_t, std::string, 512> node_id_map_;
   static AtomicHashMap<uint64_t, std::string, 256> channel_id_map_;

--- a/cyber/common/global_data.h
+++ b/cyber/common/global_data.h
@@ -32,6 +32,7 @@ namespace cyber {
 namespace common {
 
 using ::apollo::cyber::base::AtomicHashMap;
+using ::apollo::cyber::proto::ClockMode;
 using ::apollo::cyber::proto::CyberConfig;
 using ::apollo::cyber::proto::RunMode;
 
@@ -60,6 +61,7 @@ class GlobalData {
   void DisableSimulationMode();
 
   bool IsRealityMode() const;
+  bool IsMockTimeMode() const;
 
   static uint64_t GenerateHashId(const std::string& name) {
     return common::Hash(name);
@@ -99,6 +101,7 @@ class GlobalData {
 
   // run mode
   RunMode run_mode_;
+  ClockMode clock_mode_;
 
   static AtomicHashMap<uint64_t, std::string, 512> node_id_map_;
   static AtomicHashMap<uint64_t, std::string, 256> channel_id_map_;

--- a/cyber/common/util.h
+++ b/cyber/common/util.h
@@ -18,6 +18,7 @@
 #define CYBER_COMMON_UTIL_H_
 
 #include <string>
+#include <type_traits>
 
 namespace apollo {
 namespace cyber {
@@ -25,6 +26,11 @@ namespace common {
 
 inline std::size_t Hash(const std::string& key) {
   return std::hash<std::string>{}(key);
+}
+
+template <typename Enum>
+auto ToInt(Enum const value) -> typename std::underlying_type<Enum>::type {
+  return static_cast<typename std::underlying_type<Enum>::type>(value);
 }
 
 }  // namespace common

--- a/cyber/conf/cyber.pb.conf
+++ b/cyber/conf/cyber.pb.conf
@@ -27,6 +27,7 @@
 
 run_mode_conf {
     run_mode: MODE_REALITY
+    clock_mode: MODE_CYBER
 }
 
 scheduler_conf {

--- a/cyber/cyber.cc
+++ b/cyber/cyber.cc
@@ -37,8 +37,7 @@ std::unique_ptr<Node> CreateNode(const std::string& node_name,
     AERROR << "please initialize cyber firstly.";
     return nullptr;
   }
-  std::unique_ptr<Node> node(new Node(node_name, name_space));
-  return std::move(node);
+  return std::unique_ptr<Node>(new Node(node_name, name_space));
 }
 
 }  // namespace cyber

--- a/cyber/examples/talker.cc
+++ b/cyber/examples/talker.cc
@@ -31,15 +31,16 @@ int main(int argc, char *argv[]) {
   // create talker
   auto talker = talker_node->CreateWriter<Chatter>("channel/chatter");
   Rate rate(1.0);
+  uint64_t seq = 0;
   while (apollo::cyber::OK()) {
-    static uint64_t seq = 0;
     auto msg = std::make_shared<Chatter>();
     msg->set_timestamp(Time::Now().ToNanosecond());
     msg->set_lidar_timestamp(Time::Now().ToNanosecond());
-    msg->set_seq(seq++);
+    msg->set_seq(seq);
     msg->set_content("Hello, apollo!");
     talker->Write(msg);
-    AINFO << "talker sent a message!";
+    AINFO << "talker sent a message! No. " << seq;
+    seq++;
     rate.Sleep();
   }
   return 0;

--- a/cyber/node/node.h
+++ b/cyber/node/node.h
@@ -46,6 +46,7 @@ class Node {
   template <typename M0, typename M1, typename M2, typename M3>
   friend class Component;
   friend class TimerComponent;
+  friend bool Init(const char*);
   friend std::unique_ptr<Node> CreateNode(const std::string&,
                                           const std::string&);
   virtual ~Node();

--- a/cyber/proto/run_mode_conf.proto
+++ b/cyber/proto/run_mode_conf.proto
@@ -7,6 +7,12 @@ enum RunMode {
   MODE_SIMULATION = 1;
 }
 
+enum ClockMode {
+  MODE_CYBER = 0;
+  MODE_MOCK = 1;
+}
+
 message RunModeConf {
   optional RunMode run_mode = 1 [default = MODE_REALITY];
+  optional ClockMode clock_mode = 2 [default = MODE_CYBER];
 }

--- a/cyber/time/BUILD
+++ b/cyber/time/BUILD
@@ -50,4 +50,18 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "clock",
+    srcs = ["clock.cc"],
+    hdrs = ["clock.h"],
+    deps = [
+        ":time",
+        "//cyber/common:global_data",
+        "//cyber/common:log",
+        "//cyber/common:macros",
+        "//cyber/common:util",
+        "//cyber/proto:run_mode_conf_cc_proto",
+    ],
+)
+
 cpplint()

--- a/cyber/time/clock.cc
+++ b/cyber/time/clock.cc
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "cyber/time/clock.h"
+
+#include "cyber/common/global_data.h"
+#include "cyber/common/log.h"
+#include "cyber/common/util.h"
+
+namespace apollo {
+namespace cyber {
+
+using GlobalData = ::apollo::cyber::common::GlobalData;
+
+Clock::Clock() {
+    const auto& cyber_config = GlobalData::Instance()->Config();
+    const auto& clock_mode = cyber_config.run_mode_conf().clock_mode();
+    mode_ = clock_mode;
+    mock_now_ = Time(0);
+}
+
+Time Clock::Now() {
+  std::lock_guard<std::mutex> lk(mtx_);
+  switch (mode_) {
+    case ClockMode::MODE_CYBER:
+      return Time::Now();
+    case ClockMode::MODE_MOCK:
+      return mock_now_;
+    default:
+      AFATAL << "Unsupported clock mode: "
+             << apollo::cyber::common::ToInt(mode_);
+  }
+  return Time::Now();
+}
+
+double Clock::NowInSeconds() { return Now().ToSecond(); }
+
+void Clock::SetNow(const Time& now) {
+  std::lock_guard<std::mutex> lk(mtx_);
+  if (mode_ != ClockMode::MODE_MOCK) {
+    AERROR << "SetSimNow only works for ClockMode::MOCK";
+    return;
+  }
+  mock_now_ = now;
+}
+
+}  // namespace cyber
+}  // namespace apollo

--- a/cyber/time/clock.h
+++ b/cyber/time/clock.h
@@ -1,0 +1,83 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#ifndef CYBER_TIME_CLOCK_H_
+#define CYBER_TIME_CLOCK_H_
+
+#include <mutex>
+
+#include "cyber/common/macros.h"
+#include "cyber/time/time.h"
+#include "cyber/proto/run_mode_conf.pb.h"
+
+namespace apollo {
+namespace cyber {
+
+using ::apollo::cyber::proto::ClockMode;
+
+/**
+ * @class Clock
+ * @brief a singleton clock that can be used to get the current
+ * timestamp. The source can be either system(cyber) clock or a mock clock.
+ * Mock clock is for testing purpose mainly.
+ */
+class Clock {
+ public:
+  static constexpr int64_t PRECISION =
+      std::chrono::system_clock::duration::period::den /
+      std::chrono::system_clock::duration::period::num;
+
+  /// PRECISION >= 1000000 means the precision is at least 1us.
+  static_assert(PRECISION >= 1000000,
+                "The precision of the system clock should be at least 1 "
+                "microsecond.");
+
+  /**
+   * @brief get current time.
+   * @return a Time object representing the current time.
+   */
+  Time Now();
+
+  /**
+   * @brief gets the current time in second.
+   * @return the current time in second.
+   */
+  double NowInSeconds();
+
+  /**
+   * @brief This is for mock clock mode only. It will set the timestamp
+   * for the mock clock.
+   */
+  void SetNow(const Time& now);
+
+  /**
+   * @brief This is for mock clock mode only. It will set the timestamp
+   * for the mock clock with UNIX timestamp in seconds.
+   */
+  void SetNowInSeconds(const double seconds) { SetNow(Time(seconds)); }
+
+ private:
+  ClockMode mode_;
+  Time mock_now_;
+  std::mutex mtx_;
+
+  DECLARE_SINGLETON(Clock)
+};
+
+}  // namespace cyber
+}  // namespace apollo
+
+#endif  // CYBER_TIME_CLOCK_H_

--- a/cyber/time/time.cc
+++ b/cyber/time/time.cc
@@ -16,8 +16,9 @@
 
 #include "cyber/time/time.h"
 
-#include <chrono>
 #include <ctime>
+
+#include <chrono>
 #include <iomanip>
 #include <limits>
 #include <sstream>

--- a/cyber/time/time.cc
+++ b/cyber/time/time.cc
@@ -32,7 +32,7 @@ using std::chrono::steady_clock;
 using std::chrono::system_clock;
 
 const Time Time::MAX = Time(std::numeric_limits<uint64_t>::max());
-const Time Time::MIN = Time(1);
+const Time Time::MIN = Time(0);
 
 Time::Time(uint64_t nanoseconds) { nanoseconds_ = nanoseconds; }
 

--- a/cyber/time/time_test.cc
+++ b/cyber/time/time_test.cc
@@ -70,7 +70,7 @@ TEST(TimeTest, is_zero) {
   Time time;
   EXPECT_TRUE(time.IsZero());
   EXPECT_FALSE(Time::MAX.IsZero());
-  EXPECT_FALSE(Time::MIN.IsZero());
+  EXPECT_TRUE(Time::MIN.IsZero());
 }
 
 }  // namespace cyber


### PR DESCRIPTION
This PR was based on @rongguodong 's request on simulation time support for `CyberRT`.  Cf. #11808 

Env vars and gflags were not used here.  Instead, `cyber/conf/cyber.pb.conf ` was the sole config file for specifying whether system(cyber)-clock or mock-clock should be used.

A clock node was created In `cyber::init` for each process.

Also notice there are `time.h` defs under `modules/common/time`, should we combine all these to provide a unified time model ?
 