### PR TITLE
canbus: review to init timeval struct

### DIFF
--- a/modules/canbus/vehicle/lincoln/protocol/wheelspeed_6a_test.cc
+++ b/modules/canbus/vehicle/lincoln/protocol/wheelspeed_6a_test.cc
@@ -28,6 +28,7 @@ TEST(Wheelspeed6aTest, General) {
   int32_t length = 8;
   ChassisDetail cd;
   struct timeval timestamp;
+  gettimeofday(&timestamp, NULL);
   wheelspeed.Parse(data, length, timestamp, &cd);
 
   EXPECT_TRUE(cd.vehicle_spd().is_wheel_spd_fl_valid());


### PR DESCRIPTION
1. var_decl: Declaring variable timestamp without initializer.