### PR TITLE
cyber: class member init

### DIFF
--- a/cyber/scheduler/policy/scheduler_choreography.cc
+++ b/cyber/scheduler/policy/scheduler_choreography.cc
@@ -40,7 +40,8 @@ using apollo::cyber::common::PathExists;
 using apollo::cyber::common::WorkRoot;
 using apollo::cyber::croutine::RoutineState;
 
-SchedulerChoreography::SchedulerChoreography() {
+SchedulerChoreography::SchedulerChoreography()
+    : choreography_processor_prio_(0), pool_processor_prio_(0) {
   std::string conf("conf/");
   conf.append(GlobalData::Instance()->ProcessGroup()).append(".conf");
   auto cfg_file = GetAbsolutePath(WorkRoot(), conf);


### PR DESCRIPTION
review result: 
6 uninit_member: Non-static class member choreography_processor_prio_ is not initialized in this constructor nor in any functions that it calls.
8. uninit_member: Non-static class member pool_processor_prio_ is not initialized in this constructor nor in any functions that it calls