### PR TITLE
Revert "Dreamview: change recorder stop_signal to SIGINT in RTK mode"

### DIFF
--- a/modules/dreamview/conf/hmi_modes/rtk.pb.txt
+++ b/modules/dreamview/conf/hmi_modes/rtk.pb.txt
@@ -32,7 +32,7 @@ modules {
   key: "RTK Recorder"
   value: {
     start_command: "nohup /apollo/scripts/rtk_recorder.sh start &"
-    stop_command: "/apollo/scripts/rtk_recorder.sh --stop --stop_signal SIGINT"
+    stop_command: "/apollo/scripts/rtk_recorder.sh stop"
     process_monitor_config {
       command_keywords: "record_play/rtk_recorder.py"
     }


### PR DESCRIPTION
Reverts ApolloAuto/apollo#11903
test RTK recorder failed.