### PR TITLE
Bazel: default to bazel's default compilation mode rather than dbg mode

### DIFF
--- a/scripts/apollo_build.sh
+++ b/scripts/apollo_build.sh
@@ -119,7 +119,7 @@ function _run_bazel_build_impl() {
 function bazel_build() {
     if ! "${APOLLO_IN_DOCKER}" ; then
         error "The build operation must be run from within docker container"
-        # exit 1
+        exit 1
     fi
 
 	_parse_cmdline_arguments $@

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -31,8 +31,6 @@ build --cxxopt="-fdiagnostics-color=always"
 # Do not show warnings from external dependencies.
 # build --output_filter="^//"
 
-build --config=dbg
-
 build --per_file_copt=external/upb/.*@-Wno-sign-compare
 build --copt="-Werror=sign-compare"
 build --copt="-Werror=return-type"
@@ -46,10 +44,12 @@ build --define=PREFIX=/usr
 build --define=LIBDIR=$(PREFIX)/lib
 build --define=INCLUDEDIR=$(PREFIX)/include
 
-# dbg config, as a shorthand for '--config=optimize -c dbg'
-build:dbg --config=optimize -c dbg
-build:opt --config=optimize -c opt
 
+# dbg config, as a shorthand for '--config=optimize -c dbg'
+build:dbg -c dbg
+build:opt -c opt
+
+build --config=optimize
 # Instruction set optimizations
 build:optimize --copt=-march=native
 build:optimize --host_copt=-march=native


### PR DESCRIPTION
With this PR:

`./apollo.sh build` is equivalent to `--config=optimized -c fastbuild`, where the `fastbuild` compilation mode was bazel's default.
`./apollo.sh build_dbg` remains unchanged, equals to `--config=optimized -c dbg`.
`./apollo.sh build_opt` remains unchanged, equals to `--config=optimized -c opt`.

`