### PR TITLE
Drivers: fix hardcode of sample_width

### DIFF
--- a/modules/drivers/microphone/README
+++ b/modules/drivers/microphone/README
@@ -1,1 +1,0 @@
-This serves as the audio driver folder

--- a/modules/drivers/microphone/README.md
+++ b/modules/drivers/microphone/README.md
@@ -1,0 +1,24 @@
+This serves as the audio driver folder
+
+## Microphone Configuration
+
+* **microphone_model**: currently only support `RESPEAKER`.
+* **chunk**: number of frames per buffer from hardware to memory each time.
+* **record_seconds**: number of seconds each time.
+* **channel_type**
+  * May be ASR (Audio Speech Recognition), RAW (Raw Audio Data) or Playback.
+* **sample_rate**
+  * Number of frames that are recorded per second.
+* **sample_width**
+  * Number of bytes per sample (1, 2, 3, or 4).
+
+For example, if there are 6 channels with 16000 Hz rate and 2 bytes width, then 4 second recording is
+* Number of frames: 16000
+* Number of "samples": 16000 * 6
+  * I use the term "samples" here just to make it easy for understanding, which is seldom used in this context.
+* Total size: 6 × 16,000 x 4 × 2 = 768,000 bytes.
+
+You might see other metrics elsewhere as follows:
+
+* **BIT DEPTH** same to sample_width except that the unit is bit.
+* **BIT RATE** number of bits encoded per second (kbps or k) -- for compressed format like mp3.

--- a/modules/drivers/microphone/microphone_component.cc
+++ b/modules/drivers/microphone/microphone_component.cc
@@ -33,17 +33,17 @@ bool MicrophoneComponent::Init() {
   microphone_device_ptr_->init(microphone_config_ptr_);
 
   // dump config, calculate size and reserve buffer for audio
-  // chunk_: number of frames per chunk; chunk_size_: number of bytes per chunk
   n_channels_ = microphone_config_ptr_->channel_type_size();
+  sample_width_ = microphone_config_ptr_->sample_width();
+  // chunk_: number of frames per chunk; chunk_size_: number of bytes per chunk
   chunk_ = microphone_config_ptr_->chunk();
-  total_frames_ = microphone_config_ptr_->sample_rate() *
-                  microphone_config_ptr_->record_seconds();
-  chunk_size_ = microphone_device_ptr_->get_chunk_size(chunk_);
-
-  buffer_size_ = microphone_device_ptr_->get_chunk_size(total_frames_);
-  buffer_ = new char[buffer_size_];
+  n_chunk_ = static_cast<int>(
+      std::floor(microphone_config_ptr_->sample_rate() *
+                 microphone_config_ptr_->record_seconds() / chunk_));
+  chunk_size_ = chunk_ * n_channels_ * sample_width_;
+  buffer_ = new char[chunk_size_];
   if (buffer_ == nullptr) {
-    AERROR << "System calloc memory error, size:" << buffer_size_;
+    AERROR << "System new memory error, size:" << chunk_size_;
     return false;
   }
 
@@ -57,7 +57,7 @@ bool MicrophoneComponent::Init() {
       microphone_config_ptr_->frame_id());
 
   ChannelData *channel_data = nullptr;
-  int channel_size = buffer_size_ / n_channels_;
+  int channel_size = n_chunk_ * chunk_ * sample_width_;
   for (int i = 0; i < n_channels_; ++i) {
     channel_data = audio_data_ptr_->add_channel_data();
     channel_data->set_channel_type(microphone_config_ptr_->channel_type(i));
@@ -72,29 +72,28 @@ bool MicrophoneComponent::Init() {
   return true;
 }
 
-void MicrophoneComponent::run() {
-  char *pos = nullptr;
-  int i;
-  while (!cyber::IsShutdown()) {
-    AINFO << "Start recording";
-    pos = buffer_;
-    try {
-      for (i = 1; chunk_ * i <= total_frames_; ++i) {
-        microphone_device_ptr_->read_stream(chunk_, pos);
-        pos += chunk_size_;
+void MicrophoneComponent::fill_channel_data(int chunk_i) {
+  // next index of channel data to be filled
+  int pos = chunk_i * chunk_ * sample_width_;
+  for (int buff_i = 0; buff_i < chunk_size_; pos += sample_width_) {
+    for (int channel_i = 0; channel_i < n_channels_; ++channel_i) {
+      for (int di = 0; di < sample_width_; ++di) {
+        (*channel_data_ptrs_[channel_i])[pos + di] = buffer_[buff_i++];
       }
-      if (chunk_ * --i < total_frames_)
-        microphone_device_ptr_->read_stream(total_frames_ - chunk_ * i, pos);
+    }
+  }
+}
+
+void MicrophoneComponent::run() {
+  int chunk_i;
+  while (!cyber::IsShutdown()) {
+    try {
+      for (chunk_i = 0; chunk_i < n_chunk_; ++chunk_i) {
+        microphone_device_ptr_->read_stream(chunk_, buffer_);
+        fill_channel_data(chunk_i);
+      }
     } catch (const std::exception &e) {
       return;
-    }
-    AINFO << "End recording";
-
-    for (int buff_i = 0, i = 0; buff_i < buffer_size_; i += 2) {
-      for (int channel_i = 0; channel_i < n_channels_; ++channel_i) {
-        (*channel_data_ptrs_[channel_i])[i] = buffer_[buff_i++];
-        (*channel_data_ptrs_[channel_i])[i + 1] = buffer_[buff_i++];
-      }
     }
     FillHeader(node_->Name(), audio_data_ptr_.get());
     writer_ptr_->Write(audio_data_ptr_);

--- a/modules/drivers/microphone/microphone_component.h
+++ b/modules/drivers/microphone/microphone_component.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <cmath>
 #include <future>
 #include <memory>
 #include <string>
@@ -47,9 +48,11 @@ class MicrophoneComponent : public Component<> {
 
  private:
   void run();
+  void fill_channel_data(int chunk_i);
 
   // Configuration
-  int n_chunks_, n_channels_, chunk_, chunk_size_, buffer_size_, total_frames_;
+  int n_chunks_, n_channels_, chunk_, chunk_size_, n_chunk_,
+      sample_width_;
 
   // class data
   std::shared_ptr<AudioData> audio_data_ptr_;

--- a/modules/drivers/microphone/respeaker.h
+++ b/modules/drivers/microphone/respeaker.h
@@ -36,7 +36,7 @@ using apollo::drivers::microphone::config::MicrophoneConfig;
 class Stream {
  private:
   PaStream *pastream_ptr_;
-  PaStreamParameters *inputParameters_ptr_;
+  PaStreamParameters *input_parameters_ptr_;
 
  public:
   Stream() {}
@@ -44,7 +44,6 @@ class Stream {
   void init_stream(int rate, int channels, int chunk, int input_device_index,
                    PaSampleFormat format);
   void read_stream(int n_frames, char *buffer) const;
-  int get_chunk_size(int n_frames) const;
 };
 
 class Respeaker {
@@ -52,7 +51,7 @@ class Respeaker {
   std::unique_ptr<Stream> stream_ptr_;
   const PaDeviceInfo *get_device_info(const PaDeviceIndex index) const;
   const PaDeviceIndex host_api_device_index_to_device_index(
-      const PaHostApiIndex hostApi, const int hostApiDeviceIndex) const;
+      const PaHostApiIndex host_api, const int host_api_device_index) const;
   const PaHostApiInfo *get_host_api_info(const PaHostApiIndex index) const;
   const PaDeviceIndex get_respeaker_index() const;
   const PaSampleFormat get_format_from_width(int width,
@@ -63,7 +62,6 @@ class Respeaker {
   ~Respeaker();
   void init(const std::shared_ptr<const MicrophoneConfig> &microphone_config);
   void read_stream(int n_frames, char *buffer) const;
-  int get_chunk_size(int n_frames) const;
 };
 
 }  // namespace microphone


### PR DESCRIPTION
Not ready
* Sample_width is the number of bytes every sample. I didn't notice that I hardcode them in `microphone_component.cc` 95 as `i` and `i+1` -- originally it was default to be 2. Now I change them to a `for` loop
* Change buffer size from **"_size for all the seconds_"** TO **"_size for only one chunk_"**, reduce startup time by 40% and reduce memory usage.
  * Previously, a `for` loop to read all required audio data into buffer (many chunks). Then another `for` loop to copy data in buffer to `bytes` in proto
  * Now, one `for` -- read a chunk, copy to buffer, then to `byte` in proto, repeatedly
* Change the way to calculate size.
  * refer to readme.
* Fix others like `malloc` to `new`.
