### PR TITLE
Bazel: revert previous nccl bazel rules as it breaks build on aarch64 

### DIFF
--- a/third_party/gpus/cuda/BUILD.tpl
+++ b/third_party/gpus/cuda/BUILD.tpl
@@ -116,30 +116,6 @@ cc_library(
     linkstatic = 1,
 )
 
-cuda_header_library(
-    name = "nccl_headers",
-    hdrs = [":nccl-include"],
-    include_prefix="third_party/gpus",
-    includes = ["cuda/include/"],
-    deps = [":cuda_headers"],
-)
-
-cc_library(
-    name = "nccl_lib",
-    srcs = ["cuda/lib/%{nccl_lib}"],
-    data = ["cuda/lib/%{nccl_lib}"],
-    linkstatic = 1,
-)
-
-cc_library(
-    name = "nccl",
-    deps = [
-        ":nccl_headers",
-        ":nccl_lib",
-        ":cuda",
-    ]
-)
-
 cc_library(
     name = "cuda",
     deps = [

--- a/third_party/gpus/cuda/build_defs.bzl.tpl
+++ b/third_party/gpus/cuda/build_defs.bzl.tpl
@@ -97,7 +97,3 @@ def cuda_header_library(
 def cuda_library(copts = [], **kwargs):
     """Wrapper over cc_library which adds default CUDA options."""
     native.cc_library(copts = cuda_default_copts() + copts, **kwargs)
-
-def cuda_binary(copts = [], **kwargs):
-    """Wrapper over cc_binary which adds default CUDA options."""
-    native.cc_binary(copts = cuda_default_copts() + copts, **kwargs)

--- a/third_party/gpus/cuda/build_defs.bzl.tpl
+++ b/third_party/gpus/cuda/build_defs.bzl.tpl
@@ -97,3 +97,8 @@ def cuda_header_library(
 def cuda_library(copts = [], **kwargs):
     """Wrapper over cc_library which adds default CUDA options."""
     native.cc_library(copts = cuda_default_copts() + copts, **kwargs)
+
+def cuda_binary(copts = [], **kwargs):
+    """Wrapper over cc_binary which adds default CUDA options."""
+    native.cc_binary(copts = cuda_default_copts() + copts, **kwargs)
+

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -465,13 +465,6 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
             cuda_config.cuda_lib_version,
             static = False,
         ),
-        "nccl": _check_cuda_lib_params(
-            "nccl",
-            cpu_value,
-            cuda_config.config["nccl_library_dir"],
-            version = None,
-            static = False,
-        ),
     }
 
     # Verify that the libs actually exist at their locations.
@@ -536,7 +529,7 @@ def _get_cuda_config(repository_ctx, find_cuda_config_script):
           compute_capabilities: A list of the system's CUDA compute capabilities.
           cpu_value: The name of the host operating system.
       """
-    config = find_cuda_config(repository_ctx, find_cuda_config_script, ["cuda", "cudnn", "nccl"])
+    config = find_cuda_config(repository_ctx, find_cuda_config_script, ["cuda", "cudnn"])
     cpu_value = get_cpu_value(repository_ctx)
     toolkit_path = config["cuda_toolkit_path"]
 
@@ -546,7 +539,6 @@ def _get_cuda_config(repository_ctx, find_cuda_config_script):
 
     cuda_version = "{}.{}".format(cuda_major, cuda_minor)
     cudnn_version = config["cudnn_version"]
-    nccl_version = config["nccl_version"]
 
     # cuda_lib_version is for libraries like cuBLAS, cuFFT, cuSOLVER, etc.
     # It changed from 'x.y' to just 'x' in CUDA 10.1.
@@ -559,7 +551,6 @@ def _get_cuda_config(repository_ctx, find_cuda_config_script):
         cuda_toolkit_path = toolkit_path,
         cuda_version = cuda_version,
         cudnn_version = cudnn_version,
-        nccl_version = nccl_version,
         cuda_lib_version = cuda_lib_version,
         compute_capabilities = compute_capabilities(repository_ctx),
         cpu_value = cpu_value,
@@ -804,8 +795,7 @@ def _create_local_cuda_repository(repository_ctx):
     cudnn_header_dir = cuda_config.config["cudnn_include_dir"]
     cupti_header_dir = cuda_config.config["cupti_include_dir"]
     nvvm_libdevice_dir = cuda_config.config["nvvm_library_dir"]
-    nccl_header_dir = cuda_config.config["nccl_include_dir"]
-    nccl_libdevice_dir = cuda_config.config["nccl_library_dir"]
+
     # Create genrule to copy files from the installed CUDA toolkit into execroot.
     copy_rules = [
         make_copy_dir_rule(
@@ -828,31 +818,20 @@ def _create_local_cuda_repository(repository_ctx):
         ),
     ]
 
-    copy_rules.append(
-        make_copy_files_rule(
-            repository_ctx,
-            name = "cublas-include",
-            srcs = [
-                cublas_include_path + "/cublas.h",
-                cublas_include_path + "/cublas_v2.h",
-                cublas_include_path + "/cublas_api.h",
-            ],
-            outs = [
-                "cublas/include/cublas.h",
-                "cublas/include/cublas_v2.h",
-                "cublas/include/cublas_api.h",
-            ],
-        ),
-    )
-
-    copy_rules.append(
-        make_copy_files_rule(
-            repository_ctx,
-            name = "nccl-include",
-            srcs = [nccl_header_dir + "/nccl.h"],
-            outs = ["cuda/include/nccl.h"],
-        ),
-    )
+    copy_rules.append(make_copy_files_rule(
+        repository_ctx,
+        name = "cublas-include",
+        srcs = [
+            cublas_include_path + "/cublas.h",
+            cublas_include_path + "/cublas_v2.h",
+            cublas_include_path + "/cublas_api.h",
+        ],
+        outs = [
+            "cublas/include/cublas.h",
+            "cublas/include/cublas_v2.h",
+            "cublas/include/cublas_api.h",
+        ],
+    ))
 
     check_cuda_libs_script = repository_ctx.path(Label("//third_party/gpus:check_cuda_libs.py"))
     cuda_libs = _find_libs(repository_ctx, check_cuda_libs_script, cuda_config)
@@ -922,7 +901,6 @@ def _create_local_cuda_repository(repository_ctx):
             "%{curand_lib}": _basename(repository_ctx, cuda_libs["curand"]),
             "%{cupti_lib}": _basename(repository_ctx, cuda_libs["cupti"]),
             "%{cusparse_lib}": _basename(repository_ctx, cuda_libs["cusparse"]),
-            "%{nccl_lib}": _basename(repository_ctx, cuda_libs["nccl"]),
             "%{copy_rules}": "\n".join(copy_rules),
         },
     )


### PR DESCRIPTION
`nccl` was not available for aarch64 Jetson boards.
We decide to add `nccl` support in a way similar to how `TensorRT` was introduced.
RTFM: [TensorFlow: third_party/nccl](https://github.com/tensorflow/tensorflow/tree/master/third_party/nccl)
