### PR TITLE
Drivers: Change config of microphone due to firmware update

### DIFF
--- a/modules/drivers/microphone/conf/respeaker.pb.txt
+++ b/modules/drivers/microphone/conf/respeaker.pb.txt
@@ -1,6 +1,6 @@
 microphone_model: RESPEAKER
-chunk: 1024
-sample_rate: 16000
+chunk: 8192
+sample_rate: 48000
 record_seconds: 6
 sample_width: 2
 channel_name: "/apollo/sensor/microphone"

--- a/modules/drivers/microphone/microphone_component.cc
+++ b/modules/drivers/microphone/microphone_component.cc
@@ -38,8 +38,8 @@ bool MicrophoneComponent::Init() {
   // chunk_: number of frames per chunk; chunk_size_: number of bytes per chunk
   chunk_ = microphone_config_ptr_->chunk();
   n_chunk_ = static_cast<int>(
-      std::floor(microphone_config_ptr_->sample_rate() *
-                 microphone_config_ptr_->record_seconds() / chunk_));
+      std::ceil(microphone_config_ptr_->sample_rate() *
+                microphone_config_ptr_->record_seconds() / chunk_));
   chunk_size_ = chunk_ * n_channels_ * sample_width_;
   buffer_ = new char[chunk_size_];
   if (buffer_ == nullptr) {


### PR DESCRIPTION
* The firmware of Respeaker was updated to another version that supports higher sample_rate.
* Fix a small fault: `floor` to `ceil`... chunk is not small, it may be better to give a little more instead truncate data