### PR TITLE
Audio: add audio direction estimation code & fix bugs/lint

### DIFF
--- a/modules/audio/BUILD
+++ b/modules/audio/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
@@ -14,6 +14,7 @@ cc_library(
         "//cyber",
         "//modules/common/adapters:adapter_gflags",
         "//modules/audio/common:audio_info",
+        "//modules/audio/inference:direction_detection",
         "//modules/audio/proto:audio_cc_proto",
         "//modules/audio/proto:audio_conf_cc_proto",
         "//modules/drivers/microphone/proto:audio_cc_proto",

--- a/modules/audio/audio_component.cc
+++ b/modules/audio/audio_component.cc
@@ -15,7 +15,7 @@
  *****************************************************************************/
 
 #include "modules/audio/audio_component.h"
-
+#include "modules/audio/inference/direction_detection.h"
 #include "modules/audio/proto/audio_conf.pb.h"
 
 namespace apollo {
@@ -23,8 +23,7 @@ namespace audio {
 
 using apollo::drivers::microphone::config::AudioData;
 
-AudioComponent::~AudioComponent() {
-}
+AudioComponent::~AudioComponent() {}
 
 std::string AudioComponent::Name() const {
   // TODO(all) implement
@@ -48,7 +47,11 @@ bool AudioComponent::Init() {
 
 bool AudioComponent::Proc(const std::shared_ptr<AudioData>& audio_data) {
   audio_info_.Insert(audio_data);
-  // TODO(all) get data for following online processings
+  AINFO << "Current direction is: "
+        << get_direction(
+               audio_info_.GetSignals(audio_data->microphone_config().chunk()),
+               audio_data->microphone_config().sample_rate(),
+               audio_data->microphone_config().mic_distance());
   return true;
 }
 

--- a/modules/audio/audio_component.h
+++ b/modules/audio/audio_component.h
@@ -47,7 +47,7 @@ class AudioComponent
 
   bool Proc(
       const std::shared_ptr<apollo::drivers::microphone::config::AudioData>&)
-  override;
+      override;
 
  private:
   std::shared_ptr<cyber::Reader<localization::LocalizationEstimate>>

--- a/modules/audio/common/BUILD
+++ b/modules/audio/common/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])

--- a/modules/audio/inference/BUILD
+++ b/modules/audio/inference/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
@@ -7,6 +7,16 @@ cc_library(
     name = "moving_detection",
     srcs = ["moving_detection.cc"],
     hdrs = ["moving_detection.h"],
+)
+
+cc_library(
+    name = "direction_detection",
+    srcs = ["direction_detection.cc"],
+    hdrs = ["direction_detection.h"],
+    deps = [
+        "//third_party:libtorch",
+        "//cyber",
+    ],
 )
 
 cpplint()

--- a/modules/audio/inference/direction_detection.cc
+++ b/modules/audio/inference/direction_detection.cc
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * Copyright 2020 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/audio/inference/direction_detection.h"
+
+namespace apollo {
+namespace audio {
+
+using torch::indexing::None;
+using torch::indexing::Slice;
+
+int get_direction(std::vector<std::vector<float>>&& channels_vec,
+                  const int sample_rate, const int mic_distance) {
+  std::vector<torch::Tensor> channels_ts;
+  auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  int size = static_cast<int>(channels_vec[0].size());
+  for (auto& signal : channels_vec) {
+    channels_ts.push_back(torch::from_blob(signal.data(), {size}, options));
+  }
+
+  float tau0, tau1;
+  int theta0, theta1;
+  const float max_tau = mic_distance / SOUND_SPEED;
+  tau0 = gcc_phat(channels_ts[0], channels_ts[2], sample_rate, max_tau, 1);
+  theta0 = asin(tau0 / max_tau) * 180 / M_PI;
+  tau1 = gcc_phat(channels_ts[1], channels_ts[3], sample_rate, max_tau, 1);
+  theta1 = asin(tau1 / max_tau) * 180 / M_PI;
+
+  int best_guess = 0;
+  if (fabs(theta0) < fabs(theta1)) {
+    best_guess = theta1 > 0 ? (theta0 + 360) % 360 : (180 - theta0);
+  } else {
+    best_guess = theta0 < 0 ? (theta1 + 360) % 360 : (180 - theta1);
+    best_guess = (best_guess + 90 + 180) % 360;
+  }
+  best_guess = (-best_guess + 120) % 360;
+
+  return best_guess;
+}
+
+/*
+ * This function computes the offset between the signal sig and the reference
+ * signal refsig using the Generalized Cross Correlation - Phase Transform
+ * (GCC-PHAT)method.
+ */
+float gcc_phat(const torch::Tensor& sig, const torch::Tensor& refsig, int fs,
+               double max_tau, int interp) {
+  const int n_sig = sig.size(0), n_refsig = refsig.size(0),
+            n = n_sig + n_refsig;
+  torch::Tensor psig = at::constant_pad_nd(sig, {0, n_refsig}, 0);
+  torch::Tensor prefsig = at::constant_pad_nd(refsig, {0, n_sig}, 0);
+  psig = at::rfft(psig, 1, false, true);
+  prefsig = at::rfft(prefsig, 1, false, true);
+  torch::Tensor r = psig * at::conj(prefsig);
+  torch::Tensor cc = at::irfft(r / at::abs(r), 1, false, true, {interp * n});
+  int max_shift = static_cast<int>(interp * n / 2);
+  if (max_tau != 0)
+    max_shift = std::min(static_cast<int>(interp * fs * max_tau), max_shift);
+
+  auto begin = cc.index({Slice(0, cc.size(0) - max_shift, None)});
+  auto end = cc.index({Slice(0, None, max_shift + 1)});
+  cc = at::cat({begin, end});
+  auto ttt = at::argmax(at::abs(cc), 0);
+  // find max cross correlation index
+  const int shift = at::argmax(at::abs(cc), 0).item<int>() - max_shift;
+  const float tau = shift / static_cast<float>(interp * fs);
+
+  return tau;
+}
+
+}  // namespace audio
+}  // namespace apollo

--- a/modules/audio/inference/direction_detection.h
+++ b/modules/audio/inference/direction_detection.h
@@ -1,3 +1,4 @@
+
 /******************************************************************************
  * Copyright 2020 The Apollo Authors. All Rights Reserved.
  *
@@ -14,35 +15,25 @@
  * limitations under the License.
  *****************************************************************************/
 
-#include <deque>
-#include <memory>
-#include <string>
+#pragma once
+
+#include <algorithm>
+#include <cmath>
 #include <vector>
 
-#include "modules/drivers/microphone/proto/audio.pb.h"
-#include "modules/drivers/microphone/proto/microphone_config.pb.h"
+#include "ATen/ATen.h"
+#include "cyber/cyber.h"
+#include "torch/torch.h"
 
 namespace apollo {
 namespace audio {
 
-class AudioInfo {
- public:
-  AudioInfo() = default;
+constexpr float SOUND_SPEED = 343.2;
 
-  void Insert(
-      const std::shared_ptr<apollo::drivers::microphone::config::AudioData>&);
-
-  std::vector<std::vector<float>> GetSignals(const int signal_length);
-
- private:
-  void InsertChannelData(
-      const std::size_t index,
-      const apollo::drivers::microphone::config::ChannelData& channel_data,
-      const apollo::drivers::microphone::config::MicrophoneConfig&
-          microphone_config);
-
-  std::vector<std::deque<float>> signals_;
-};
+float gcc_phat(const torch::Tensor& sig, const torch::Tensor& refsig, int fs,
+               double max_tau, int interp);
+int get_direction(std::vector<std::vector<float>>&& channels_vec,
+                  const int sample_rate, const int mic_distance);
 
 }  // namespace audio
 }  // namespace apollo

--- a/modules/drivers/microphone/conf/respeaker.pb.txt
+++ b/modules/drivers/microphone/conf/respeaker.pb.txt
@@ -5,6 +5,7 @@ record_seconds: 6
 sample_width: 2
 channel_name: "/apollo/sensor/microphone"
 frame_id: "respeaker"
+mic_distance: 0.08127
 channel_type: ASR
 channel_type: RAW
 channel_type: RAW

--- a/modules/drivers/microphone/proto/microphone_config.proto
+++ b/modules/drivers/microphone/proto/microphone_config.proto
@@ -21,5 +21,6 @@ message MicrophoneConfig {
   optional int32 sample_width = 6; // in bytes
   optional string channel_name = 7;
   optional string frame_id = 8;
+  optional float mic_distance = 9;
   repeated ChannelType channel_type = 1;
 }


### PR DESCRIPTION
## Changes

* Add direction detection code
* `AudioInfo` Init was not invoked. Besides, we did not have a `microphone_config` to init it at first. So I remove the Init function & get `microphone_config` from `audio_data` dynamically.
* Signal is a signed `int` & due to some C++ weird problem, I change to the line that combines two raw `char` to a `int_16` to `int16_t signal = ((int16_t(data[i])) << 8) | (0x00ff & data[i + 1]);`
* Remove unnecessary symbols suggested by `buildifier`

## TODO

* Test direction detection