### PR TITLE
Control: fix the bug due to the wrong time unit which is cherry-pick from master

### DIFF
--- a/modules/control/control_component.cc
+++ b/modules/control/control_component.cc
@@ -398,7 +398,8 @@ bool ControlComponent::Proc() {
   const double time_diff_ms = absl::ToDoubleMilliseconds(end_time - start_time);
   control_command.mutable_latency_stats()->set_total_time_ms(time_diff_ms);
   control_command.mutable_latency_stats()->set_total_time_exceeded(
-      time_diff_ms > control_conf_.control_period());
+      time_diff_ms > absl::ToDoubleMilliseconds(
+                         absl::Seconds(control_conf_.control_period())));
   ADEBUG << "control cycle time is: " << time_diff_ms << " ms.";
   status.Save(control_command.mutable_header()->mutable_status());
 


### PR DESCRIPTION
Control: fix the bug due to the wrong time unit which is cherry-pick from master PR: Control: fix the bug due to the wrong time unit #10659 .