### PR TITLE
Perception: add conf for lgsvl dag

### DIFF
--- a/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf_lgsvl.pb.txt
+++ b/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf_lgsvl.pb.txt
@@ -1,0 +1,5 @@
+sensor_name: "velodyne128"
+enable_hdmap: true
+lidar_query_tf_offset: 200
+lidar2novatel_tf2_child_frame_id: "velodyne128"
+output_channel_name: "/perception/inner/DetectionObjects"

--- a/modules/perception/production/conf/perception/lidar/velodyne64_detection_conf.pb.txt
+++ b/modules/perception/production/conf/perception/lidar/velodyne64_detection_conf.pb.txt
@@ -1,0 +1,5 @@
+sensor_name: "velodyne64"
+enable_hdmap: true
+lidar_query_tf_offset: 0
+lidar2novatel_tf2_child_frame_id: "velodyne64"
+output_channel_name: "/perception/inner/DetectionObjects"

--- a/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
@@ -5,7 +5,7 @@ module_config {
     class_name : "DetectionComponent"
     config {
       name: "Velodyne128Detection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf.pb.txt"
+      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf_lgsvl.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
           channel: "/apollo/sensor/lidar128/compensator/PointCloud2"


### PR DESCRIPTION
Set `lidar_query_tf_offset` 200 in velodyne 128 detection for lgsvl, to solve the problem of matching timestamps.