### PR TITLE
Build: reuse or start volumes for CI run

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -407,7 +407,7 @@ function mount_map_volumes() {
 
     if [ "$FAST_MODE" = "no" ]; then
         for map_name in ${DEFAULT_MAPS[@]}; do
-            restart_map_volume_if_needed ${map_name} "${VOLUME_VERSION}"
+            restart_map_volume_if_needed "${map_name}" "${VOLUME_VERSION}"
         done
     else
         for map_name in ${DEFAULT_TEST_MAPS[@]}; do

--- a/modules/contrib/cyber_bridge/README.md
+++ b/modules/contrib/cyber_bridge/README.md
@@ -1,42 +1,50 @@
-# Apollo 3.5 Cyber bridge
+# Apollo Cyber bridge for the `master` branch
 
 This is bridge that exposes custom TCP socket for accepting and transmitting Cyber messages.
 
 # Building
 
-Place this contents of this folder in new `/apollo/cyber/bridge` folder.
+Run the build from the `/apollo` directory inside docker.
 
-Run the build:
-
-    bazel build //cyber/bridge:cyber_bridge
+```
+bazel build //modules/contrib/cyber_bridge
+```
 
 # Running
 
-Go in `/apollo` folder and execute:
+From the `/apollo` directory, execute:
 
-    ./bazel-bin/cyber/bridge/cyber_bridge
+```
+./bazel-bin/module/contrib/cyber_bridge/cyber_bridge
+```
 
 For extra logging:
 
-    GLOG_v=4 GLOG_logtostderr=1 ./bazel-bin/cyber/bridge/cyber_bridge
+```
+GLOG_v=4 GLOG_logtostderr=1 ./bazel-bin/modules/contrib/cyber_bridge/cyber_bridge
+```
 
 Add extra `-port 9090` argument for custom port (9090 is default).
 
-
 # Example
 
-In on terminal launch bridge:
+In one terminal launch `cyber_bridge`:
 
-    ./bazel-bin/cyber/bridge/cyber_bridge
+```
+./bazel-bin/modules/contrib/cyber_bridge/cyber_bridge
+```
 
 In another terminal launch example talker:
 
-    python cyber/python/examples/talker.py 
+```
+./bazel-bin/cyber/python/cyber_py3/examples/talker
+```
 
 In one more terminal launch example listener:
 
-    python cyber/python/examples/listener.py 
+```
+./bazel-bin/cyber/python/cyber_py3/examples/listener
+```
 
-Now you should see talker and listener sending & receiving message with incrementing integer.
-
+Now you should observe talker and listener sending & receiving message with incrementing integer.
 

--- a/scripts/bridge.sh
+++ b/scripts/bridge.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd "${DIR}/.."
+TOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${TOP_DIR}/scripts/apollo_base.sh"
 
-bazel-bin/modules/contrib/cyber_bridge/cyber_bridge
+${TOP_DIR}/bazel-bin/modules/contrib/cyber_bridge/cyber_bridge


### PR DESCRIPTION
To fix error msgs (see below) when running `run_ci.sh` on Teamcity.

```
  [INFO] Start pulling docker image apolloauto/apollo:map_volume-sunnyvale_with_two_offices-latest ...
19:38:44
  map_volume-sunnyvale_with_two_offices-latest: Pulling from apolloauto/apollo
19:38:44
  Digest: sha256:5893abb847f7cffb5dd310f9bac307d5c2537797c247eb1c609f36de1943bdf5
19:38:44
  Status: Image is up to date for apolloauto/apollo:map_volume-sunnyvale_with_two_offices-latest
19:38:44
  docker.io/apolloauto/apollo:map_volume-sunnyvale_with_two_offices-latest
19:38:45
  docker: Error response from daemon: Conflict. The container name "/apollo_map_volume-sunnyvale_with_two_offices_root" is already in use by container "75897d1962d75147642dfd2c456246cd4150b08568ca3eb471f31dfd067999c3". You have to remove (or rename) that container to be able to reuse that name.
19:38:45
  See 'docker run --help'.
```
