### PR TITLE
cyber_recorder close file asynchronously

### DIFF
--- a/cyber/record/record_writer.cc
+++ b/cyber/record/record_writer.cc
@@ -16,8 +16,11 @@
 
 #include "cyber/record/record_writer.h"
 
+#include <chrono>
+#include <future>
 #include <iomanip>
 #include <iostream>
+#include <utility>
 
 #include "cyber/common/log.h"
 
@@ -141,8 +144,11 @@ bool RecordWriter::WriteMessage(const SingleMessage& message) {
        message.time() - segment_begin_time_ > header_.segment_interval()) ||
       (header_.segment_raw_size() > 0 &&
        segment_raw_size_ > header_.segment_raw_size())) {
-    file_writer_backup_.swap(file_writer_);
-    file_writer_backup_->Close();
+    ACHECK(old_file_writer_closer_.wait_for(std::chrono::milliseconds(0)) ==
+           std::future_status::ready);
+    // Close the file via the destructor asynchronously
+    old_file_writer_closer_ = std::async(
+        std::launch::async, [](FileWriterPtr p) {}, std::move(file_writer_));
     if (!SplitOutfile()) {
       AERROR << "Split out file is failed.";
       return false;

--- a/cyber/record/record_writer.h
+++ b/cyber/record/record_writer.h
@@ -18,6 +18,7 @@
 #define CYBER_RECORD_RECORD_WRITER_H_
 
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -184,7 +185,9 @@ class RecordWriter : public RecordBase {
   MessageTypeMap channel_message_type_map_;
   MessageProtoDescMap channel_proto_desc_map_;
   FileWriterPtr file_writer_ = nullptr;
-  FileWriterPtr file_writer_backup_ = nullptr;
+  // Initialize with a dummy value to simplify checking later
+  std::future<void> old_file_writer_closer_ =
+      std::async(std::launch::async, []() {});
   std::mutex mutex_;
   std::stringstream sstream_;
 };


### PR DESCRIPTION
When `RecordWriter` calls `RecordFileWriter::Close`, it has to write out its data. There's a sleep in there for 100ms, if it doesn't write fast enough. during that time new messages are coming in. If too many messages come in, cyber's callback threads will be exhausted and messages will be stuck in the queue. The result is messages with the same received timestamp.

This proposed solution is to put the destructor call on another async task. The next time the file is split, the previous async operation cleaned up and a new async operation is created via `~future()` and `async` operation respectively. Similarly, std::future will clean itself up on `~RecordWriter`.