### PR TITLE
Audio: fix bugs & improve audio saver

### DIFF
--- a/modules/audio/common/audio_info.cc
+++ b/modules/audio/common/audio_info.cc
@@ -47,7 +47,7 @@ void AudioInfo::InsertChannelData(const std::size_t index,
   int width = microphone_config.sample_width();
   const std::string& data = channel_data.data();
   for (std::size_t i = 0; i < data.length(); i += width) {
-    int16_t signal = ((int16_t(data[i])) << 8) | (0x00ff & data[i + 1]);
+    int16_t signal = ((int16_t(data[i + 1])) << 8) | (0x00ff & data[i]);
     signals_[index].push_back(static_cast<double>(signal));
   }
   std::size_t max_signal_length = static_cast<std::size_t>(

--- a/modules/audio/inference/direction_detection.cc
+++ b/modules/audio/inference/direction_detection.cc
@@ -60,7 +60,7 @@ double DirectionDetection::EstimateDirection(
   }
 
   double tau0, tau1;
-  int theta0, theta1;
+  double theta0, theta1;
   const double max_tau = mic_distance / kSoundSpeed;
   tau0 = GccPhat(channels_ts[0], channels_ts[2], sample_rate, max_tau, 1);
   theta0 = asin(tau0 / max_tau) * 180 / M_PI;
@@ -69,12 +69,12 @@ double DirectionDetection::EstimateDirection(
 
   int best_guess = 0;
   if (fabs(theta0) < fabs(theta1)) {
-    best_guess = theta1 > 0 ? (theta0 + 360) % 360 : (180 - theta0);
+    best_guess = theta1 > 0 ? std::fmod(theta0 + 360, 360) : (180 - theta0);
   } else {
-    best_guess = theta0 < 0 ? (theta1 + 360) % 360 : (180 - theta1);
+    best_guess = theta0 < 0 ? std::fmod(theta1 + 360, 360) : (180 - theta1);
     best_guess = (best_guess + 90 + 180) % 360;
   }
-  best_guess = (-best_guess + 120) % 360;
+  best_guess = (-best_guess + 480) % 360;
 
   return static_cast<double>(best_guess) / 90 * M_PI;
 }


### PR DESCRIPTION
* Fix a bug that it is small endianness when assembling bytes.
* Since the frequency is increased, the duration of a single wave is too small. I pack them together. When finish playing the record, use ctrl+c to stop the audio saver program and it will save all frames to a wave file.