### PR TITLE
Scripts: mkl dependency goes to libtorch installer

### DIFF
--- a/docker/build/installers/install_libtorch.sh
+++ b/docker/build/installers/install_libtorch.sh
@@ -27,6 +27,9 @@ if [ "${TARGET_ARCH}" = "aarch64" ]; then
     exit 0
 fi
 
+# Libtorch-gpu dependency
+pip3_install mkl
+
 # PKG_NAME="libtorch-cxx11-abi-shared-with-deps-1.5.0.zip"
 # DOWNLOAD_LINK="https://download.pytorch.org/libtorch/cu102/${PKG_NAME}"
 # CHECKSUM="0efdd4e709ab11088fa75f0501c19b0e294404231442bab1d1fb953924feb6b5"

--- a/docker/build/installers/py3_requirements.txt
+++ b/docker/build/installers/py3_requirements.txt
@@ -32,5 +32,3 @@ utm
 numpy
 scipy
 
-# Libtorch-gpu dependency
-mkl


### PR DESCRIPTION
`mkl` can't be found on aarch64 platforms, and it was required when building `libtorch` from source only. As such, put the step of installing`mkl` python module to `libtorch` installer script.