### PR TITLE
monitor: use realtime timestamp to avoid node name duplication

### DIFF
--- a/modules/common/monitor_log/monitor_logger.cc
+++ b/modules/common/monitor_log/monitor_logger.cc
@@ -19,7 +19,7 @@
 
 #include "absl/strings/str_cat.h"
 
-using ::apollo::cyber::Clock;
+using ::apollo::cyber::Time;
 
 namespace apollo {
 namespace common {
@@ -27,7 +27,7 @@ namespace monitor {
 
 MonitorLogger::MonitorLogger() {
   const std::string node_name =
-      absl::StrCat("monitor_logger", Clock::Now().ToNanosecond());
+      absl::StrCat("monitor_logger", Time::Now().ToNanosecond());
   node_ = cyber::CreateNode(node_name);
   if (node_ != nullptr) {
     monitor_msg_writer_ =

--- a/modules/localization/rtk/rtk_localization_component.cc
+++ b/modules/localization/rtk/rtk_localization_component.cc
@@ -20,8 +20,6 @@
 namespace apollo {
 namespace localization {
 
-using apollo::cyber::Clock;
-
 RTKLocalizationComponent::RTKLocalizationComponent()
     : localization_(new RTKLocalization()) {}
 

--- a/modules/transform/buffer.cc
+++ b/modules/transform/buffer.cc
@@ -21,6 +21,7 @@
 #include "cyber/time/clock.h"
 #include "modules/common/adapters/adapter_gflags.h"
 
+using Time = ::apollo::cyber::Time;
 using Clock = ::apollo::cyber::Clock;
 
 namespace {
@@ -34,7 +35,7 @@ Buffer::Buffer() : BufferCore() { Init(); }
 
 int Buffer::Init() {
   const std::string node_name =
-      absl::StrCat("transform_listener_", Clock::Now().ToNanosecond());
+      absl::StrCat("transform_listener_", Time::Now().ToNanosecond());
   node_ = cyber::CreateNode(node_name);
   apollo::cyber::proto::RoleAttributes attr;
   attr.set_channel_name("/tf");


### PR DESCRIPTION
And, what about using PID for such node name? @xiaoxq 