### PR TITLE
Improve Conti radar preprocessor.

### DIFF
--- a/modules/perception/radar/common/types.h
+++ b/modules/perception/radar/common/types.h
@@ -22,7 +22,6 @@ namespace radar {
 const double PI = 3.1415926535898;
 const int MAX_RADAR_IDX = 2147483647;
 const double CONTI_ARS_INTERVAL = 0.074;
-const int ORIGIN_CONTI_MAX_ID_NUM = 100;
 const double MIN_PROBEXIST = 0.08;
 
 enum ContiObjectType {

--- a/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
+++ b/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.cc
@@ -21,7 +21,7 @@ namespace perception {
 namespace radar {
 
 int ContiArsPreprocessor::current_idx_ = 0;
-int ContiArsPreprocessor::local2global_[ORIGIN_CONTI_MAX_ID_NUM] = {0};
+std::unordered_map<int, int> ContiArsPreprocessor::local2global_;
 
 bool ContiArsPreprocessor::Init() {
   std::string model_name = "ContiArsPreprocessor";
@@ -70,15 +70,20 @@ void ContiArsPreprocessor::ExpandIds(drivers::ContiRadar* corrected_obstacles) {
   for (int iobj = 0; iobj < corrected_obstacles->contiobs_size(); ++iobj) {
     const auto& contiobs = corrected_obstacles->contiobs(iobj);
     int id = contiobs.obstacle_id();
-    if (CONTI_NEW == contiobs.meas_state()) {
-      local2global_[id] = GetNextId();
-    } else {
-      if (local2global_[id] == 0) {
-        local2global_[id] = GetNextId();
+    int corrected_id = 0;
+    auto ob = local2global_.find(id);
+    if (ob != local2global_.end()) {
+      if (CONTI_NEW == contiobs.meas_state()) {
+        corrected_id = GetNextId();
+        ob->second = corrected_id;
+      } else {
+        corrected_id = ob->second;
       }
+    } else {
+      corrected_id = GetNextId();
+      local2global_.insert({id, corrected_id});
     }
-    corrected_obstacles->mutable_contiobs(iobj)->set_obstacle_id(
-        local2global_[id]);
+    corrected_obstacles->mutable_contiobs(iobj)->set_obstacle_id(corrected_id);
   }
 }
 

--- a/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.h
+++ b/modules/perception/radar/lib/preprocessor/conti_ars_preprocessor/conti_ars_preprocessor.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 #include "cyber/common/macros.h"
 #include "modules/perception/radar/lib/interface/base_preprocessor.h"
@@ -48,7 +49,7 @@ class ContiArsPreprocessor : public BasePreprocessor {
 
   float delay_time_ = 0.0f;
   static int current_idx_;
-  static int local2global_[ORIGIN_CONTI_MAX_ID_NUM];
+  static std::unordered_map<int, int> local2global_;
 
   friend class ContiArsPreprocessorTest;
 


### PR DESCRIPTION
Enable the Conti Radar pre-processor to handle obstacles ids in the whole range int32 (previously only in the range 0-99).
This fix enable the use of LGSVL's RADAR for obstacle detection.