### PR TITLE
Disable the possible proxy for curl when obtaining the HTTP status code in the scripts/bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -31,7 +31,7 @@ function start() {
   ./scripts/dreamview.sh start
   if [ $? -eq 0 ]; then
     sleep 2 # wait for some time before starting to check
-    http_status="$(curl -o /dev/null -I -L -s -w '%{http_code}' ${DREAMVIEW_URL})"
+    http_status="$(curl -o /dev/null -x '' -I -L -s -w '%{http_code}' ${DREAMVIEW_URL})"
     if [ $http_status -eq 200 ]; then
       echo "Dreamview is running at" $DREAMVIEW_URL
     else


### PR DESCRIPTION
When the proxy is set for docker, it may defeat the curl testing used in the scripts/bootstrap.sh for obtaining the HTTP status code. OTOH, the  dreamview is running on localhost, which really don't need proxy for connection to. 

See here for more discussions on the relative problem:
https://github.com/ApolloAuto/apollo/issues/12285#issuecomment-682435918
