### PR TITLE
bazel dependency: add bos to download

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,10 @@ apollo_repositories()
 http_archive(
     name = "bazel_skylib",
     sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz"],
+    urls = [
+        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/bazel_skylib-0.9.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+    ],
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
@@ -20,8 +23,8 @@ http_archive(
     sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
     strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
     urls = [
+        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
         "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
     ],
 )
 
@@ -35,7 +38,10 @@ http_archive(
     name = "rules_python",
     sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
     strip_prefix = "rules_python-0.0.2",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+    urls = [
+        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/rules_python-0.0.2.tar.gz",
+        "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+    ],
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
@@ -59,7 +65,10 @@ http_archive(
     name = "com_github_grpc_grpc",
     sha256 = "419dba362eaf8f1d36849ceee17c3e2ff8ff12ac666b42d3ff02a164ebe090e9",
     strip_prefix = "grpc-1.30.0",
-    urls = ["https://github.com/grpc/grpc/archive/v1.30.0.tar.gz"],
+    urls = [
+        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/v1.30.0.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.30.0.tar.gz",
+    ],
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")


### PR DESCRIPTION
To speed up download speed and decrease Error situation,add bos to download.
if this change is OK, more will be modified in third party.