### PR TITLE
Best practice Hesai Driver

### DIFF
--- a/modules/drivers/hesai/BUILD
+++ b/modules/drivers/hesai/BUILD
@@ -7,38 +7,122 @@ cc_binary(
     name = "libhesai_driver_component.so",
     linkshared = True,
     linkstatic = False,
-    deps = [":driver"],
+    deps = [
+        ":hesai_component",
+        ":hesai_convert_component",
+    ],
+)
+
+cc_library(
+    name = "hesai_convert_component",
+    srcs = ["hesai_convert_component.cc"],
+    hdrs = ["hesai_convert_component.h"],
+    copts = ['-DMODULE_NAME=\\"hesai\\"'],
+    deps = [
+        ":driver",
+        ":parser_factory",
+        "//cyber",
+        "//modules/drivers/hesai/proto:config_cc_proto",
+    ],
+)
+
+cc_library(
+    name = "hesai_component",
+    srcs = ["hesai_component.cc"],
+    hdrs = ["hesai_component.h"],
+    copts = ['-DMODULE_NAME=\\"hesai\\"'],
+    deps = [
+        ":driver",
+        ":parser_factory",
+        "//cyber",
+        "//modules/drivers/hesai/proto:config_cc_proto",
+    ],
 )
 
 cc_library(
     name = "driver",
-    srcs = [
-        "component.cc",
-        "driver.cc",
-        "hesai40_parser.cc",
-        "hesai64_parser.cc",
-        "parser.cc",
-        "tcp_cmd_client.cc",
-        "udp_input.cc",
-    ],
-    hdrs = [
-        "const_var.h",
-        "driver.h",
-        "hesai_convert_component.h",
-        "hesai_driver_component.h",
-        "parser.h",
-        "tcp_cmd_client.h",
-        "type_defs.h",
-        "udp_input.h",
-    ],
-    copts = ['-DMODULE_NAME=\\"hesai\\"'],
+    srcs = ["driver.cc"],
+    hdrs = ["driver.h"],
     deps = [
+        ":parser",
+        ":type_defs",
+        ":udp_input",
         "//cyber",
-        "//modules/common/util",
+    ],
+)
+
+cc_library(
+    name = "parser_factory",
+    srcs = ["parser_factory.cc"],
+    hdrs = ["parser_factory.h"],
+    deps = [
+        ":hesai40_parser",
+        ":hesai64_parser",
+        ":parser",
+        "//cyber",
+    ],
+)
+
+cc_library(
+    name = "hesai64_parser",
+    srcs = ["hesai64_parser.cc"],
+    hdrs = ["hesai64_parser.h"],
+    deps = [
+        ":parser",
+        "//cyber",
+    ],
+)
+
+cc_library(
+    name = "hesai40_parser",
+    srcs = ["hesai40_parser.cc"],
+    hdrs = ["hesai40_parser.h"],
+    deps = [
+        ":parser",
+        "//cyber",
+    ],
+)
+
+cc_library(
+    name = "parser",
+    srcs = ["parser.cc"],
+    hdrs = ["parser.h"],
+    deps = [
+        ":tcp_cmd_client",
+        ":type_defs",
+        "//cyber",
         "//modules/drivers/hesai/proto:config_cc_proto",
         "//modules/drivers/hesai/proto:hesai_cc_proto",
         "//modules/drivers/proto:pointcloud_cc_proto",
     ],
+)
+
+cc_library(
+    name = "udp_input",
+    srcs = ["udp_input.cc"],
+    hdrs = ["udp_input.h"],
+    deps = [
+        ":type_defs",
+        "//cyber",
+    ],
+)
+
+cc_library(
+    name = "tcp_cmd_client",
+    srcs = ["tcp_cmd_client.cc"],
+    hdrs = ["tcp_cmd_client.h"],
+    deps = ["//cyber"],
+)
+
+cc_library(
+    name = "type_defs",
+    hdrs = ["type_defs.h"],
+    deps = [":const_var"],
+)
+
+cc_library(
+    name = "const_var",
+    hdrs = ["const_var.h"],
 )
 
 cpplint()

--- a/modules/drivers/hesai/BUILD
+++ b/modules/drivers/hesai/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+HESAI_COPTS = ['-DMODULE_NAME=\\"hesai\\"']
+
 cc_binary(
     name = "libhesai_driver_component.so",
     linkshared = True,
@@ -17,7 +19,7 @@ cc_library(
     name = "hesai_convert_component",
     srcs = ["hesai_convert_component.cc"],
     hdrs = ["hesai_convert_component.h"],
-    copts = ['-DMODULE_NAME=\\"hesai\\"'],
+    copts = HESAI_COPTS,
     deps = [
         ":driver",
         ":parser_factory",
@@ -30,7 +32,7 @@ cc_library(
     name = "hesai_component",
     srcs = ["hesai_component.cc"],
     hdrs = ["hesai_component.h"],
-    copts = ['-DMODULE_NAME=\\"hesai\\"'],
+    copts = HESAI_COPTS,
     deps = [
         ":driver",
         ":parser_factory",
@@ -43,6 +45,7 @@ cc_library(
     name = "driver",
     srcs = ["driver.cc"],
     hdrs = ["driver.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":parser",
         ":type_defs",
@@ -55,6 +58,7 @@ cc_library(
     name = "parser_factory",
     srcs = ["parser_factory.cc"],
     hdrs = ["parser_factory.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":hesai40_parser",
         ":hesai64_parser",
@@ -67,6 +71,7 @@ cc_library(
     name = "hesai64_parser",
     srcs = ["hesai64_parser.cc"],
     hdrs = ["hesai64_parser.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":parser",
         "//cyber",
@@ -77,6 +82,7 @@ cc_library(
     name = "hesai40_parser",
     srcs = ["hesai40_parser.cc"],
     hdrs = ["hesai40_parser.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":parser",
         "//cyber",
@@ -87,6 +93,7 @@ cc_library(
     name = "parser",
     srcs = ["parser.cc"],
     hdrs = ["parser.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":tcp_cmd_client",
         ":type_defs",
@@ -101,6 +108,7 @@ cc_library(
     name = "udp_input",
     srcs = ["udp_input.cc"],
     hdrs = ["udp_input.h"],
+    copts = HESAI_COPTS,
     deps = [
         ":type_defs",
         "//cyber",
@@ -111,6 +119,7 @@ cc_library(
     name = "tcp_cmd_client",
     srcs = ["tcp_cmd_client.cc"],
     hdrs = ["tcp_cmd_client.h"],
+    copts = HESAI_COPTS,
     deps = ["//cyber"],
 )
 

--- a/modules/drivers/hesai/driver.h
+++ b/modules/drivers/hesai/driver.h
@@ -29,36 +29,27 @@
 #include <vector>
 
 #include "cyber/cyber.h"
-#include "modules/drivers/hesai/const_var.h"
-#include "modules/drivers/hesai/driver.h"
 #include "modules/drivers/hesai/parser.h"
-#include "modules/drivers/hesai/proto/config.pb.h"
-#include "modules/drivers/hesai/proto/hesai.pb.h"
-#include "modules/drivers/hesai/type_defs.h"
 #include "modules/drivers/hesai/udp_input.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-using apollo::cyber::Node;
-using apollo::cyber::Writer;
-using apollo::drivers::hesai::HesaiScan;
-
 class HesaiDriver {
  public:
-  HesaiDriver(const std::shared_ptr<Node>& node, const Config& conf,
-              const std::shared_ptr<Parser>& parser)
+  HesaiDriver(const std::shared_ptr<::apollo::cyber::Node>& node,
+              const Config& conf, const std::shared_ptr<Parser>& parser)
       : node_(node), conf_(conf), parser_(parser) {}
   ~HesaiDriver() { Stop(); }
   bool Init();
 
  private:
-  std::shared_ptr<Node> node_ = nullptr;
+  std::shared_ptr<::apollo::cyber::Node> node_ = nullptr;
   Config conf_;
   std::shared_ptr<Parser> parser_ = nullptr;
   std::shared_ptr<Input> input_ = nullptr;
-  std::shared_ptr<Writer<HesaiScan>> scan_writer_ = nullptr;
+  std::shared_ptr<::apollo::cyber::Writer<HesaiScan>> scan_writer_ = nullptr;
   std::mutex packet_mutex_;
   std::condition_variable packet_condition_;
   std::thread poll_thread_;

--- a/modules/drivers/hesai/hesai40_parser.cc
+++ b/modules/drivers/hesai/hesai40_parser.cc
@@ -14,11 +14,14 @@
  * limitations under the License.
  *****************************************************************************/
 
-#include "modules/drivers/hesai/parser.h"
+#include "modules/drivers/hesai/hesai40_parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
+
+using ::apollo::cyber::Node;
+using apollo::drivers::PointXYZIT;
 
 Hesai40Parser::Hesai40Parser(const std::shared_ptr<Node> &node,
                              const Config &conf)

--- a/modules/drivers/hesai/hesai40_parser.h
+++ b/modules/drivers/hesai/hesai40_parser.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "cyber/cyber.h"
 #include "modules/drivers/hesai/parser.h"
 

--- a/modules/drivers/hesai/hesai40_parser.h
+++ b/modules/drivers/hesai/hesai40_parser.h
@@ -14,30 +14,30 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_SRC_INPUT_H_
-#define LIDAR_HESAI_SRC_INPUT_H_
+#pragma once
 
-#include <cstdint>
-#include "modules/drivers/hesai/type_defs.h"
+#include "cyber/cyber.h"
+#include "modules/drivers/hesai/parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-class Input {
+class Hesai40Parser : public Parser {
  public:
-  Input(uint16_t port, uint16_t gpsPort);
-  ~Input();
-  int GetPacket(HesaiPacket *pkt);
+  Hesai40Parser(const std::shared_ptr<::apollo::cyber::Node>& node,
+                const Config& conf);
+  ~Hesai40Parser();
+
+ protected:
+  void ParseRawPacket(const uint8_t* buf, const int len, bool* is_end) override;
 
  private:
-  int socketForLidar = -1;
-  int socketForGPS = -1;
-  int socketNumber = -1;
+  void CalcPointXYZIT(Hesai40Packet* pkt, int blockid);
+  double block_offset_[BLOCKS_PER_PACKET];
+  double laser_offset_[LASER_COUNT];
 };
 
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif  // SRC_INPUT_H_

--- a/modules/drivers/hesai/hesai64_parser.cc
+++ b/modules/drivers/hesai/hesai64_parser.cc
@@ -14,11 +14,14 @@
  * limitations under the License.
  *****************************************************************************/
 
-#include "modules/drivers/hesai/parser.h"
+#include "modules/drivers/hesai/hesai64_parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
+
+using Node = ::apollo::cyber::Node;
+using apollo::drivers::PointXYZIT;
 
 Hesai64Parser::Hesai64Parser(const std::shared_ptr<Node> &node,
                              const Config &conf)

--- a/modules/drivers/hesai/hesai64_parser.h
+++ b/modules/drivers/hesai/hesai64_parser.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "cyber/cyber.h"
 #include "modules/drivers/hesai/parser.h"
 

--- a/modules/drivers/hesai/hesai64_parser.h
+++ b/modules/drivers/hesai/hesai64_parser.h
@@ -14,30 +14,30 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_SRC_INPUT_H_
-#define LIDAR_HESAI_SRC_INPUT_H_
+#pragma once
 
-#include <cstdint>
-#include "modules/drivers/hesai/type_defs.h"
+#include "cyber/cyber.h"
+#include "modules/drivers/hesai/parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-class Input {
+class Hesai64Parser : public Parser {
  public:
-  Input(uint16_t port, uint16_t gpsPort);
-  ~Input();
-  int GetPacket(HesaiPacket *pkt);
+  Hesai64Parser(const std::shared_ptr<::apollo::cyber::Node>& node,
+                const Config& conf);
+  ~Hesai64Parser();
+
+ protected:
+  void ParseRawPacket(const uint8_t* buf, const int len, bool* is_end) override;
 
  private:
-  int socketForLidar = -1;
-  int socketForGPS = -1;
-  int socketNumber = -1;
+  void CalcPointXYZIT(Hesai64Packet* pkt, int blockid, uint8_t chLaserNumber);
+  double block_offset_[BLOCKS_PER_PACKET_L64] = {0};
+  double laser_offset_[LASER_COUNT_L64] = {0};
 };
 
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif  // SRC_INPUT_H_

--- a/modules/drivers/hesai/hesai_component.cc
+++ b/modules/drivers/hesai/hesai_component.cc
@@ -13,31 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *****************************************************************************/
-
-#ifndef LIDAR_HESAI_SRC_INPUT_H_
-#define LIDAR_HESAI_SRC_INPUT_H_
-
-#include <cstdint>
-#include "modules/drivers/hesai/type_defs.h"
+#include "modules/drivers/hesai/hesai_component.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-class Input {
- public:
-  Input(uint16_t port, uint16_t gpsPort);
-  ~Input();
-  int GetPacket(HesaiPacket *pkt);
+bool HesaiComponent::Init() {
+  if (!GetProtoConfig(&conf_)) {
+    AERROR << "load config error, file:" << config_file_path_;
+    return false;
+  }
 
- private:
-  int socketForLidar = -1;
-  int socketForGPS = -1;
-  int socketNumber = -1;
-};
+  AINFO << "conf:" << conf_.DebugString();
+  Parser* parser = ParserFactory::CreateParser(node_, conf_);
+  if (parser == nullptr) {
+    AERROR << "create parser error";
+    return false;
+  }
+  parser_.reset(parser);
+  driver_.reset(new HesaiDriver(node_, conf_, parser_));
+
+  if (!driver_->Init()) {
+    AERROR << "driver init error";
+    return false;
+  }
+  return true;
+}
 
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif  // SRC_INPUT_H_

--- a/modules/drivers/hesai/hesai_component.h
+++ b/modules/drivers/hesai/hesai_component.h
@@ -14,51 +14,24 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_HESAI_ALL_COMPONENT_H_
-#define LIDAR_HESAI_HESAI_ALL_COMPONENT_H_
+#pragma once
 
-#include <list>
 #include <memory>
 #include <string>
-#include <thread>
 
-#include "cyber/cyber.h"
-#include "modules/drivers/hesai/const_var.h"
-#include "modules/drivers/hesai/driver.h"
-#include "modules/drivers/hesai/parser.h"
 #include "modules/drivers/hesai/proto/config.pb.h"
-#include "modules/drivers/hesai/type_defs.h"
+#include "cyber/cyber.h"
+#include "modules/drivers/hesai/driver.h"
+#include "modules/drivers/hesai/parser_factory.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-using apollo::cyber::Component;
-
-class HesaiComponent : public Component<> {
+class HesaiComponent : public ::apollo::cyber::Component<> {
  public:
   ~HesaiComponent() {}
-  bool Init() override {
-    if (!GetProtoConfig(&conf_)) {
-      AERROR << "load config error, file:" << config_file_path_;
-      return false;
-    }
-
-    AINFO << "conf:" << conf_.DebugString();
-    Parser* parser = ParserFactory::CreateParser(node_, conf_);
-    if (parser == nullptr) {
-      AERROR << "create parser error";
-      return false;
-    }
-    parser_.reset(parser);
-    driver_.reset(new HesaiDriver(node_, conf_, parser_));
-
-    if (!driver_->Init()) {
-      AERROR << "driver init error";
-      return false;
-    }
-    return true;
-  }
+  bool Init() override;
 
  private:
   std::shared_ptr<HesaiDriver> driver_;
@@ -71,5 +44,3 @@ CYBER_REGISTER_COMPONENT(HesaiComponent)
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif

--- a/modules/drivers/hesai/hesai_convert_component.cc
+++ b/modules/drivers/hesai/hesai_convert_component.cc
@@ -15,4 +15,38 @@
  *****************************************************************************/
 
 #include "modules/drivers/hesai/hesai_convert_component.h"
-#include "modules/drivers/hesai/hesai_driver_component.h"
+
+namespace apollo {
+namespace drivers {
+namespace hesai {
+
+using apollo::cyber::Component;
+
+bool HesaiConvertComponent::Init() {
+  if (!GetProtoConfig(&conf_)) {
+    AERROR << "load config error, file:" << config_file_path_;
+    return false;
+  }
+
+  AINFO << "conf:" << conf_.DebugString();
+  Parser* parser = ParserFactory::CreateParser(node_, conf_);
+  if (parser == nullptr) {
+    AERROR << "create parser error";
+    return false;
+  }
+  parser_.reset(parser);
+
+  if (!parser_->Init()) {
+    return false;
+  }
+  AINFO << "HesaiConvertComponent init success";
+  return true;
+}
+
+bool HesaiConvertComponent::Proc(const std::shared_ptr<HesaiScan>& scan) {
+  return parser_->Parse(scan);
+}
+
+}  // namespace hesai
+}  // namespace drivers
+}  // namespace apollo

--- a/modules/drivers/hesai/hesai_convert_component.h
+++ b/modules/drivers/hesai/hesai_convert_component.h
@@ -14,56 +14,26 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_HESAI_CONVERT_COMPONENT_H_
-#define LIDAR_HESAI_HESAI_CONVERT_COMPONENT_H_
+#pragma once
 
-#include <list>
 #include <memory>
 #include <string>
-#include <thread>
-
-#include "cyber/cyber.h"
-#include "modules/drivers/hesai/const_var.h"
-#include "modules/drivers/hesai/parser.h"
-#include "modules/drivers/hesai/type_defs.h"
 
 #include "modules/drivers/hesai/proto/config.pb.h"
 #include "modules/drivers/hesai/proto/hesai.pb.h"
+#include "cyber/cyber.h"
+#include "modules/drivers/hesai/parser_factory.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-using apollo::cyber::Component;
-using apollo::drivers::hesai::HesaiScan;
-
-class HesaiConvertComponent : public Component<HesaiScan> {
+class HesaiConvertComponent : public ::apollo::cyber::Component<HesaiScan> {
  public:
-  ~HesaiConvertComponent() {}
-  bool Init() override {
-    if (!GetProtoConfig(&conf_)) {
-      AERROR << "load config error, file:" << config_file_path_;
-      return false;
-    }
+  virtual ~HesaiConvertComponent() = default;
+  bool Init() override;
 
-    AINFO << "conf:" << conf_.DebugString();
-    Parser* parser = ParserFactory::CreateParser(node_, conf_);
-    if (parser == nullptr) {
-      AERROR << "create parser error";
-      return false;
-    }
-    parser_.reset(parser);
-
-    if (!parser_->Init()) {
-      return false;
-    }
-    AINFO << "HesaiConvertComponent init success";
-    return true;
-  }
-
-  bool Proc(const std::shared_ptr<HesaiScan>& scan) override {
-    return parser_->Parse(scan);
-  }
+  bool Proc(const std::shared_ptr<HesaiScan>& scan) override;
 
  private:
   std::shared_ptr<Parser> parser_;
@@ -75,5 +45,3 @@ CYBER_REGISTER_COMPONENT(HesaiConvertComponent)
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif

--- a/modules/drivers/hesai/parser.cc
+++ b/modules/drivers/hesai/parser.cc
@@ -24,7 +24,10 @@ namespace apollo {
 namespace drivers {
 namespace hesai {
 
-Parser::Parser(const std::shared_ptr<Node>& node, const Config& conf)
+using apollo::drivers::PointCloud;
+
+Parser::Parser(const std::shared_ptr<::apollo::cyber::Node>& node,
+               const Config& conf)
     : node_(node), conf_(conf) {
   tz_second_ = conf_.time_zone() * 3600;
   start_angle_ = static_cast<int>(conf_.start_angle() * 100);
@@ -266,18 +269,6 @@ void Parser::CheckPktTime(double time_sec) {
     // AWARN << conf_.frame_id() << " time too big, diff:" << diff
     //       << "host time:" << now << ";lidar time:" << time_sec;
   }
-}
-
-Parser* ParserFactory::CreateParser(const std::shared_ptr<Node>& node,
-                                    const Config& conf) {
-  if (conf.model() == HESAI40P) {
-    return new Hesai40Parser(node, conf);
-  } else if (conf.model() == HESAI64) {
-    return new Hesai64Parser(node, conf);
-  }
-
-  AERROR << "only support HESAI40P | HESAI64";
-  return nullptr;
 }
 
 }  // namespace hesai

--- a/modules/drivers/hesai/parser_factory.cc
+++ b/modules/drivers/hesai/parser_factory.cc
@@ -14,30 +14,29 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_SRC_INPUT_H_
-#define LIDAR_HESAI_SRC_INPUT_H_
+#include "modules/drivers/hesai/parser_factory.h"
 
-#include <cstdint>
-#include "modules/drivers/hesai/type_defs.h"
+#include "modules/drivers/hesai/hesai40_parser.h"
+#include "modules/drivers/hesai/hesai64_parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-class Input {
- public:
-  Input(uint16_t port, uint16_t gpsPort);
-  ~Input();
-  int GetPacket(HesaiPacket *pkt);
+using ::apollo::cyber::Node;
 
- private:
-  int socketForLidar = -1;
-  int socketForGPS = -1;
-  int socketNumber = -1;
-};
+Parser* ParserFactory::CreateParser(const std::shared_ptr<Node>& node,
+                                    const Config& conf) {
+  if (conf.model() == HESAI40P) {
+    return new Hesai40Parser(node, conf);
+  } else if (conf.model() == HESAI64) {
+    return new Hesai64Parser(node, conf);
+  }
+
+  AERROR << "only support HESAI40P | HESAI64";
+  return nullptr;
+}
 
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif  // SRC_INPUT_H_

--- a/modules/drivers/hesai/parser_factory.h
+++ b/modules/drivers/hesai/parser_factory.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "cyber/cyber.h"
 #include "modules/drivers/hesai/parser.h"
 

--- a/modules/drivers/hesai/parser_factory.h
+++ b/modules/drivers/hesai/parser_factory.h
@@ -14,30 +14,21 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef LIDAR_HESAI_SRC_INPUT_H_
-#define LIDAR_HESAI_SRC_INPUT_H_
+#pragma once
 
-#include <cstdint>
-#include "modules/drivers/hesai/type_defs.h"
+#include "cyber/cyber.h"
+#include "modules/drivers/hesai/parser.h"
 
 namespace apollo {
 namespace drivers {
 namespace hesai {
 
-class Input {
+class ParserFactory {
  public:
-  Input(uint16_t port, uint16_t gpsPort);
-  ~Input();
-  int GetPacket(HesaiPacket *pkt);
-
- private:
-  int socketForLidar = -1;
-  int socketForGPS = -1;
-  int socketNumber = -1;
+  static Parser* CreateParser(
+      const std::shared_ptr<::apollo::cyber::Node>& node, const Config& conf);
 };
 
 }  // namespace hesai
 }  // namespace drivers
 }  // namespace apollo
-
-#endif  // SRC_INPUT_H_

--- a/modules/drivers/hesai/tcp_cmd_client.cc
+++ b/modules/drivers/hesai/tcp_cmd_client.cc
@@ -15,25 +15,22 @@
  *****************************************************************************/
 
 #include <arpa/inet.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <linux/sockios.h>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <pthread.h>
-#include <setjmp.h>
-#include <signal.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
-#include <sys/ipc.h>
 #include <sys/msg.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <syslog.h>
 #include <unistd.h>
+#include <linux/sockios.h>
+
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
 
 #include "cyber/cyber.h"
 #include "modules/drivers/hesai/tcp_cmd_client.h"

--- a/modules/drivers/hesai/type_defs.h
+++ b/modules/drivers/hesai/type_defs.h
@@ -17,6 +17,7 @@
 #ifndef LIDAR_HESAI_SRC_TYPE_DEFS_H_
 #define LIDAR_HESAI_SRC_TYPE_DEFS_H_
 
+#include <ctime>
 #include "modules/drivers/hesai/const_var.h"
 
 namespace apollo {

--- a/modules/drivers/hesai/udp_input.cc
+++ b/modules/drivers/hesai/udp_input.cc
@@ -14,18 +14,20 @@
  * limitations under the License.
  *****************************************************************************/
 
+#include "modules/drivers/hesai/udp_input.h"
+
 #include <arpa/inet.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <string.h>
 #include <sys/file.h>
 #include <sys/socket.h>
-#include <sys/time.h>
-#include <iostream>
+
+#include <cerrno>
+#include <cstring>
+
 #include <sstream>
 
-#include "modules/drivers/hesai/udp_input.h"
+#include "cyber/cyber.h"
 
 namespace apollo {
 namespace drivers {


### PR DESCRIPTION
Demo PR to show Best Practices on Building C++ with Bazel.


1) Avoid using "using xxx;"  in header files.
2) Split targets into smaller ones, as described here: https://docs.bazel.build/versions/master/bazel-and-cpp.html#build-files
3) Shared `HESAI_COPTS` variable, See: https://docs.bazel.build/versions/master/skylark/tutorial-sharing-variables.html
4) Include necessary headers **ONLY**
5) Prefer C++ headers to C headers. E.g., using `<ctime>` rather than `<time.h>`
6) Pay attention to header orders. Run `scripts/apollo_format.sh modules/drivers/hesai` to format C/C++ files and BAZEL BUILD files.
7) Don't Over/Under estimate your dependency. No more, No less
8) Using `scripts/mdfmt.sh path/or/file` to format markdown/json/yaml files.

@xiaoxq @changsh726 @lfcarol @lx18233184051 @Capri2014 @jinghaomiao 
