### PR TITLE
Drivers: fix bug about lidar messages

### DIFF
--- a/modules/drivers/velodyne/fusion/pri_sec_fusion_component.cc
+++ b/modules/drivers/velodyne/fusion/pri_sec_fusion_component.cc
@@ -43,7 +43,7 @@ bool PriSecFusionComponent::Init() {
 
 bool PriSecFusionComponent::Proc(
     const std::shared_ptr<PointCloud>& point_cloud) {
-  auto target = point_cloud;
+  auto target = std::make_shared<PointCloud>(*point_cloud);
   auto fusion_readers = readers_;
   auto start_time = Time::Now().ToSecond();
   while ((Time::Now().ToSecond() - start_time) < conf_.wait_time_s() &&


### PR DESCRIPTION
Solve two bugs :
  1. "/apollo/sensor/lidar16/front/center/Scan" and "/apollo/sensor/lidar16/front/center/PointCloud2" message frequency inconsistency.
  2. When the "driver/velodyne" runs for long time, the messages "/apollo/sensor/lidarXXX/compensator/PointCloud2" don't output.