### PR TITLE
Change scripts which use "pgrep" to avoid PID 1.

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -136,7 +136,7 @@ function decide_task_dir() {
 function is_stopped_customized_path() {
   MODULE_PATH=$1
   MODULE=$2
-  NUM_PROCESSES="$(pgrep -c -f "modules/${MODULE_PATH}/launch/${MODULE}.launch")"
+  NUM_PROCESSES="$(pgrep -f "modules/${MODULE_PATH}/launch/${MODULE}.launch" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     return 1
   else

--- a/scripts/camera.sh
+++ b/scripts/camera.sh
@@ -25,7 +25,7 @@ source "${DIR}/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/camera.out"
   CMD="cyber_launch start /apollo/modules/drivers/camera/launch/camera.launch"
-  NUM_PROCESSES="$(pgrep -c -f "modules/drivers/camera/dag/camera.dag")"
+  NUM_PROCESSES="$(pgrep -f "modules/drivers/camera/dag/camera.dag" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/camera_and_video.sh
+++ b/scripts/camera_and_video.sh
@@ -25,7 +25,7 @@ source "${DIR}/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/camera_and_video.out"
   CMD="cyber_launch start /apollo/modules/drivers/camera/launch/camera_and_video.launch"
-  NUM_PROCESSES=$(expr "$(pgrep -c -f "modules/drivers/camera/dag/camera.dag")" + "$(pgrep -c -f "modules/drivers/video/dag/video.dag")")
+  NUM_PROCESSES=$(expr "$(pgrep -f "modules/drivers/camera/dag/camera.dag" | grep -cv '^1$')" + "$(pgrep -f "modules/drivers/video/dag/video.dag" | grep -cv '^1$')")
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/lidar_calibration.sh
+++ b/scripts/lidar_calibration.sh
@@ -75,7 +75,7 @@ function start_record() {
   MODULE="republish_msg"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "modules/calibration/${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "modules/calibration/${MODULE}" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${APOLLO_BIN_PREFIX}/modules/calibration/${MODULE}/${MODULE} \
       --flagfile=${APOLLO_ROOT_DIR}/modules/calibration/${MODULE}/conf/${MODULE}.conf \
@@ -89,7 +89,7 @@ function start_record() {
   fi
 
   # start to record lidar calibration data
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record -b 2048 -O lidar_calib.bag \
       /apollo/sensor/gnss/ins_stat \
@@ -123,7 +123,7 @@ function start_check_extrin() {
   MODULE="lidar_ex_checker"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "modules/calibration/${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "modules/calibration/${MODULE}" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Start program, Ctrl+C to exit."
     eval "${APOLLO_BIN_PREFIX}/modules/calibration/${MODULE}/${MODULE} \

--- a/scripts/navigation_usb_camera.sh
+++ b/scripts/navigation_usb_camera.sh
@@ -25,7 +25,7 @@ source "${DIR}/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/usb_cam.out"
   CMD="roslaunch usb_cam start_obstacle_camera.launch"
-  NUM_PROCESSES="$(pgrep -c -f "camera_nodelet_manager")"
+  NUM_PROCESSES="$(pgrep -f "camera_nodelet_manager" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/record_bag.py
+++ b/scripts/record_bag.py
@@ -252,7 +252,7 @@ class Recorder(object):
     @staticmethod
     def is_running():
         """Test if the given process running."""
-        _, stdout, _ = shell_cmd('pgrep -c -f "cyber_recorder record"', False)
+        _, stdout, _ = shell_cmd('pgrep -f "cyber_recorder record" | grep -cv '^1$'', False)
         # If stdout is the pgrep command itself, no such process is running.
         return stdout.strip() != '1' if stdout else False
 

--- a/scripts/record_bag.sh
+++ b/scripts/record_bag.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "cyber_recorder record")"
+  NUM_PROCESSES="$(pgrep -f "cyber_recorder record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup cyber_recorder record -a -i 60 -m 2048 /apollo/sensor/camera/obstacle/front_6mm \
       /apollo/sensor/conti_radar \

--- a/scripts/record_bag_local.sh
+++ b/scripts/record_bag_local.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record --split --duration=1m -b 2048 \
       /apollo/sensor/gnss/best_pose \

--- a/scripts/record_bag_navigation_perception.sh
+++ b/scripts/record_bag_navigation_perception.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record --split --duration=1m -b 2048 \
       /apollo/sensor/camera/obstacle/front_6mm \

--- a/scripts/record_bag_pnc.sh
+++ b/scripts/record_bag_pnc.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record --split --duration=10m -b 2048 \
       /apollo/sensor/conti_radar \

--- a/scripts/record_bag_sensor.sh
+++ b/scripts/record_bag_sensor.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record --split --duration=1m -b 2048 \
       /apollo/sensor/camera/traffic/image_short \

--- a/scripts/record_map_data.py
+++ b/scripts/record_map_data.py
@@ -169,7 +169,7 @@ class Recorder(object):
     @staticmethod
     def is_running():
         """Test if the given process running."""
-        _, stdout, _ = shell_cmd('pgrep -c -f "cyber_recorder record"', False)
+        _, stdout, _ = shell_cmd('pgrep -f "cyber_recorder record" | grep -cv '^1$'', False)
         # If stdout is the pgrep command itself, no such process is running.
         return stdout.strip() != '1' if stdout else False
 

--- a/scripts/record_map_data.sh
+++ b/scripts/record_map_data.sh
@@ -27,7 +27,7 @@ function start() {
   # Start recording.
   record_bag_env_log
   LOG="/tmp/apollo_record.out"
-  NUM_PROCESSES="$(pgrep -c -f "rosbag record")"
+  NUM_PROCESSES="$(pgrep -f "rosbag record" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     nohup rosbag record --split --duration=1m -b 2048 \
       /apollo/sensor/camera/traffic/image_long \

--- a/scripts/record_message.py
+++ b/scripts/record_message.py
@@ -142,7 +142,7 @@ class Recorder(object):
     @staticmethod
     def is_running():
         """Test if the given process running."""
-        _, stdout, _ = shell_cmd('pgrep -c -f "smart_recorder"', False)
+        _, stdout, _ = shell_cmd('pgrep -f "smart_recorder" | grep -cv '^1$'', False)
         # If stdout is the pgrep command itself, no such process is running.
         return stdout.strip() != '1' if stdout else False
 

--- a/scripts/rtk_player.sh
+++ b/scripts/rtk_player.sh
@@ -27,7 +27,7 @@ function setup() {
 }
 
 function start() {
-  NUM_PROCESSES="$(pgrep -c -f "record_play/rtk_player")"
+  NUM_PROCESSES="$(pgrep -f "record_play/rtk_player" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -ne 0 ]; then
     pkill -SIGKILL -f rtk_player
   fi

--- a/scripts/rtk_recorder.sh
+++ b/scripts/rtk_recorder.sh
@@ -32,7 +32,7 @@ function start() {
     cp data/log/garage.csv data/log/garage-${TIME}.csv
   fi
 
-  NUM_PROCESSES="$(pgrep -c -f "record_play/rtk_recorder")"
+  NUM_PROCESSES="$(pgrep -f "record_play/rtk_recorder" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     ${TOP_DIR}/bazel-bin/modules/tools/record_play/rtk_recorder
   fi

--- a/scripts/sensor_calibration.sh
+++ b/scripts/sensor_calibration.sh
@@ -25,7 +25,7 @@ function calibrate_camera_camera() {
   MODULE="camera_camera_calibrator"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "${MODULE}" | grep -cv '^1$')"
 
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Start to calibrate Camera-Camera extrinsics, Ctrl+C to exit."
@@ -41,7 +41,7 @@ function calibrate_lidar_camera() {
   MODULE="lidar_camera_calibrator"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "${MODULE}" | grep -cv '^1$')"
 
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Start to calibrate LiDAR-Camera extrinsics, Ctrl+C to exit."
@@ -56,7 +56,7 @@ function calibrate_radar_camera() {
   MODULE="radar_camera_calibrator"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "${MODULE}" | grep -cv '^1$')"
 
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Start to calibrate Radar-Camera extrinsics, Ctrl+C to exit."
@@ -71,7 +71,7 @@ function visualize_radar_lidar() {
   MODULE="radar_lidar_visualizer"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "${MODULE}" | grep -cv '^1$')"
 
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Visualize Radar and LiDAR data, Ctrl+C to exit."
@@ -86,7 +86,7 @@ function calibrate_imu_vehicle() {
   MODULE="imu_car_calibrator"
 
   # check if the module has started
-  NUM_PROCESSES="$(pgrep -c -f "${MODULE}")"
+  NUM_PROCESSES="$(pgrep -f "${MODULE}" | grep -cv '^1$')"
 
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     echo "Start to calibrate Imu-Vehicle extrinsics, Ctrl+C to exit."

--- a/scripts/transform.sh
+++ b/scripts/transform.sh
@@ -22,7 +22,7 @@ source "${DIR}/scripts/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/transform.out"
   CMD="cyber_launch start /apollo/modules/transform/launch/static_transform.launch"
-  NUM_PROCESSES="$(pgrep -c -f "modules/transform/dag/static_transform.dag")"
+  NUM_PROCESSES="$(pgrep -f "modules/transform/dag/static_transform.dag" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/velodyne.sh
+++ b/scripts/velodyne.sh
@@ -22,7 +22,7 @@ source "${DIR}/scripts/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/velodyne.out"
   CMD="cyber_launch start /apollo/modules/drivers/velodyne/launch/velodyne.launch"
-  NUM_PROCESSES="$(pgrep -c -f "/apollo/modules/drivers/velodyne/dag/velodyne.dag")"
+  NUM_PROCESSES="$(pgrep -f "/apollo/modules/drivers/velodyne/dag/velodyne.dag" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/velodyne_16.sh
+++ b/scripts/velodyne_16.sh
@@ -25,7 +25,7 @@ source "${DIR}/scripts/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/velodyne16.out"
   CMD="roslaunch velodyne start_velodyne_16.launch"
-  NUM_PROCESSES="$(pgrep -c -f "sensor_velodyne16")"
+  NUM_PROCESSES="$(pgrep -f "sensor_velodyne16" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi

--- a/scripts/velodyne_for_map_data_colloector.sh
+++ b/scripts/velodyne_for_map_data_colloector.sh
@@ -22,7 +22,7 @@ source "${DIR}/scripts/apollo_base.sh"
 function start() {
   LOG="${APOLLO_ROOT_DIR}/data/log/velodyne.out"
   CMD="roslaunch velodyne start_velodyne_for_map_data_collector.launch"
-  NUM_PROCESSES="$(pgrep -c -f "velodyne_nodelet_manager")"
+  NUM_PROCESSES="$(pgrep -f "velodyne_nodelet_manager" | grep -cv '^1$')"
   if [ "${NUM_PROCESSES}" -eq 0 ]; then
     eval "nohup ${CMD} </dev/null >${LOG} 2>&1 &"
   fi


### PR DESCRIPTION
Apollo uses `pgrep -c -f` to determine if processes are running. Unfortunately, this finds them in the inline container startup command. This is a problem when we try to run Apollo in our own container on cloud where the container startup command contains some strings matching Apollo's pgrep string.

This change uses of `pgrep -f` to ignore when PID 1 is output by filtering the output with `| grep -v '^1$'`, and use `| wc -l` to count the lines of the output.