### PR TITLE
Update apollo.sh fix bug

### DIFF
--- a/apollo.sh
+++ b/apollo.sh
@@ -822,7 +822,7 @@ function main() {
       cibuild_extended $@
       ;;
     build_opt)
-      DEFINES="${DEFINES} --cxxopt=-DCPU_ONLY --copt=-fpic"
+      DEFINES="${DEFINES} --cxxopt=-DCPU_ONLY --copt=-fPIC"
       apollo_build_opt $@
       ;;
     build_gpu)
@@ -831,12 +831,12 @@ function main() {
       ;;
     build_opt_gpu)
       set_use_gpu
-      DEFINES="${DEFINES} --copt=-fpic"
+      DEFINES="${DEFINES} --copt=-fPIC"
       apollo_build_opt $@
       ;;
     build_teleop)
       set_use_gpu
-      DEFINES="${DEFINES} --copt=-fpic --define WITH_TELEOP=1 --cxxopt=-DTELEOP"
+      DEFINES="${DEFINES} --copt=-fPIC --define WITH_TELEOP=1 --cxxopt=-DTELEOP"
       apollo_build_opt $@
       ;;
     build_fe)


### PR DESCRIPTION
When building apollo as opt method on arm platform, should change `-fpic` to `-fPIC` or will failed. 

Reasons below:

```
-fpic Generate position-independent code (PIC) suitable for use in a shared library, if supported for the target machine. Such code accesses all constant addresses through a global offset table (GOT). The dynamic loader resolves the GOT entries when the program starts (the dynamic loader is not part of GCC; it is part of the operating system). If the GOT size for the linked executable exceeds a machine-specific maximum size, you get an error message from the linker indicating that -fpic does not work; in that case, recompile with -fPIC instead. (These maximums are 8k on the SPARC, 28k on AArch64 and 32k on the m68k and RS/6000. The x86 has no such limit.) Position-independent code requires special support, and therefore works only on certain machines. For the x86, GCC supports PIC for System V but not for the Sun 386i. Code generated for the IBM RS/6000 is always position-independent. When this flag is set, the macros __pic__ and __PIC__ are defined to 1. -fPIC If supported for the target machine, emit position-independent code, suitable for dynamic linking and avoiding any limit on the size of the global offset table. This option makes a difference on AArch64, m68k, PowerPC and SPARC. Position-independent code requires special support, and therefore works only on certain machines. When this flag is set, the macros __pic__ and __PIC__ are defined to 2.
```