### PR TITLE
routing: (1) fixed an issue where end_s is shorter than start_s in so…

### DIFF
--- a/modules/routing/core/result_generator.h
+++ b/modules/routing/core/result_generator.h
@@ -57,8 +57,8 @@ class ResultGenerator {
                           RoutingResponse* result);
 
   void AddRoadSegment(const std::vector<PassageInfo>& passages,
-                      const std::pair<std::size_t, std::size_t>& start,
-                      const std::pair<std::size_t, std::size_t>& end,
+                      const std::pair<std::size_t, std::size_t>& start_index,
+                      const std::pair<std::size_t, std::size_t>& end_index,
                       RoutingResponse* result);
   void ExtendPassages(const TopoRangeManager& range_manager,
                       std::vector<PassageInfo>* const passages);


### PR DESCRIPTION
…me result segment; (2) use index instead of index of end_iter for end_index.second to be consistent with other indices and avoid confution