### PR TITLE
Cyber: improve the visual effect for cyber_monitor

### DIFF
--- a/cyber/tools/cyber_monitor/cyber_topology_message.cc
+++ b/cyber/tools/cyber_monitor/cyber_topology_message.cc
@@ -53,9 +53,9 @@ bool CyberTopologyMessage::isFromHere(const std::string& nodeName) {
   return (templateName.compare(baseName) == 0);
 }
 
-RenderableMessage* CyberTopologyMessage::Child(int lineNo) const {
+RenderableMessage* CyberTopologyMessage::Child(int line_no) const {
   RenderableMessage* ret = nullptr;
-  auto iter = findChild(lineNo);
+  auto iter = findChild(line_no);
   if (iter != all_channels_map_.cend() &&
       !GeneralChannelMessage::isErrorCode(iter->second) &&
       iter->second->is_enabled()) {
@@ -65,13 +65,13 @@ RenderableMessage* CyberTopologyMessage::Child(int lineNo) const {
 }
 
 std::map<std::string, GeneralChannelMessage*>::const_iterator
-CyberTopologyMessage::findChild(int lineNo) const {
-  --lineNo;
+CyberTopologyMessage::findChild(int line_no) const {
+  --line_no;
 
   std::map<std::string, GeneralChannelMessage*>::const_iterator ret =
       all_channels_map_.cend();
 
-  if (lineNo > -1 && lineNo < page_item_count_) {
+  if (line_no > -1 && line_no < page_item_count_) {
     int i = 0;
 
     auto iter = all_channels_map_.cbegin();
@@ -81,7 +81,7 @@ CyberTopologyMessage::findChild(int lineNo) const {
     }
 
     for (i = 0; iter != all_channels_map_.cend(); ++iter) {
-      if (i == lineNo) {
+      if (i == line_no) {
         ret = iter;
         break;
       }

--- a/cyber/tools/cyber_monitor/cyber_topology_message.cc
+++ b/cyber/tools/cyber_monitor/cyber_topology_message.cc
@@ -206,7 +206,7 @@ void CyberTopologyMessage::ChangeState(const Screen* s, int key) {
   }
 }
 
-void CyberTopologyMessage::Render(const Screen* s, int key) {
+int CyberTopologyMessage::Render(const Screen* s, int key) {
   page_item_count_ = s->Height() - 1;
   pages_ = static_cast<int>(all_channels_map_.size()) / page_item_count_ + 1;
   ChangeState(s, key);
@@ -275,4 +275,6 @@ void CyberTopologyMessage::Render(const Screen* s, int key) {
     }
     s->ClearCurrentColor();
   }
+
+  return line;
 }

--- a/cyber/tools/cyber_monitor/cyber_topology_message.h
+++ b/cyber/tools/cyber_monitor/cyber_topology_message.h
@@ -39,7 +39,7 @@ class CyberTopologyMessage : public RenderableMessage {
   explicit CyberTopologyMessage(const std::string& channel);
   ~CyberTopologyMessage();
 
-  void Render(const Screen* s, int key) override;
+  int Render(const Screen* s, int key) override;
   RenderableMessage* Child(int index) const override;
 
   void TopologyChanged(const apollo::cyber::proto::ChangeMsg& change_msg);

--- a/cyber/tools/cyber_monitor/general_channel_message.cc
+++ b/cyber/tools/cyber_monitor/general_channel_message.cc
@@ -152,36 +152,36 @@ int GeneralChannelMessage::Render(const Screen* s, int key) {
 
   clear();
 
-  int lineNo = 0;
+  int line_no = 0;
 
   s->SetCurrentColor(Screen::WHITE_BLACK);
-  s->AddStr(0, lineNo++, "ChannelName: ");
+  s->AddStr(0, line_no++, "ChannelName: ");
   s->AddStr(channel_reader_->GetChannelName().c_str());
 
-  s->AddStr(0, lineNo++, "MessageType: ");
+  s->AddStr(0, line_no++, "MessageType: ");
   s->AddStr(message_type().c_str());
 
   if (is_enabled()) {
     switch (current_state_) {
       case State::ShowDebugString:
-        RenderDebugString(s, key, lineNo);
+        RenderDebugString(s, key, line_no);
         break;
       case State::ShowInfo:
-        RenderInfo(s, key, lineNo);
+        RenderInfo(s, key, line_no);
         break;
     }
   } else {
-    s->AddStr(0, lineNo++, "Channel has been closed");
+    s->AddStr(0, line_no++, "Channel has been closed");
   }
   s->ClearCurrentColor();
 
-  return lineNo;
+  return line_no;
 }
 
 void GeneralChannelMessage::RenderInfo(const Screen* s, int key,
-                                       int& lineNo) {
-  page_item_count_ = s->Height() - lineNo;
-  pages_ = static_cast<int>(readers_.size() + writers_.size() + lineNo) /
+                                       int& line_no) {
+  page_item_count_ = s->Height() - line_no;
+  pages_ = static_cast<int>(readers_.size() + writers_.size() + line_no) /
                page_item_count_ +
            1;
   SplitPages(key);
@@ -208,24 +208,24 @@ void GeneralChannelMessage::RenderInfo(const Screen* s, int key,
   }
 
   if (hasReader) {
-    s->AddStr(0, lineNo++, "Readers:");
+    s->AddStr(0, line_no++, "Readers:");
     for (; iter != vec->cend(); ++iter) {
-      s->AddStr(ReaderWriterOffset, lineNo++, iter->c_str());
+      s->AddStr(ReaderWriterOffset, line_no++, iter->c_str());
     }
 
-    ++lineNo;
+    ++line_no;
     vec = &writers_;
     iter = vec->cbegin();
   }
 
-  s->AddStr(0, lineNo++, "Writers:");
+  s->AddStr(0, line_no++, "Writers:");
   for (; iter != vec->cend(); ++iter) {
-    s->AddStr(ReaderWriterOffset, lineNo++, iter->c_str());
+    s->AddStr(ReaderWriterOffset, line_no++, iter->c_str());
   }
 }
 
 void GeneralChannelMessage::RenderDebugString(const Screen* s, int key,
-                                              int& lineNo) {
+                                              int& line_no) {
   if (has_message_come()) {
     if (raw_msg_class_ == nullptr) {
       auto rawFactory = apollo::cyber::message::ProtobufFactory::Instance();
@@ -233,9 +233,9 @@ void GeneralChannelMessage::RenderDebugString(const Screen* s, int key,
     }
 
     if (raw_msg_class_ == nullptr) {
-      s->AddStr(0, lineNo++, "Cannot Generate Message by Message Type");
+      s->AddStr(0, line_no++, "Cannot Generate Message by Message Type");
     } else {
-      s->AddStr(0, lineNo++, "FrameRatio: ");
+      s->AddStr(0, line_no++, "FrameRatio: ");
 
       std::ostringstream outStr;
       outStr << std::fixed << std::setprecision(FrameRatio_Precision)
@@ -245,7 +245,7 @@ void GeneralChannelMessage::RenderDebugString(const Screen* s, int key,
       decltype(channel_message_) channelMsg = CopyMsgPtr();
 
       if (channelMsg->message.size()) {
-        s->AddStr(0, lineNo++, "RawMessage Size: ");
+        s->AddStr(0, line_no++, "RawMessage Size: ");
         outStr.str("");
         outStr << channelMsg->message.size() << " Bytes";
         if (channelMsg->message.size() >= kGB) {
@@ -261,22 +261,22 @@ void GeneralChannelMessage::RenderDebugString(const Screen* s, int key,
         s->AddStr(outStr.str().c_str());
         if (raw_msg_class_->ParseFromString(channelMsg->message)) {
           int lcount = lineCount(*raw_msg_class_, s->Width());
-          page_item_count_ = s->Height() - lineNo;
+          page_item_count_ = s->Height() - line_no;
           pages_ = lcount / page_item_count_ + 1;
           SplitPages(key);
           int jumpLines = page_index_ * page_item_count_;
           jumpLines <<= 2;
           jumpLines /= 5;
           GeneralMessageBase::PrintMessage(this, *raw_msg_class_, jumpLines, s,
-                                           lineNo, 0);
+                                           line_no, 0);
         } else {
-          s->AddStr(0, lineNo++, "Cannot parse the raw message");
+          s->AddStr(0, line_no++, "Cannot parse the raw message");
         }
       } else {
-        s->AddStr(0, lineNo++, "The size of this raw Message is Zero");
+        s->AddStr(0, line_no++, "The size of this raw Message is Zero");
       }
     }
   } else {
-    s->AddStr(0, lineNo++, "No Message Came");
+    s->AddStr(0, line_no++, "No Message Came");
   }
 }

--- a/cyber/tools/cyber_monitor/general_channel_message.cc
+++ b/cyber/tools/cyber_monitor/general_channel_message.cc
@@ -135,7 +135,7 @@ GeneralChannelMessage* GeneralChannelMessage::OpenChannel(
   return this;
 }
 
-void GeneralChannelMessage::Render(const Screen* s, int key) {
+int GeneralChannelMessage::Render(const Screen* s, int key) {
   switch (key) {
     case 'b':
     case 'B':
@@ -152,7 +152,7 @@ void GeneralChannelMessage::Render(const Screen* s, int key) {
 
   clear();
 
-  unsigned lineNo = 0;
+  int lineNo = 0;
 
   s->SetCurrentColor(Screen::WHITE_BLACK);
   s->AddStr(0, lineNo++, "ChannelName: ");
@@ -174,10 +174,12 @@ void GeneralChannelMessage::Render(const Screen* s, int key) {
     s->AddStr(0, lineNo++, "Channel has been closed");
   }
   s->ClearCurrentColor();
+
+  return lineNo;
 }
 
 void GeneralChannelMessage::RenderInfo(const Screen* s, int key,
-                                       unsigned lineNo) {
+                                       int& lineNo) {
   page_item_count_ = s->Height() - lineNo;
   pages_ = static_cast<int>(readers_.size() + writers_.size() + lineNo) /
                page_item_count_ +
@@ -223,7 +225,7 @@ void GeneralChannelMessage::RenderInfo(const Screen* s, int key,
 }
 
 void GeneralChannelMessage::RenderDebugString(const Screen* s, int key,
-                                              unsigned lineNo) {
+                                              int& lineNo) {
   if (has_message_come()) {
     if (raw_msg_class_ == nullptr) {
       auto rawFactory = apollo::cyber::message::ProtobufFactory::Instance();

--- a/cyber/tools/cyber_monitor/general_channel_message.h
+++ b/cyber/tools/cyber_monitor/general_channel_message.h
@@ -85,7 +85,7 @@ class GeneralChannelMessage : public GeneralMessageBase {
     }
   }
 
-  void Render(const Screen* s, int key) override;
+  int Render(const Screen* s, int key) override;
 
   void CloseChannel(void) {
     if (channel_reader_ != nullptr) {
@@ -159,8 +159,8 @@ class GeneralChannelMessage : public GeneralMessageBase {
 
   GeneralChannelMessage* OpenChannel(const std::string& channelName);
 
-  void RenderDebugString(const Screen* s, int key, unsigned lineNo);
-  void RenderInfo(const Screen* s, int key, unsigned lineNo);
+  void RenderDebugString(const Screen* s, int key, int& lineNo);
+  void RenderInfo(const Screen* s, int key, int& lineNo);
 
   void set_has_message_come(bool b) { has_message_come_ = b; }
 

--- a/cyber/tools/cyber_monitor/general_channel_message.h
+++ b/cyber/tools/cyber_monitor/general_channel_message.h
@@ -159,8 +159,8 @@ class GeneralChannelMessage : public GeneralMessageBase {
 
   GeneralChannelMessage* OpenChannel(const std::string& channelName);
 
-  void RenderDebugString(const Screen* s, int key, int& lineNo);
-  void RenderInfo(const Screen* s, int key, int& lineNo);
+  void RenderDebugString(const Screen* s, int key, int& line_no);
+  void RenderInfo(const Screen* s, int key, int& line_no);
 
   void set_has_message_come(bool b) { has_message_come_ = b; }
 

--- a/cyber/tools/cyber_monitor/general_message.cc
+++ b/cyber/tools/cyber_monitor/general_message.cc
@@ -82,12 +82,10 @@ GeneralMessage::GeneralMessage(GeneralMessageBase* parent,
       message_ptr_(msg),
       reflection_ptr_(reflection) {}
 
-void GeneralMessage::Render(const Screen* s, int key) {
+int GeneralMessage::Render(const Screen* s, int key) {
   s->SetCurrentColor(Screen::WHITE_BLACK);
-
+  int lineNo = 0;
   {
-    unsigned lineNo = 0;
-
     RenderableMessage* p = this;
     while (p->parent()->parent()->parent()) {
       p = p->parent();
@@ -112,7 +110,7 @@ void GeneralMessage::Render(const Screen* s, int key) {
     auto channelMsg = channelMsgPtr->CopyMsgPtr();
     if (!channelMsgPtr->raw_msg_class_->ParseFromString(channelMsg->message)) {
       s->AddStr(0, lineNo++, "Cannot Parse the message for Real-Time Updating");
-      return;
+      return lineNo;
     }
 
     if (message_ptr_ && reflection_ptr_) {
@@ -130,7 +128,7 @@ void GeneralMessage::Render(const Screen* s, int key) {
         outStr.str("");
         outStr << "The item [" << itemIndex_ << "] has been empty !!!";
         s->AddStr(0, lineNo++, outStr.str().c_str());
-        return;
+        return lineNo;
       }
 
       if (key == ',') {
@@ -183,4 +181,5 @@ void GeneralMessage::Render(const Screen* s, int key) {
   }
 
   s->ClearCurrentColor();
+  return lineNo;
 }

--- a/cyber/tools/cyber_monitor/general_message.cc
+++ b/cyber/tools/cyber_monitor/general_message.cc
@@ -84,7 +84,7 @@ GeneralMessage::GeneralMessage(GeneralMessageBase* parent,
 
 int GeneralMessage::Render(const Screen* s, int key) {
   s->SetCurrentColor(Screen::WHITE_BLACK);
-  int lineNo = 0;
+  int line_no = 0;
   {
     RenderableMessage* p = this;
     while (p->parent()->parent()->parent()) {
@@ -93,24 +93,24 @@ int GeneralMessage::Render(const Screen* s, int key) {
 
     GeneralChannelMessage* channelMsgPtr =
         static_cast<GeneralChannelMessage*>(p->parent());
-    s->AddStr(0, lineNo++, "ChannelName: ");
+    s->AddStr(0, line_no++, "ChannelName: ");
     s->AddStr(channelMsgPtr->GetChannelName().c_str());
 
-    s->AddStr(0, lineNo++, "MessageType: ");
+    s->AddStr(0, line_no++, "MessageType: ");
     s->AddStr(channelMsgPtr->message_type().c_str());
 
     std::ostringstream outStr;
     outStr << std::fixed << std::setprecision(FrameRatio_Precision)
            << channelMsgPtr->frame_ratio();
-    s->AddStr(0, lineNo++, "FrameRatio: ");
+    s->AddStr(0, line_no++, "FrameRatio: ");
     s->AddStr(outStr.str().c_str());
 
     clear();
 
     auto channelMsg = channelMsgPtr->CopyMsgPtr();
     if (!channelMsgPtr->raw_msg_class_->ParseFromString(channelMsg->message)) {
-      s->AddStr(0, lineNo++, "Cannot Parse the message for Real-Time Updating");
-      return lineNo;
+      s->AddStr(0, line_no++, "Cannot Parse the message for Real-Time Updating");
+      return line_no;
     }
 
     if (message_ptr_ && reflection_ptr_) {
@@ -127,8 +127,8 @@ int GeneralMessage::Render(const Screen* s, int key) {
       if (size <= itemIndex_) {
         outStr.str("");
         outStr << "The item [" << itemIndex_ << "] has been empty !!!";
-        s->AddStr(0, lineNo++, outStr.str().c_str());
-        return lineNo;
+        s->AddStr(0, line_no++, outStr.str().c_str());
+        return line_no;
       }
 
       if (key == ',') {
@@ -157,7 +157,7 @@ int GeneralMessage::Render(const Screen* s, int key) {
 
       int lcount = lineCountOfField(*message_ptr_, s->Width(), field_,
                                     reflection_ptr_, is_folded_);
-      page_item_count_ = s->Height() - lineNo - 8;
+      page_item_count_ = s->Height() - line_no - 8;
       if (page_item_count_ < 1) {
         page_item_count_ = 1;
       }
@@ -168,12 +168,12 @@ int GeneralMessage::Render(const Screen* s, int key) {
           SortProtobufMapByKeys(*message_ptr_, field_, *reflection_ptr_, size));
       if (is_folded_) {
         GeneralMessageBase::PrintField(this, *message_ptr_, jumpLines, s,
-                                       lineNo, 0, reflection_ptr_, field_,
+                                       line_no, 0, reflection_ptr_, field_,
                                        indices[itemIndex_]);
       } else {
         for (const int index : indices) {
           GeneralMessageBase::PrintField(this, *message_ptr_, jumpLines, s,
-                                         lineNo, 0, reflection_ptr_, field_,
+                                         line_no, 0, reflection_ptr_, field_,
                                          index);
         }
       }
@@ -181,5 +181,5 @@ int GeneralMessage::Render(const Screen* s, int key) {
   }
 
   s->ClearCurrentColor();
-  return lineNo;
+  return line_no;
 }

--- a/cyber/tools/cyber_monitor/general_message.h
+++ b/cyber/tools/cyber_monitor/general_message.h
@@ -36,7 +36,7 @@ class GeneralMessage : public GeneralMessageBase {
     reflection_ptr_ = nullptr;
   }
 
-  void Render(const Screen* s, int key) override;
+  int Render(const Screen* s, int key) override;
 
  private:
   GeneralMessage(const GeneralMessage&) = delete;

--- a/cyber/tools/cyber_monitor/general_message_base.cc
+++ b/cyber/tools/cyber_monitor/general_message_base.cc
@@ -131,7 +131,7 @@ int GeneralMessageBase::lineCountOfField(
 void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
                                       const google::protobuf::Message& msg,
                                       int& jumpLines, const Screen* s,
-                                      int& lineNo, int indent) {
+                                      int& line_no, int indent) {
   const google::protobuf::Reflection* reflection = msg.GetReflection();
   const google::protobuf::Descriptor* descriptor = msg.GetDescriptor();
   std::vector<const google::protobuf::FieldDescriptor*> fields;
@@ -142,7 +142,7 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
     reflection->ListFields(msg, &fields);
   }
   for (std::size_t i = 0; i < fields.size(); ++i) {
-    if (lineNo > s->Height()) {
+    if (line_no > s->Height()) {
       break;
     }
     const google::protobuf::FieldDescriptor* field = fields[i];
@@ -157,12 +157,12 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
         GeneralMessage* item =
             new GeneralMessage(baseMsg, &msg, reflection, field);
         if (item) {
-          baseMsg->insertRepeatedMessage(lineNo, item);
+          baseMsg->insertRepeatedMessage(line_no, item);
         }
-        s->AddStr(indent, lineNo++, outStr.str().c_str());
+        s->AddStr(indent, line_no++, outStr.str().c_str());
       }
     } else {
-      PrintField(baseMsg, msg, jumpLines, s, lineNo, indent, reflection, field,
+      PrintField(baseMsg, msg, jumpLines, s, line_no, indent, reflection, field,
                  -1);
     }  // end else
   }    // end for
@@ -173,7 +173,7 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
     Screen::ColorPair c = s->Color();
     s->ClearCurrentColor();
     s->SetCurrentColor(Screen::RED_BLACK);
-    s->AddStr(indent, lineNo++, "Have Unknown Fields");
+    s->AddStr(indent, line_no++, "Have Unknown Fields");
     s->ClearCurrentColor();
     s->SetCurrentColor(c);
   }
@@ -181,7 +181,7 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
 
 void GeneralMessageBase::PrintField(
     GeneralMessageBase* baseMsg, const google::protobuf::Message& msg,
-    int& jumpLines, const Screen* s, int& lineNo, int indent,
+    int& jumpLines, const Screen* s, int& line_no, int indent,
     const google::protobuf::Reflection* ref,
     const google::protobuf::FieldDescriptor* field, int index) {
   std::ostringstream outStr;
@@ -204,7 +204,7 @@ void GeneralMessageBase::PrintField(
                      ? ref->GetRepeated##METHOD(msg, field, index) \
                      : ref->Get##METHOD(msg, field));              \
       outStr.flags(old_flags);                                     \
-      s->AddStr(indent, lineNo++, outStr.str().c_str());           \
+      s->AddStr(indent, line_no++, outStr.str().c_str());           \
     }                                                              \
     break
 
@@ -266,8 +266,8 @@ void GeneralMessageBase::PrintField(
             outStr << ch;
           }
 
-          s->AddStr(indent, lineNo, outStr.str().c_str());
-          lineNo += lineCount;
+          s->AddStr(indent, line_no, outStr.str().c_str());
+          line_no += lineCount;
         }
       }
 
@@ -293,7 +293,7 @@ void GeneralMessageBase::PrintField(
         } else {
           outStr << enum_value;
         }
-        s->AddStr(indent, lineNo++, outStr.str().c_str());
+        s->AddStr(indent, line_no++, outStr.str().c_str());
       }
       break;
     }
@@ -308,7 +308,7 @@ void GeneralMessageBase::PrintField(
             outStr << "[" << index << "] ";
           }
         }
-        s->AddStr(indent, lineNo++, outStr.str().c_str());
+        s->AddStr(indent, line_no++, outStr.str().c_str());
       } else {
         --jumpLines;
       }
@@ -316,16 +316,16 @@ void GeneralMessageBase::PrintField(
           baseMsg,
           field->is_repeated() ? ref->GetRepeatedMessage(msg, field, index)
                                : ref->GetMessage(msg, field),
-          jumpLines, s, lineNo, indent + 2);
+          jumpLines, s, line_no, indent + 2);
       break;
   }
 }
 
-RenderableMessage* GeneralMessageBase::Child(int lineNo) const {
-  if (lineNo < 0) {
+RenderableMessage* GeneralMessageBase::Child(int line_no) const {
+  if (line_no < 0) {
     return nullptr;
   }
-  auto iter = children_map_.find(lineNo);
+  auto iter = children_map_.find(line_no);
   if (iter == children_map_.cend()) {
     return nullptr;
   }

--- a/cyber/tools/cyber_monitor/general_message_base.cc
+++ b/cyber/tools/cyber_monitor/general_message_base.cc
@@ -131,7 +131,7 @@ int GeneralMessageBase::lineCountOfField(
 void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
                                       const google::protobuf::Message& msg,
                                       int& jumpLines, const Screen* s,
-                                      unsigned& lineNo, int indent) {
+                                      int& lineNo, int indent) {
   const google::protobuf::Reflection* reflection = msg.GetReflection();
   const google::protobuf::Descriptor* descriptor = msg.GetDescriptor();
   std::vector<const google::protobuf::FieldDescriptor*> fields;
@@ -142,7 +142,7 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
     reflection->ListFields(msg, &fields);
   }
   for (std::size_t i = 0; i < fields.size(); ++i) {
-    if (lineNo > static_cast<unsigned>(s->Height())) {
+    if (lineNo > s->Height()) {
       break;
     }
     const google::protobuf::FieldDescriptor* field = fields[i];
@@ -181,7 +181,7 @@ void GeneralMessageBase::PrintMessage(GeneralMessageBase* baseMsg,
 
 void GeneralMessageBase::PrintField(
     GeneralMessageBase* baseMsg, const google::protobuf::Message& msg,
-    int& jumpLines, const Screen* s, unsigned& lineNo, int indent,
+    int& jumpLines, const Screen* s, int& lineNo, int indent,
     const google::protobuf::Reflection* ref,
     const google::protobuf::FieldDescriptor* field, int index) {
   std::ostringstream outStr;

--- a/cyber/tools/cyber_monitor/general_message_base.h
+++ b/cyber/tools/cyber_monitor/general_message_base.h
@@ -29,10 +29,10 @@ class GeneralMessageBase : public RenderableMessage {
  protected:
   static void PrintMessage(GeneralMessageBase* baseMsg,
                            const google::protobuf::Message& msg, int& jumpLines,
-                           const Screen* s, int& lineNo, int indent);
+                           const Screen* s, int& line_no, int indent);
   static void PrintField(GeneralMessageBase* baseMsg,
                          const google::protobuf::Message& msg, int& jumpLines,
-                         const Screen* s, int& lineNo, int indent,
+                         const Screen* s, int& line_no, int indent,
                          const google::protobuf::Reflection* ref,
                          const google::protobuf::FieldDescriptor* field,
                          int index);
@@ -44,11 +44,11 @@ class GeneralMessageBase : public RenderableMessage {
                               const google::protobuf::Reflection* reflection,
                               bool is_folded = true);
 
-  void insertRepeatedMessage(int lineNo, GeneralMessageBase* item) {
-    children_map_.insert(std::make_pair(lineNo, item));
+  void insertRepeatedMessage(int line_no, GeneralMessageBase* item) {
+    children_map_.insert(std::make_pair(line_no, item));
   }
 
-  RenderableMessage* Child(int lineNo) const override;
+  RenderableMessage* Child(int line_no) const override;
 
   explicit GeneralMessageBase(RenderableMessage* parent = nullptr)
       : RenderableMessage(parent), children_map_() {}

--- a/cyber/tools/cyber_monitor/general_message_base.h
+++ b/cyber/tools/cyber_monitor/general_message_base.h
@@ -29,10 +29,10 @@ class GeneralMessageBase : public RenderableMessage {
  protected:
   static void PrintMessage(GeneralMessageBase* baseMsg,
                            const google::protobuf::Message& msg, int& jumpLines,
-                           const Screen* s, unsigned& lineNo, int indent);
+                           const Screen* s, int& lineNo, int indent);
   static void PrintField(GeneralMessageBase* baseMsg,
                          const google::protobuf::Message& msg, int& jumpLines,
-                         const Screen* s, unsigned& lineNo, int indent,
+                         const Screen* s, int& lineNo, int indent,
                          const google::protobuf::Reflection* ref,
                          const google::protobuf::FieldDescriptor* field,
                          int index);

--- a/cyber/tools/cyber_monitor/renderable_message.h
+++ b/cyber/tools/cyber_monitor/renderable_message.h
@@ -26,8 +26,8 @@ class RenderableMessage {
   static constexpr int FrameRatio_Precision = 2;
 
   explicit RenderableMessage(RenderableMessage* parent = nullptr,
-                             int lineNo = 0)
-      : line_no_(lineNo),
+                             int line_no = 0)
+      : line_no_(line_no),
         pages_(1),
         page_index_(0),
         page_item_count_(24),
@@ -37,7 +37,7 @@ class RenderableMessage {
   virtual ~RenderableMessage() { parent_ = nullptr; }
 
   virtual int Render(const Screen* s, int key) = 0;
-  virtual RenderableMessage* Child(int /* lineNo */) const = 0;
+  virtual RenderableMessage* Child(int /* line_no */) const = 0;
 
   virtual double frame_ratio(void) { return frame_ratio_; }
 
@@ -53,7 +53,7 @@ class RenderableMessage {
 
  protected:
   int* line_no(void) { return &line_no_; }
-  void set_line_no(int lineNo) { line_no_ = lineNo; }
+  void set_line_no(int line_no) { line_no_ = line_no; }
   void reset_line_page(void) {
     line_no_ = 0;
     page_index_ = 0;

--- a/cyber/tools/cyber_monitor/renderable_message.h
+++ b/cyber/tools/cyber_monitor/renderable_message.h
@@ -36,7 +36,7 @@ class RenderableMessage {
 
   virtual ~RenderableMessage() { parent_ = nullptr; }
 
-  virtual void Render(const Screen* s, int key) = 0;
+  virtual int Render(const Screen* s, int key) = 0;
   virtual RenderableMessage* Child(int /* lineNo */) const = 0;
 
   virtual double frame_ratio(void) { return frame_ratio_; }

--- a/cyber/tools/cyber_monitor/screen.cc
+++ b/cyber/tools/cyber_monitor/screen.cc
@@ -161,22 +161,22 @@ void Screen::MoveOffsetXY(int offsetX, int offsetY) const {
   }
 }
 
-void Screen::HighlightLine(int lineNo) {
-  if (IsInit() && lineNo < Height()) {
+void Screen::HighlightLine(int line_no) {
+  if (IsInit() && line_no < Height()) {
     SetCurrentColor(WHITE_BLACK);
     for (int x = 0; x < Width(); ++x) {
-      chtype ch = mvinch(lineNo + highlight_direction_, x);
+      chtype ch = mvinch(line_no + highlight_direction_, x);
       ch &= A_CHARTEXT;
       if (ch == ' ') {
-        mvaddch(lineNo + highlight_direction_, x, ch);
+        mvaddch(line_no + highlight_direction_, x, ch);
       }
     }
     ClearCurrentColor();
 
     SetCurrentColor(BLACK_WHITE);
     for (int x = 0; x < Width(); ++x) {
-      chtype ch = mvinch(lineNo, x);
-      mvaddch(lineNo, x, ch & A_CHARTEXT);
+      chtype ch = mvinch(line_no, x);
+      mvaddch(line_no, x, ch & A_CHARTEXT);
     }
     ClearCurrentColor();
   }

--- a/cyber/tools/cyber_monitor/screen.cc
+++ b/cyber/tools/cyber_monitor/screen.cc
@@ -243,7 +243,8 @@ void Screen::Resize(void) {
 
 void Screen::ShowRenderMessage(int ch) {
   erase();
-  current_render_obj_->Render(this, ch);
+  int line_num = current_render_obj_->Render(this, ch);
+  const int max_height = std::min(Height(), line_num);
 
   int* y = current_render_obj_->line_no();
 
@@ -257,8 +258,8 @@ void Screen::ShowRenderMessage(int ch) {
     case KEY_DOWN:
       ++(*y);
       highlight_direction_ = -1;
-      if (*y >= Height()) {
-        *y = Height() - 1;
+      if (*y >= max_height) {
+        *y = max_height - 1;
       }
       break;
 

--- a/cyber/tools/cyber_monitor/screen.h
+++ b/cyber/tools/cyber_monitor/screen.h
@@ -72,7 +72,7 @@ class Screen final {
   Screen& operator=(const Screen&) = delete;
 
   int SwitchState(int ch);
-  void HighlightLine(int lineNo);
+  void HighlightLine(int line_no);
 
   void ShowInteractiveCmd(int ch);
   void ShowRenderMessage(int ch);


### PR DESCRIPTION
Currently, cyber_monitor's highlighted bar can be located anywhere on the terminal as shown below, which is unreasonable.
![2020-09-08_19-32-36](https://user-images.githubusercontent.com/62049794/92474502-87cc5280-f20e-11ea-99a2-b9793b32e664.png)
In this PR, the location of the highlighted bar is restricted to where there is content.
