### PR TITLE
Cyber: binary threading fixes

### DIFF
--- a/cyber/BUILD
+++ b/cyber/BUILD
@@ -31,6 +31,7 @@ cc_binary(
 cc_library(
     name = "binary",
     hdrs = ["binary.h"],
+    srcs = ["binary.cc"],
 )
 
 cc_library(
@@ -47,6 +48,7 @@ cc_library(
     srcs = ["init.cc"],
     hdrs = ["init.h"],
     deps = [
+        "//cyber:binary",
         "//cyber:state",
         "//cyber/common:file",
         "//cyber/logger:async_logger",

--- a/cyber/binary.cc
+++ b/cyber/binary.cc
@@ -14,18 +14,28 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef CYBER_BINARY_H_
-#define CYBER_BINARY_H_
+#include "cyber/binary.h"
 
+#include <mutex>
 #include <string>
 
 namespace apollo {
 namespace cyber {
 namespace binary {
-std::string GetName();
-void SetName(const std::string& name);
+
+static std::mutex m;
+static std::string binary_name;  // NOLINT
+
+std::string GetName() {
+  std::lock_guard<std::mutex> lock(m);
+  return binary_name;
+}
+void SetName(const std::string& name) {
+  std::lock_guard<std::mutex> lock(m);
+  binary_name = name;
+}
+
 }  // namespace binary
 }  // namespace cyber
 }  // namespace apollo
 
-#endif  // CYBER_BINARY_H_

--- a/cyber/common/log.h
+++ b/cyber/common/log.h
@@ -33,7 +33,7 @@
 #define RIGHT_BRACKET "]"
 
 #ifndef MODULE_NAME
-#define MODULE_NAME apollo::cyber::Binary::GetName().c_str()
+#define MODULE_NAME apollo::cyber::binary::GetName().c_str()
 #endif
 
 #define ADEBUG_MODULE(module) \

--- a/cyber/init.cc
+++ b/cyber/init.cc
@@ -62,9 +62,9 @@ logger::AsyncLogger* async_logger = nullptr;
 void InitLogger(const char* binary_name) {
   const char* slash = strrchr(binary_name, '/');
   if (slash) {
-    ::apollo::cyber::Binary::SetName(slash + 1);
+    ::apollo::cyber::binary::SetName(slash + 1);
   } else {
-    ::apollo::cyber::Binary::SetName(binary_name);
+    ::apollo::cyber::binary::SetName(binary_name);
   }
 
   // Init glog


### PR DESCRIPTION
There's some potential threading problems when using the header only binary library. I separated the header and the source file to hide the mutex header and added a mutex. The problems are reported by running a threading sanitizer.