### PR TITLE
Cyber: timer remove shutdown bug

### DIFF
--- a/cyber/common/global_data.h
+++ b/cyber/common/global_data.h
@@ -17,6 +17,7 @@
 #ifndef CYBER_COMMON_GLOBAL_DATA_H_
 #define CYBER_COMMON_GLOBAL_DATA_H_
 
+#include <atomic>
 #include <string>
 #include <unordered_map>
 
@@ -101,7 +102,7 @@ class GlobalData {
   std::string sched_name_ = "CYBER_DEFAULT";
 
   // run mode
-  RunMode run_mode_;
+  std::atomic<RunMode> run_mode_;
   ClockMode clock_mode_;
 
   static AtomicHashMap<uint64_t, std::string, 512> node_id_map_;

--- a/cyber/common/macros.h
+++ b/cyber/common/macros.h
@@ -17,6 +17,7 @@
 #ifndef CYBER_COMMON_MACROS_H_
 #define CYBER_COMMON_MACROS_H_
 
+#include <atomic>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -52,7 +53,7 @@ typename std::enable_if<!HasShutdown<T>::value>::type CallShutdown(
 #define DECLARE_SINGLETON(classname)                                      \
  public:                                                                  \
   static classname *Instance(bool create_if_needed = true) {              \
-    static classname *instance = nullptr;                                 \
+    static std::atomic<classname *> instance{};                           \
     if (!instance && create_if_needed) {                                  \
       static std::once_flag flag;                                         \
       std::call_once(flag,                                                \

--- a/cyber/croutine/croutine.h
+++ b/cyber/croutine/croutine.h
@@ -103,7 +103,7 @@ class CRoutine {
       std::chrono::steady_clock::now();
 
   RoutineFunc func_;
-  RoutineState state_;
+  std::atomic<RoutineState> state_;
 
   std::shared_ptr<RoutineContext> context_;
 

--- a/cyber/logger/async_logger.h
+++ b/cyber/logger/async_logger.h
@@ -177,6 +177,7 @@ class AsyncLogger : public google::base::Logger {
   // 64 bits should be enough to never worry about overflow.
   uint64_t drop_count_ = 0;
 
+  std::mutex active_buf_mutex_;
   // The buffer to which application threads append new log messages.
   std::unique_ptr<std::deque<Msg>> active_buf_;
 
@@ -188,6 +189,7 @@ class AsyncLogger : public google::base::Logger {
   enum State { INITTED, RUNNING, STOPPED };
   std::atomic<State> state_ = {INITTED};
   std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+  std::mutex map_mutex_;
   std::unordered_map<std::string, std::unique_ptr<LogFileObject>>
       module_logger_map_;
 

--- a/cyber/scheduler/policy/classic_context.h
+++ b/cyber/scheduler/policy/classic_context.h
@@ -45,7 +45,6 @@ using CR_GROUP = std::unordered_map<std::string, MULTI_PRIO_QUEUE>;
 using LOCK_QUEUE = std::array<base::AtomicRWLock, MAX_PRIO>;
 using RQ_LOCK_GROUP = std::unordered_map<std::string, LOCK_QUEUE>;
 
-using GRP_WQ_MUTEX = std::unordered_map<std::string, MutexWrapper>;
 using GRP_WQ_CV = std::unordered_map<std::string, CvWrapper>;
 using NOTIFY_GRP = std::unordered_map<std::string, int>;
 
@@ -61,11 +60,11 @@ class ClassicContext : public ProcessorContext {
   static void Notify(const std::string &group_name);
   static bool RemoveCRoutine(const std::shared_ptr<CRoutine> &cr);
 
-  alignas(CACHELINE_SIZE) static CR_GROUP cr_group_;
-  alignas(CACHELINE_SIZE) static RQ_LOCK_GROUP rq_locks_;
-  alignas(CACHELINE_SIZE) static GRP_WQ_CV cv_wq_;
-  alignas(CACHELINE_SIZE) static GRP_WQ_MUTEX mtx_wq_;
-  alignas(CACHELINE_SIZE) static NOTIFY_GRP notify_grp_;
+  static std::mutex mtx_wq_;
+  static CR_GROUP cr_group_;
+  static RQ_LOCK_GROUP rq_locks_;
+  static GRP_WQ_CV cv_wq_;
+  static NOTIFY_GRP notify_grp_;
 
  private:
   void InitGroup(const std::string &group_name);
@@ -75,7 +74,6 @@ class ClassicContext : public ProcessorContext {
 
   MULTI_PRIO_QUEUE *multi_pri_rq_ = nullptr;
   LOCK_QUEUE *lq_ = nullptr;
-  MutexWrapper *mtx_wrapper_ = nullptr;
   CvWrapper *cw_ = nullptr;
 
   std::string current_grp;

--- a/cyber/timer/timer_bucket.h
+++ b/cyber/timer/timer_bucket.h
@@ -34,11 +34,11 @@ class TimerBucket {
   }
 
   std::mutex& mutex() { return mutex_; }
-  std::list<std::weak_ptr<TimerTask>>& task_list() { return task_list_; }
+  std::list<std::shared_ptr<TimerTask>>& task_list() { return task_list_; }
 
  private:
   std::mutex mutex_;
-  std::list<std::weak_ptr<TimerTask>> task_list_;
+  std::list<std::shared_ptr<TimerTask>> task_list_;
 };
 
 }  // namespace cyber

--- a/cyber/timer/timer_task.h
+++ b/cyber/timer/timer_task.h
@@ -34,6 +34,7 @@ struct TimerTask {
   uint64_t next_fire_duration_ms = 0;
   int64_t accumulated_error_ns = 0;
   uint64_t last_execute_time_ns = 0;
+  bool active = false;
   std::mutex mutex;
 };
 

--- a/cyber/timer/timing_wheel.h
+++ b/cyber/timer/timing_wheel.h
@@ -17,6 +17,7 @@
 #ifndef CYBER_TIMER_TIMING_WHEEL_H_
 #define CYBER_TIMER_TIMING_WHEEL_H_
 
+#include <atomic>
 #include <future>
 #include <list>
 #include <memory>
@@ -72,7 +73,7 @@ class TimingWheel {
     return index & (ASSISTANT_WHEEL_SIZE - 1);
   }
 
-  bool running_ = false;
+  std::atomic<bool> running_{};
   uint64_t tick_count_ = 0;
   std::mutex running_mutex_;
   TimerBucket work_wheel_[WORK_WHEEL_SIZE];


### PR DESCRIPTION
There are a lot of threading warning when the thread sanitizer is invoked on cyber's timer.
```
bazel build -c dbg --copt -fsanitize=thread --copt --linkopt -fsanitize=thread //cyber/timer:timer_testt-frame-pointer --linkopt -fsanitize=thread //cyber/timer:timer_test
```
Note that protobuf has a warning. So compilation will fail. Commenting out `build --copt="-Werror=return-type"` in tools/bazel.rc will let compilation pass.

Most bugs don't exhibit symptoms, but the timer shutdown seem problematic. Instead, of locking the thread and then checking if the timer is active, it checks if the thread is active via the weak pointer and then locks. This behavior is a race condition. An explicit active bool is added to the data **after** the threading lock is used.

I don't know what the intention was with `alignas(CACHELINE_SIZE)` in cyber/scheduler/policy/classic_context.h , so I removed it. The real problem was that having a mutable unordered_map of mutexes causes problems when they are added and accessed asynchronously. Therefore, only one mutex is used.

Here's another useful test. It seems that the thread sanitizer may crash on destruction. If the program is compiled in optimized mode, it should pass.
```
#!/bin/bash
rm /tmp/timer_test_out.txt
for i in {0..100}
  do
    bazel-bin/cyber/timer/timer_test >> /tmp/timer_test_out.txt 2>&1
    if [ "$?" -ne "0" ]; then
      echo "Failed"
      exit 1
    fi
  done
echo /tmp/timer_test_out.txt
```