### PR TITLE
Bazel: bump bazel-skylib to 1.0.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ apollo_repositories()
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     urls = [
-        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/bazel_skylib-0.9.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+        "https://apollo-platform-system.cdn.bcebos.com/archive/6.0/bazel_skylib-1.0.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
     ],
 )
 


### PR DESCRIPTION
@lx18233184051 Please help with  hosting https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz on https://apollo-platform-system.cdn.bcebos.com/archive/6.0/bazel_skylib-1.0.3.tar.gz , thank you. 