### PR TITLE
Use two buffers to handle message larger than 65536 bytes.

### DIFF
--- a/modules/contrib/cyber_bridge/client.h
+++ b/modules/contrib/cyber_bridge/client.h
@@ -17,8 +17,7 @@ class Node;
 
 class Client : public std::enable_shared_from_this<Client> {
  public:
-  Client(Node* node, Clients* clients,
-         boost::asio::ip::tcp::socket socket);
+  Client(Node* node, Clients* clients, boost::asio::ip::tcp::socket socket);
   ~Client();
 
   void start();
@@ -34,6 +33,10 @@ class Client : public std::enable_shared_from_this<Client> {
 
   uint8_t temp[1024 * 1024];
   std::vector<uint8_t> buffer;
+  std::vector<uint8_t> writing;
+  std::vector<uint8_t> pending;
+  std::mutex publish_mutex;
+  const uint MAX_PENDING_SIZE = 1073741824;  // 1GB
 
   void handle_read(const boost::system::error_code& ec, std::size_t length);
   void handle_write(const boost::system::error_code& ec);


### PR DESCRIPTION
Existing bridge cannot handle messages larger than 65536 bytes. More details see https://github.com/lgsvl/simulator/issues/941.

This MR implemented the solution suggested by Yun and Martins on GitHub. If the big message is published at high frequency, the pending buffer may accumulate more and more data. To avoid too much accumulated data, I set a max size of 1GB and discard the pending buffer if its size is larger than the max size.