### PR TITLE
Perception: simplify dag to release GPU memory

### DIFF
--- a/modules/perception/production/dag/dag_streaming_perception.dag
+++ b/modules/perception/production/dag/dag_streaming_perception.dag
@@ -1,7 +1,7 @@
 module_config {
   module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_lidar.so"
 
- components {
+  components {
     class_name : "DetectionComponent"
     config {
       name: "Velodyne128Detection"
@@ -12,17 +12,6 @@ module_config {
         }
     }
   }
-
- components {
-    class_name : "DetectionComponent"
-    config {
-      name: "Velodyne16Detection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne16_detection_conf.pb.txt"
-      readers {
-          channel: "/apollo/sensor/lidar16/compensator/PointCloud2"
-        }
-    }
- }
 
   components {
     class_name : "RecognitionComponent"
@@ -67,22 +56,21 @@ module_config {
         }
     }
   }
-
 }
 
 module_config {
-    module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
+  module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
 
-    components {
-      class_name : "V2XFusionComponent"
-      config {
-        name : "v2x_fusion"
-        flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
-        readers: [
-          {
-            channel: "/perception/vehicle/obstacles"
-          }
-        ]
-      }
+  components {
+    class_name : "V2XFusionComponent"
+    config {
+      name : "v2x_fusion"
+      flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
+      readers: [
+        {
+          channel: "/perception/vehicle/obstacles"
+        }
+      ]
     }
+  }
 }

--- a/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
@@ -1,7 +1,7 @@
 module_config {
   module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_lidar.so"
 
- components {
+  components {
     class_name : "DetectionComponent"
     config {
       name: "Velodyne128Detection"
@@ -12,17 +12,6 @@ module_config {
         }
     }
   }
-
- components {
-    class_name : "DetectionComponent"
-    config {
-      name: "Velodyne16Detection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne16_detection_conf.pb.txt"
-      readers {
-          channel: "/apollo/sensor/lidar16/compensator/PointCloud2"
-        }
-    }
- }
 
   components {
     class_name : "RecognitionComponent"
@@ -67,23 +56,21 @@ module_config {
         }
     }
   }
-
-
 }
 
 module_config {
-    module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
+  module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
 
-    components {
-      class_name : "V2XFusionComponent"
-      config {
-        name : "v2x_fusion"
-        flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
-        readers: [
-          {
-            channel: "/perception/vehicle/obstacles"
-          }
-        ]
-      }
+  components {
+    class_name : "V2XFusionComponent"
+    config {
+      name : "v2x_fusion"
+      flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
+      readers: [
+        {
+          channel: "/perception/vehicle/obstacles"
+        }
+      ]
     }
+  }
 }

--- a/modules/perception/production/dag/dag_streaming_perception_lidar.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lidar.dag
@@ -1,7 +1,7 @@
 module_config {
   module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_lidar.so"
 
- components {
+  components {
     class_name : "DetectionComponent"
     config {
       name: "Velodyne128Detection"
@@ -39,18 +39,18 @@ module_config {
 }
 
 module_config {
-    module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
+  module_library : "/apollo/bazel-bin/modules/v2x/fusion/apps/libv2x_fusion_component.so"
 
-    components {
-      class_name : "V2XFusionComponent"
-      config {
-        name : "v2x_fusion"
-        flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
-        readers: [
-          {
-            channel: "/perception/vehicle/obstacles"
-          }
-        ]
-      }
+  components {
+    class_name : "V2XFusionComponent"
+    config {
+      name : "v2x_fusion"
+      flag_file_path : "/apollo/modules/v2x/conf/v2x_fusion_tracker.conf"
+      readers: [
+        {
+          channel: "/perception/vehicle/obstacles"
+        }
+      ]
     }
+  }
 }


### PR DESCRIPTION
1. Remove redundant Velodyne16 Detection Component to release GPU memory.
2. Adjust dags' format.