### PR TITLE
cyber: fix debug glog config in setup.bash

### DIFF
--- a/cyber/setup.bash
+++ b/cyber/setup.bash
@@ -42,7 +42,6 @@ export GLOG_minloglevel=0
 export sysmo_start=0
 
 # for DEBUG log
-#export GLOG_minloglevel=-1
 #export GLOG_v=4
 
 source ${CYBER_PATH}/tools/cyber_tools_auto_complete.bash


### PR DESCRIPTION
Fix debug glog config in setup.bash, glog can't set LogSeverityto -1, detail discuss in #12723

