### PR TITLE
Cyber: cyber_recorder file writer threading bug fix

### DIFF
--- a/cyber/record/file/record_file_base.h
+++ b/cyber/record/file/record_file_base.h
@@ -45,7 +45,7 @@ class RecordFileBase {
   std::string path_;
   proto::Header header_;
   proto::Index index_;
-  int fd_;
+  int fd_ = -1;
 };
 
 }  // namespace record

--- a/cyber/record/file/record_file_base.h
+++ b/cyber/record/file/record_file_base.h
@@ -45,7 +45,7 @@ class RecordFileBase {
   std::string path_;
   proto::Header header_;
   proto::Index index_;
-  int fd_ = -1;
+  int fd_;
 };
 
 }  // namespace record

--- a/cyber/record/file/record_file_test.cc
+++ b/cyber/record/file/record_file_test.cc
@@ -222,56 +222,56 @@ TEST(RecordFileTest, TestOneChunkFile) {
 
 TEST(RecordFileTest, TestIndex) {
   {
-    RecordFileWriter rfw;
+    RecordFileWriter* rfw = new RecordFileWriter();
 
-    ASSERT_TRUE(rfw.Open(kTestFile2));
-    ASSERT_EQ(kTestFile2, rfw.GetPath());
+    ASSERT_TRUE(rfw->Open(kTestFile2));
+    ASSERT_EQ(kTestFile2, rfw->GetPath());
 
     Header header = HeaderBuilder::GetHeaderWithChunkParams(0, 0);
     header.set_segment_interval(0);
     header.set_segment_raw_size(0);
-    ASSERT_TRUE(rfw.WriteHeader(header));
-    ASSERT_FALSE(rfw.GetHeader().is_complete());
+    ASSERT_TRUE(rfw->WriteHeader(header));
+    ASSERT_FALSE(rfw->GetHeader().is_complete());
 
     Channel chan1;
     chan1.set_name(kChan1);
     chan1.set_message_type(kMsgType);
     chan1.set_proto_desc(kStr10B);
-    ASSERT_TRUE(rfw.WriteChannel(chan1));
+    ASSERT_TRUE(rfw->WriteChannel(chan1));
 
     Channel chan2;
     chan2.set_name(kChan2);
     chan2.set_message_type(kMsgType);
     chan2.set_proto_desc(kStr10B);
-    ASSERT_TRUE(rfw.WriteChannel(chan2));
+    ASSERT_TRUE(rfw->WriteChannel(chan2));
 
     SingleMessage msg1;
     msg1.set_channel_name(chan1.name());
     msg1.set_content(kStr10B);
     msg1.set_time(1e9);
-    ASSERT_TRUE(rfw.WriteMessage(msg1));
-    ASSERT_EQ(1, rfw.GetMessageNumber(chan1.name()));
+    ASSERT_TRUE(rfw->WriteMessage(msg1));
+    ASSERT_EQ(1, rfw->GetMessageNumber(chan1.name()));
 
     SingleMessage msg2;
     msg2.set_channel_name(chan2.name());
     msg2.set_content(kStr10B);
     msg2.set_time(2e9);
-    ASSERT_TRUE(rfw.WriteMessage(msg2));
-    ASSERT_EQ(1, rfw.GetMessageNumber(chan2.name()));
+    ASSERT_TRUE(rfw->WriteMessage(msg2));
+    ASSERT_EQ(1, rfw->GetMessageNumber(chan2.name()));
 
     SingleMessage msg3;
     msg3.set_channel_name(chan1.name());
     msg3.set_content(kStr10B);
     msg3.set_time(3e9);
-    ASSERT_TRUE(rfw.WriteMessage(msg3));
-    ASSERT_EQ(2, rfw.GetMessageNumber(chan1.name()));
+    ASSERT_TRUE(rfw->WriteMessage(msg3));
+    ASSERT_EQ(2, rfw->GetMessageNumber(chan1.name()));
 
-    rfw.Close();
-    ASSERT_TRUE(rfw.GetHeader().is_complete());
-    ASSERT_EQ(1, rfw.GetHeader().chunk_number());
-    ASSERT_EQ(1e9, rfw.GetHeader().begin_time());
-    ASSERT_EQ(3e9, rfw.GetHeader().end_time());
-    ASSERT_EQ(3, rfw.GetHeader().message_number());
+    rfw->Close();
+    ASSERT_TRUE(rfw->GetHeader().is_complete());
+    ASSERT_EQ(1, rfw->GetHeader().chunk_number());
+    ASSERT_EQ(1e9, rfw->GetHeader().begin_time());
+    ASSERT_EQ(3e9, rfw->GetHeader().end_time());
+    ASSERT_EQ(3, rfw->GetHeader().message_number());
   }
   {
     RecordFileReader reader;
@@ -304,7 +304,6 @@ TEST(RecordFileTest, TestIndex) {
       }
     }
   }
-  ASSERT_FALSE(remove(kTestFile2));
 }
 
 }  // namespace record

--- a/cyber/record/file/record_file_writer.cc
+++ b/cyber/record/file/record_file_writer.cc
@@ -35,6 +35,8 @@ using apollo::cyber::proto::Header;
 using apollo::cyber::proto::SectionType;
 using apollo::cyber::proto::SingleIndex;
 
+RecordFileWriter::RecordFileWriter() {}
+
 RecordFileWriter::~RecordFileWriter() { Close(); }
 
 bool RecordFileWriter::Open(const std::string& path) {
@@ -50,31 +52,57 @@ bool RecordFileWriter::Open(const std::string& path) {
            << ", errno: " << errno;
     return false;
   }
-  chunk_active_ = std::make_unique<Chunk>();
+  chunk_active_.reset(new Chunk());
+  chunk_flush_.reset(new Chunk());
+  is_writing_ = true;
+  flush_thread_ = std::make_shared<std::thread>([this]() { this->Flush(); });
+  if (flush_thread_ == nullptr) {
+    AERROR << "Init flush thread error.";
+    return false;
+  }
   return true;
 }
 
 void RecordFileWriter::Close() {
-  if (fd_ < 0) {
-    return;
-  }
-  flush_task_.wait();
-  Flush(*chunk_active_);
+  if (is_writing_) {
+    // wait for the flush operation that may exist now
+    while (!chunk_flush_->empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 
-  if (!WriteIndex()) {
-    AERROR << "Write index section failed, file: " << path_;
-  }
+    // last swap
+    {
+      std::unique_lock<std::mutex> flush_lock(flush_mutex_);
+      chunk_flush_.swap(chunk_active_);
+      flush_cv_.notify_one();
+    }
 
-  header_.set_is_complete(true);
-  if (!WriteHeader(header_)) {
-    AERROR << "Overwrite header section failed, file: " << path_;
-  }
+    // wait for the last flush operation
+    while (!chunk_flush_->empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 
-  if (close(fd_) < 0) {
-    AERROR << "Close file failed, file: " << path_ << ", fd: " << fd_
-           << ", errno: " << errno;
+    is_writing_ = false;
+    flush_cv_.notify_all();
+    if (flush_thread_ && flush_thread_->joinable()) {
+      flush_thread_->join();
+      flush_thread_ = nullptr;
+    }
+
+    if (!WriteIndex()) {
+      AERROR << "Write index section failed, file: " << path_;
+    }
+
+    header_.set_is_complete(true);
+    if (!WriteHeader(header_)) {
+      AERROR << "Overwrite header section failed, file: " << path_;
+    }
+
+    if (close(fd_) < 0) {
+      AERROR << "Close file failed, file: " << path_ << ", fd: " << fd_
+             << ", errno: " << errno;
+    }
   }
-  fd_ = -1;
 }
 
 bool RecordFileWriter::WriteHeader(const Header& header) {
@@ -168,7 +196,6 @@ bool RecordFileWriter::WriteChunk(const ChunkHeader& chunk_header,
 }
 
 bool RecordFileWriter::WriteMessage(const proto::SingleMessage& message) {
-  CHECK_GE(fd_, 0) << "First, call Open";
   chunk_active_->add(message);
   auto it = channel_message_number_map_.find(message.channel_name());
   if (it != channel_message_number_map_.end()) {
@@ -190,27 +217,31 @@ bool RecordFileWriter::WriteMessage(const proto::SingleMessage& message) {
   if (!need_flush) {
     return true;
   }
-
-  ACHECK(flush_task_.wait_for(std::chrono::milliseconds(0)) ==
-         std::future_status::ready)
-      << "Flushing didn't finish. Either the hardware cannot keep up or the "
-         "flush rate is too fast.";
-
-  flush_task_ = std::async(
-      std::launch::async,
-      [this, chunk = std::move(chunk_active_)]() { this->Flush(*chunk); });
-  chunk_active_ = std::make_unique<Chunk>();
-
+  {
+    std::unique_lock<std::mutex> flush_lock(flush_mutex_);
+    chunk_flush_.swap(chunk_active_);
+    flush_cv_.notify_one();
+  }
   return true;
 }
 
-void RecordFileWriter::Flush(const Chunk& chunk) {
-  if (!WriteChunk(chunk.header_, *(chunk.body_.get()))) {
-    AERROR << "Write chunk fail.";
+void RecordFileWriter::Flush() {
+  while (is_writing_) {
+    std::unique_lock<std::mutex> flush_lock(flush_mutex_);
+    flush_cv_.wait(flush_lock,
+                   [this] { return !chunk_flush_->empty() || !is_writing_; });
+    if (!is_writing_) {
+      break;
+    }
+    if (chunk_flush_->empty()) {
+      continue;
+    }
+    if (!WriteChunk(chunk_flush_->header_, *(chunk_flush_->body_.get()))) {
+      AERROR << "Write chunk fail.";
+    }
+    chunk_flush_->clear();
   }
 }
-
-void RecordFileWriter::WaitForWrite() { flush_task_.wait(); }
 
 uint64_t RecordFileWriter::GetMessageNumber(
     const std::string& channel_name) const {

--- a/cyber/record/file/record_file_writer.h
+++ b/cyber/record/file/record_file_writer.h
@@ -92,7 +92,7 @@ class RecordFileWriter : public RecordFileBase {
   bool WriteSection(const T& message);
   bool WriteIndex();
   void Flush();
-  bool is_writing_ = false;
+  std::atomic_bool is_writing_;
   std::unique_ptr<Chunk> chunk_active_ = nullptr;
   std::unique_ptr<Chunk> chunk_flush_ = nullptr;
   std::shared_ptr<std::thread> flush_thread_ = nullptr;

--- a/cyber/record/record_viewer_test.cc
+++ b/cyber/record/record_viewer_test.cc
@@ -25,7 +25,6 @@
 
 #include "gtest/gtest.h"
 
-#include "cyber/common/file.h"
 #include "cyber/common/log.h"
 #include "cyber/record/record_reader.h"
 #include "cyber/record/record_writer.h"
@@ -54,9 +53,6 @@ static void ConstructRecord(uint64_t msg_num, uint64_t begin_time,
       ai = msg_num - 1 - i;
     }
     auto msg = std::make_shared<RawMessage>(std::to_string(ai));
-    // Since writer is meant for real time operations at a set rate,
-    // we need to wait in the test. Otherwise, we should write synchronously
-    writer.WaitForWrite();
     writer.WriteMessage(kChannelName1, msg, begin_time + time_step * ai);
   }
   ASSERT_EQ(msg_num, writer.GetMessageNumber(kChannelName1));
@@ -88,28 +84,28 @@ TEST(RecordTest, iterator_test) {
 
   uint64_t i = 0;
   for (auto& msg : viewer) {
-    ASSERT_EQ(kChannelName1, msg.channel_name);
-    ASSERT_EQ(begin_time + step_time * i, msg.time);
-    ASSERT_EQ(std::to_string(i), msg.content);
-    ++i;
+    EXPECT_EQ(kChannelName1, msg.channel_name);
+    EXPECT_EQ(begin_time + step_time * i, msg.time);
+    EXPECT_EQ(std::to_string(i), msg.content);
+    i++;
   }
   EXPECT_EQ(msg_num, i);
 
   i = 0;
   std::for_each(viewer.begin(), viewer.end(), [&i](RecordMessage& msg) {
-    ASSERT_EQ(kChannelName1, msg.channel_name);
+    EXPECT_EQ(kChannelName1, msg.channel_name);
     // EXPECT_EQ(begin_time + step_time * i, msg.time);
-    ASSERT_EQ(std::to_string(i), msg.content);
-    ++i;
+    EXPECT_EQ(std::to_string(i), msg.content);
+    i++;
   });
   EXPECT_EQ(msg_num, i);
 
   i = 0;
   for (auto it = viewer.begin(); it != viewer.end(); ++it) {
-    ASSERT_EQ(kChannelName1, it->channel_name);
-    ASSERT_EQ(begin_time + step_time * i, it->time);
-    ASSERT_EQ(std::to_string(i), it->content);
-    ++i;
+    EXPECT_EQ(kChannelName1, it->channel_name);
+    EXPECT_EQ(begin_time + step_time * i, it->time);
+    EXPECT_EQ(std::to_string(i), it->content);
+    i++;
   }
   EXPECT_EQ(msg_num, i);
   ASSERT_FALSE(remove(kTestFile));
@@ -133,19 +129,19 @@ TEST(RecordTest, iterator_test_reverse) {
 
   uint64_t i = 0;
   for (auto& msg : viewer) {
-    ASSERT_EQ(kChannelName1, msg.channel_name);
-    ASSERT_EQ(begin_time + step_time * i, msg.time);
-    ASSERT_EQ(std::to_string(i), msg.content);
-    ++i;
+    EXPECT_EQ(kChannelName1, msg.channel_name);
+    EXPECT_EQ(begin_time + step_time * i, msg.time);
+    EXPECT_EQ(std::to_string(i), msg.content);
+    i++;
   }
   EXPECT_EQ(msg_num, i);
 
   i = 0;
   for (auto it = viewer.begin(); it != viewer.end(); ++it) {
-    ASSERT_EQ(kChannelName1, it->channel_name);
-    ASSERT_EQ(begin_time + step_time * i, it->time);
-    ASSERT_EQ(std::to_string(i), it->content);
-    ++i;
+    EXPECT_EQ(kChannelName1, it->channel_name);
+    EXPECT_EQ(begin_time + step_time * i, it->time);
+    EXPECT_EQ(std::to_string(i), it->content);
+    i++;
   }
   EXPECT_EQ(msg_num, i);
   ASSERT_FALSE(remove(kTestFile));
@@ -219,10 +215,10 @@ TEST(RecordTest, mult_iterator_test) {
 
   uint64_t i = 0;
   for (auto& msg : viewer) {  // #2 iterator
-    ASSERT_EQ(kChannelName1, msg.channel_name);
-    ASSERT_EQ(begin_time + step_time * i, msg.time);
-    ASSERT_EQ(std::to_string(i), msg.content);
-    ++i;
+    EXPECT_EQ(kChannelName1, msg.channel_name);
+    EXPECT_EQ(begin_time + step_time * i, msg.time);
+    EXPECT_EQ(std::to_string(i), msg.content);
+    i++;
   }
   EXPECT_EQ(msg_num, i);
   ASSERT_FALSE(remove(kTestFile));

--- a/cyber/record/record_writer.cc
+++ b/cyber/record/record_writer.cc
@@ -180,8 +180,6 @@ bool RecordWriter::IsNewChannel(const std::string& channel_name) const {
          channel_message_number_map_.end();
 }
 
-void RecordWriter::WaitForWrite() { file_writer_->WaitForWrite(); }
-
 void RecordWriter::OnNewChannel(const std::string& channel_name,
                                 const std::string& message_type,
                                 const std::string& proto_desc) {

--- a/cyber/record/record_writer.h
+++ b/cyber/record/record_writer.h
@@ -18,7 +18,6 @@
 #define CYBER_RECORD_RECORD_WRITER_H_
 
 #include <cstdint>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -186,9 +185,7 @@ class RecordWriter : public RecordBase {
   MessageTypeMap channel_message_type_map_;
   MessageProtoDescMap channel_proto_desc_map_;
   FileWriterPtr file_writer_ = nullptr;
-  // Initialize with a dummy value to simplify checking later
-  std::future<void> old_file_writer_closer_ =
-      std::async(std::launch::async, []() {});
+  FileWriterPtr file_writer_backup_ = nullptr;
   std::mutex mutex_;
   std::stringstream sstream_;
 };

--- a/cyber/record/record_writer.h
+++ b/cyber/record/record_writer.h
@@ -170,11 +170,6 @@ class RecordWriter : public RecordBase {
    */
   bool IsNewChannel(const std::string& channel_name) const;
 
-  /**
-   * @brief Meant for testing
-   */
-  void WaitForWrite();
-
  private:
   bool WriteMessage(const proto::SingleMessage& single_msg);
   bool SplitOutfile();

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -33,7 +33,7 @@ build --cxxopt="-fdiagnostics-color=always"
 
 build --per_file_copt=external/upb/.*@-Wno-sign-compare
 build --copt="-Werror=sign-compare"
-build --per_file_copt=^modules/.*\.cc,^cyber/.*\.cc,@"-Werror=return-type"
+build --copt="-Werror=return-type"
 build --copt="-Werror=unused-variable"
 build --copt="-Werror=unused-but-set-variable"
 build --copt="-Werror=switch"


### PR DESCRIPTION
bug fix [link](https://github.com/ApolloAuto/apollo/pull/12377)
reason:
  The reason is data race of two functions:  1) RecordFileWriter::Close() ; 2) RecordFileWriter::Flush()
  When the [record_viewer_test.cc:59](https://github.com/ApolloAuto/apollo/blob/de70315b459fd53f527e342eb884099406ce7481/cyber/record/record_viewer_test.cc#L63) call the 'Close()' function, and there are some message flushing to file at that moment(call the 'Flush()' function). The two functions run in two threads, so it can produce the two data race points : 1) RecordFileWriter::chunk_flush_;  2)RecordFileWriter::is_writing_ 

@Fla3inH0tCheet0s

Fixed issue #12840