### PR TITLE
Canbus: add the battery soc info in vehicle ch and dev_kit

### DIFF
--- a/modules/canbus/proto/ch.proto
+++ b/modules/canbus/proto/ch.proto
@@ -3,26 +3,16 @@ syntax = "proto2";
 package apollo.canbus;
 
 // Coolhigh vehicle starts from here
-message Control_command_115 {
+message Throttle_command_110 {
   // Control Message
-  enum Ctrl_cmdType {
-    CTRL_CMD_OUT_OF_CONTROL = 0;
-    CTRL_CMD_UNDER_CONTROL = 1;
+  enum Throttle_pedal_en_ctrlType {
+    THROTTLE_PEDAL_EN_CTRL_DISABLE = 0;
+    THROTTLE_PEDAL_EN_CTRL_ENABLE = 1;
   }
-  // Take control(Command) [] [0|1]
-  optional Ctrl_cmdType ctrl_cmd = 1;
-}
-
-message Gear_command_114 {
-  // Control Message
-  enum Gear_cmdType {
-    GEAR_CMD_PARK = 1;
-    GEAR_CMD_REVERSE = 2;
-    GEAR_CMD_NEUTRAL = 3;
-    GEAR_CMD_DRIVE = 4;
-  }
-  // PRND control(Command) [] [1|4]
-  optional Gear_cmdType gear_cmd = 1;
+  // throttle pedal enable bit(Command) [] [0|1]
+  optional Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl = 1;
+  // Percentage of throttle pedal(Command) [%] [0|100]
+  optional int32 throttle_pedal_cmd = 2;
 }
 
 message Brake_command_111 {
@@ -37,16 +27,16 @@ message Brake_command_111 {
   optional int32 brake_pedal_cmd = 2;
 }
 
-message Throttle_command_110 {
+message Steer_command_112 {
   // Control Message
-  enum Throttle_pedal_en_ctrlType {
-    THROTTLE_PEDAL_EN_CTRL_DISABLE = 0;
-    THROTTLE_PEDAL_EN_CTRL_ENABLE = 1;
+  enum Steer_angle_en_ctrlType {
+    STEER_ANGLE_EN_CTRL_DISABLE = 0;
+    STEER_ANGLE_EN_CTRL_ENABLE = 1;
   }
-  // throttle pedal enable bit(Command) [] [0|1]
-  optional Throttle_pedal_en_ctrlType throttle_pedal_en_ctrl = 1;
-  // Percentage of throttle pedal(Command) [%] [0|100]
-  optional int32 throttle_pedal_cmd = 2;
+  // steering angle enable bit(Command) [] [0|1]
+  optional Steer_angle_en_ctrlType steer_angle_en_ctrl = 1;
+  // Current steering angle(Command) [radian] [-0.524|0.524]
+  optional double steer_angle_cmd = 2;
 }
 
 message Turnsignal_command_113 {
@@ -60,16 +50,51 @@ message Turnsignal_command_113 {
   optional Turn_signal_cmdType turn_signal_cmd = 1;
 }
 
-message Steer_command_112 {
+message Gear_command_114 {
   // Control Message
-  enum Steer_angle_en_ctrlType {
-    STEER_ANGLE_EN_CTRL_DISABLE = 0;
-    STEER_ANGLE_EN_CTRL_ENABLE = 1;
+  enum Gear_cmdType {
+    GEAR_CMD_PARK = 1;
+    GEAR_CMD_REVERSE = 2;
+    GEAR_CMD_NEUTRAL = 3;
+    GEAR_CMD_DRIVE = 4;
   }
-  // steering angle enable bit(Command) [] [0|1]
-  optional Steer_angle_en_ctrlType steer_angle_en_ctrl = 1;
-  // Current steering angle(Command) [radian] [-0.524|0.524]
-  optional double steer_angle_cmd = 2;
+  // PRND control(Command) [] [1|4]
+  optional Gear_cmdType gear_cmd = 1;
+}
+
+message Control_command_115 {
+  // Control Message
+  enum Ctrl_cmdType {
+    CTRL_CMD_OUT_OF_CONTROL = 0;
+    CTRL_CMD_UNDER_CONTROL = 1;
+  }
+  // Take control(Command) [] [0|1]
+  optional Ctrl_cmdType ctrl_cmd = 1;
+}
+
+message Throttle_status__510 {
+  // Report Message
+  enum Throttle_pedal_en_stsType {
+    THROTTLE_PEDAL_EN_STS_DISABLE = 0;
+    THROTTLE_PEDAL_EN_STS_ENABLE = 1;
+    THROTTLE_PEDAL_EN_STS_TAKEOVER = 2;
+  }
+  enum Drive_motor_errType {
+    DRIVE_MOTOR_ERR_NOERR = 0;
+    DRIVE_MOTOR_ERR_DRV_MOTOR_ERR = 1;
+  }
+  enum Battery_bms_errType {
+    BATTERY_BMS_ERR_NOERR = 0;
+    BATTERY_BMS_ERR_BATTERY_ERR = 1;
+  }
+  // throttle pedal enable bit(Status) [] [0|2]
+  optional Throttle_pedal_en_stsType throttle_pedal_en_sts = 1;
+  // Percentage of throttle pedal(Status) [%] [0|100]
+  optional int32 throttle_pedal_sts = 2;
+  // [] [0|1]
+  optional Drive_motor_errType drive_motor_err = 3;
+  // [] [0|1]
+  optional Battery_bms_errType battery_bms_err = 4;
 }
 
 message Brake_status__511 {
@@ -99,7 +124,7 @@ message Brake_status__511 {
     OVERSPD_ENV_NOENV = 0;
     OVERSPD_ENV_OVERSPEED_ENV = 1;
   }
-  // brake pedal enable bit(Status) [] [0|1]
+  // brake pedal enable bit(Status) [] [0|2]
   optional Brake_pedal_en_stsType brake_pedal_en_sts = 1;
   // Percentage of brake pedal(Status) [%] [0|100]
   optional int32 brake_pedal_sts = 2;
@@ -113,42 +138,6 @@ message Brake_status__511 {
   optional Back_bump_envType back_bump_env = 6;
   // [] [0|1]
   optional Overspd_envType overspd_env = 7;
-}
-
-message Throttle_status__510 {
-  // Report Message
-  enum Throttle_pedal_en_stsType {
-    THROTTLE_PEDAL_EN_STS_DISABLE = 0;
-    THROTTLE_PEDAL_EN_STS_ENABLE = 1;
-    THROTTLE_PEDAL_EN_STS_TAKEOVER = 2;
-  }
-  enum Drive_motor_errType {
-    DRIVE_MOTOR_ERR_NOERR = 0;
-    DRIVE_MOTOR_ERR_DRV_MOTOR_ERR = 1;
-  }
-  enum Battery_bms_errType {
-    BATTERY_BMS_ERR_NOERR = 0;
-    BATTERY_BMS_ERR_BATTERY_ERR = 1;
-  }
-  // throttle pedal enable bit(Status) [] [0|1]
-  optional Throttle_pedal_en_stsType throttle_pedal_en_sts = 1;
-  // Percentage of throttle pedal(Status) [%] [0|100]
-  optional int32 throttle_pedal_sts = 2;
-  // [] [0|1]
-  optional Drive_motor_errType drive_motor_err = 3;
-  // [] [0|1]
-  optional Battery_bms_errType battery_bms_err = 4;
-}
-
-message Turnsignal_status__513 {
-  // Report Message
-  enum Turn_signal_stsType {
-    TURN_SIGNAL_STS_NONE = 0;
-    TURN_SIGNAL_STS_LEFT = 1;
-    TURN_SIGNAL_STS_RIGHT = 2;
-  }
-  // Lighting control(Status) [] [0|2]
-  optional Turn_signal_stsType turn_signal_sts = 1;
 }
 
 message Steer_status__512 {
@@ -166,7 +155,7 @@ message Steer_status__512 {
     SENSOR_ERR_NOERR = 0;
     SENSOR_ERR_STEER_SENSOR_ERR = 1;
   }
-  // steering angle enable bit(Status) [] [0|1]
+  // steering angle enable bit(Status) [] [0|2]
   optional Steer_angle_en_stsType steer_angle_en_sts = 1;
   // Current steering angle(Status) [radian] [-0.524|0.524]
   optional double steer_angle_sts = 2;
@@ -174,6 +163,29 @@ message Steer_status__512 {
   optional Steer_errType steer_err = 3;
   // [] [0|1]
   optional Sensor_errType sensor_err = 4;
+}
+
+message Turnsignal_status__513 {
+  // Report Message
+  enum Turn_signal_stsType {
+    TURN_SIGNAL_STS_NONE = 0;
+    TURN_SIGNAL_STS_LEFT = 1;
+    TURN_SIGNAL_STS_RIGHT = 2;
+  }
+  // Lighting control(Status) [] [0|2]
+  optional Turn_signal_stsType turn_signal_sts = 1;
+}
+
+message Gear_status_514 {
+  // Report Message
+  enum Gear_stsType {
+    GEAR_STS_PARK = 1;
+    GEAR_STS_REVERSE = 2;
+    GEAR_STS_NEUTRAL = 3;
+    GEAR_STS_DRIVE = 4;
+  }
+  // PRND control(Status) [] [1|4]
+  optional Gear_stsType gear_sts = 1;
 }
 
 message Ecu_status_1_515 {
@@ -194,64 +206,53 @@ message Ecu_status_1_515 {
   optional int32 chassis_err = 5;
 }
 
-message Gear_status_514 {
+message Ecu_status_2_516 {
   // Report Message
-  enum Gear_stsType {
-    GEAR_STS_PARK = 1;
-    GEAR_STS_REVERSE = 2;
-    GEAR_STS_NEUTRAL = 3;
-    GEAR_STS_DRIVE = 4;
-  }
-  // PRND control(Status) [] [1|4]
-  optional Gear_stsType gear_sts = 1;
+  // Percentage of battery remaining (BMS status) [%] [0|100]
+  optional int32 battery_soc = 1;
+  // Battery full capacity (BMS status) [Ah] [0|100]
+  optional int32 battery_capacity = 2;
+  // Current battery voltage (BMS status) [V] [0|80]
+  optional double battery_voltage = 3;
+  // Current battery current (BMS status) [A] [-60|60]
+  optional double battery_current = 4;
+  // Current battery temperature (BMS status) [℃] [-40|110]
+  optional int32 battery_temperature = 5;
 }
 
 message Ecu_status_3_517 {
   // Report Message
-  // Ultrasonic detection distance 1 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_1 = 1;
-  // Ultrasonic detection distance 2 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_2 = 2;
-  // Ultrasonic detection distance 3 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_3 = 3;
-  // Ultrasonic detection distance 4 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_4 = 4;
-  // Ultrasonic detection distance 5 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_5 = 5;
-  // Ultrasonic detection distance 6 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_6 = 6;
-  // Ultrasonic detection distance 7 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_7 = 7;
-  // Ultrasonic detection distance 8 (Ultrasound status) [cm] [0|0]
-  optional int32 ultrasound_dist_8 = 8;
-}
-
-message Ecu_status_2_516 {
-  // Report Message
-  // Percentage of battery remaining (BMS status) [%] [0|100]
-  optional int32 battery_remaining_capacity = 1;
-  // Current battery voltage (BMS status) [V] [0|80]
-  optional double battery_voltage = 2;
-  // Current battery current (BMS status) [A] [-60|60]
-  optional double battery_current = 3;
-  // Current battery temperature (BMS status) [?] [-40|110]
-  optional int32 battery_temperature = 4;
+  // Ultrasonic detection distance 1 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_1 = 1;
+  // Ultrasonic detection distance 2 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_2 = 2;
+  // Ultrasonic detection distance 3 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_3 = 3;
+  // Ultrasonic detection distance 4 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_4 = 4;
+  // Ultrasonic detection distance 5 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_5 = 5;
+  // Ultrasonic detection distance 6 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_6 = 6;
+  // Ultrasonic detection distance 7 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_7 = 7;
+  // Ultrasonic detection distance 8 (Ultrasound status) [cm] [0|500]
+  optional double ultrasound_dist_8 = 8;
 }
 
 message Ch {
-  optional Control_command_115 control_command_115 = 1;    // control message
-  optional Gear_command_114 gear_command_114 = 2;          // control message
-  optional Brake_command_111 brake_command_111 = 3;        // control message
-  optional Throttle_command_110 throttle_command_110 = 4;  // control message
-  optional Turnsignal_command_113 turnsignal_command_113 =
-      5;                                                   // control message
-  optional Steer_command_112 steer_command_112 = 6;        // control message
-  optional Brake_status__511 brake_status__511 = 7;        // report message
-  optional Throttle_status__510 throttle_status__510 = 8;  // report message
-  optional Turnsignal_status__513 turnsignal_status__513 = 9;  // report message
-  optional Steer_status__512 steer_status__512 = 10;           // report message
-  optional Ecu_status_1_515 ecu_status_1_515 = 11;             // report message
-  optional Gear_status_514 gear_status_514 = 12;               // report message
-  optional Ecu_status_3_517 ecu_status_3_517 = 13;             // report message
-  optional Ecu_status_2_516 ecu_status_2_516 = 14;             // report message
+  optional Throttle_command_110 throttle_command_110 = 1; // control message
+  optional Brake_command_111 brake_command_111 = 2; // control message
+  optional Steer_command_112 steer_command_112 = 3; // control message
+  optional Turnsignal_command_113 turnsignal_command_113 = 4; // control message
+  optional Gear_command_114 gear_command_114 = 5; // control message
+  optional Control_command_115 control_command_115 = 6; // control message
+  optional Throttle_status__510 throttle_status__510 = 7; // report message
+  optional Brake_status__511 brake_status__511 = 8; // report message
+  optional Steer_status__512 steer_status__512 = 9; // report message
+  optional Turnsignal_status__513 turnsignal_status__513 = 10; // report message
+  optional Gear_status_514 gear_status_514 = 11; // report message
+  optional Ecu_status_1_515 ecu_status_1_515 = 12; // report message
+  optional Ecu_status_2_516 ecu_status_2_516 = 13; // report message
+  optional Ecu_status_3_517 ecu_status_3_517 = 14; // report message
 }

--- a/modules/canbus/proto/chassis.proto
+++ b/modules/canbus/proto/chassis.proto
@@ -124,6 +124,8 @@ message Chassis {
   // replace this [id 23]
 
   optional apollo.common.VehicleID vehicle_id = 33;
+
+  optional int32 battery_soc_percentage = 34;
 }
 
 message ChassisGPS {

--- a/modules/canbus/proto/devkit.proto
+++ b/modules/canbus/proto/devkit.proto
@@ -219,6 +219,8 @@ message Vcu_report_505 {
   optional double acc = 5;
   // [m/s] [0|65.535]
   optional double speed = 6;
+  // [%] [0|100]
+  optional int32 battery_soc = 7;
 }
 
 message Steering_report_502 {

--- a/modules/canbus/vehicle/ch/ch_controller.cc
+++ b/modules/canbus/vehicle/ch/ch_controller.cc
@@ -16,11 +16,12 @@
 
 #include "modules/canbus/vehicle/ch/ch_controller.h"
 
+#include "modules/common/proto/vehicle_signal.pb.h"
+
 #include "cyber/common/log.h"
 #include "cyber/time/time.h"
 #include "modules/canbus/vehicle/ch/ch_message_manager.h"
 #include "modules/canbus/vehicle/vehicle_controller.h"
-#include "modules/common/proto/vehicle_signal.pb.h"
 #include "modules/drivers/canbus/can_comm/can_sender.h"
 #include "modules/drivers/canbus/can_comm/protocol_data.h"
 
@@ -245,6 +246,15 @@ Chassis ChController::chassis() {
         apollo::common::EngageAdvice::DISALLOW_ENGAGE);
     chassis_.mutable_engage_advice()->set_reason(
         "CANBUS not ready, firmware error or emergency button pressed!");
+  }
+
+  // 27 battery soc
+  if (chassis_detail.ch().has_ecu_status_2_516() &&
+      chassis_detail.ch().ecu_status_2_516().has_battery_soc()) {
+    chassis_.set_battery_soc_percentage(
+        chassis_detail.ch().ecu_status_2_516().battery_soc());
+  } else {
+    chassis_.set_battery_soc_percentage(0);
   }
 
   return chassis_;

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.cc
@@ -30,10 +30,10 @@ const int32_t Ecustatus2516::ID = 0x516;
 
 void Ecustatus2516::Parse(const std::uint8_t* bytes, int32_t length,
                           ChassisDetail* chassis) const {
-  chassis->mutable_ch()
-      ->mutable_ecu_status_2_516()
-      ->set_battery_remaining_capacity(
-          battery_remaining_capacity(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_soc(
+      battery_soc(bytes, length));
+  chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_capacity(
+      battery_capacity(bytes, length));
   chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_voltage(
       battery_voltage(bytes, length));
   chassis->mutable_ch()->mutable_ecu_status_2_516()->set_battery_current(
@@ -42,28 +42,36 @@ void Ecustatus2516::Parse(const std::uint8_t* bytes, int32_t length,
       battery_temperature(bytes, length));
 }
 
-// config detail: {'description': 'Percentage of battery remaining (BMS
-// status)', 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name':
-// 'battery_remaining_capacity', 'is_signed_var': False, 'physical_range':
-// '[0|100]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
-int Ecustatus2516::battery_remaining_capacity(const std::uint8_t* bytes,
-                                              int32_t length) const {
-  Byte t0(bytes + 1);
+// config detail: {'bit': 0, 'description': 'Percentage of battery remaining
+// (BMS status)', 'is_signed_var': False, 'len': 8, 'name': 'battery_soc',
+// 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|100]',
+// 'physical_unit': '%', 'precision': 1.0, 'type': 'int'}
+int Ecustatus2516::battery_soc(const std::uint8_t* bytes,
+                               int32_t length) const {
+  Byte t0(bytes + 0);
   int32_t x = t0.get_byte(0, 8);
-
-  Byte t1(bytes + 0);
-  int32_t t = t1.get_byte(0, 8);
-  x <<= 8;
-  x |= t;
 
   int ret = x;
   return ret;
 }
 
-// config detail: {'description': 'Current battery voltage (BMS status)',
-// 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'battery_voltage',
-// 'is_signed_var': False, 'physical_range': '[0|0]', 'bit': 16, 'type':
-// 'double', 'order': 'intel', 'physical_unit': 'V'}
+// config detail: {'bit': 8, 'description': 'Battery full capacity (BMS
+// status)', 'is_signed_var': False, 'len': 8, 'name': 'battery_capacity',
+// 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|100]',
+// 'physical_unit': 'Ah', 'precision': 1.0, 'type': 'int'}
+int Ecustatus2516::battery_capacity(const std::uint8_t* bytes,
+                                    int32_t length) const {
+  Byte t0(bytes + 1);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
+}
+
+// config detail: {'bit': 16, 'description': 'Current battery voltage (BMS
+// status)', 'is_signed_var': False, 'len': 16, 'name': 'battery_voltage',
+// 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|80]', 'physical_unit':
+// 'V', 'precision': 0.1, 'type': 'double'}
 double Ecustatus2516::battery_voltage(const std::uint8_t* bytes,
                                       int32_t length) const {
   Byte t0(bytes + 3);
@@ -78,10 +86,10 @@ double Ecustatus2516::battery_voltage(const std::uint8_t* bytes,
   return ret;
 }
 
-// config detail: {'description': 'Current battery current (BMS status)',
-// 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'battery_current',
-// 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 32, 'type':
-// 'double', 'order': 'intel', 'physical_unit': 'A'}
+// config detail: {'bit': 32, 'description': 'Current battery current (BMS
+// status)', 'is_signed_var': True, 'len': 16, 'name': 'battery_current',
+// 'offset': 0.0, 'order': 'intel', 'physical_range': '[-60|60]',
+// 'physical_unit': 'A', 'precision': 0.1, 'type': 'double'}
 double Ecustatus2516::battery_current(const std::uint8_t* bytes,
                                       int32_t length) const {
   Byte t0(bytes + 5);
@@ -99,10 +107,10 @@ double Ecustatus2516::battery_current(const std::uint8_t* bytes,
   return ret;
 }
 
-// config detail: {'description': 'Current battery temperature (BMS status)',
-// 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'battery_temperature',
-// 'is_signed_var': True, 'physical_range': '[0|0]', 'bit': 48, 'type': 'int',
-// 'order': 'intel', 'physical_unit': '?'}
+// config detail: {'bit': 48, 'description': 'Current battery temperature (BMS
+// status)', 'is_signed_var': True, 'len': 16, 'name': 'battery_temperature',
+// 'offset': 0.0, 'order': 'intel', 'physical_range': '[-40|110]',
+// 'physical_unit': '℃', 'precision': 1.0, 'type': 'int'}
 int Ecustatus2516::battery_temperature(const std::uint8_t* bytes,
                                        int32_t length) const {
   Byte t0(bytes + 7);

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516.h
@@ -32,29 +32,34 @@ class Ecustatus2516 : public ::apollo::drivers::canbus::ProtocolData<
              ChassisDetail* chassis) const override;
 
  private:
-  // config detail: {'description': 'Percentage of battery remaining (BMS
-  // status)', 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name':
-  // 'BATTERY_REMAINING_CAPACITY', 'is_signed_var': False, 'physical_range':
-  // '[0|0]', 'bit': 0, 'type': 'int', 'order': 'intel', 'physical_unit': '%'}
-  int battery_remaining_capacity(const std::uint8_t* bytes,
-                                 const int32_t length) const;
+  // config detail: {'bit': 0, 'description': 'Percentage of battery remaining
+  // (BMS status)', 'is_signed_var': False, 'len': 8, 'name': 'BATTERY_SOC',
+  // 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|100]',
+  // 'physical_unit': '%', 'precision': 1.0, 'type': 'int'}
+  int battery_soc(const std::uint8_t* bytes, const int32_t length) const;
 
-  // config detail: {'description': 'Current battery voltage (BMS status)',
-  // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_VOLTAGE',
-  // 'is_signed_var': False, 'physical_range': '[0|80]', 'bit': 16, 'type':
-  // 'double', 'order': 'intel', 'physical_unit': 'V'}
+  // config detail: {'bit': 8, 'description': 'Battery full capacity (BMS
+  // status)', 'is_signed_var': False, 'len': 8, 'name': 'BATTERY_CAPACITY',
+  // 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|100]',
+  // 'physical_unit': 'Ah', 'precision': 1.0, 'type': 'int'}
+  int battery_capacity(const std::uint8_t* bytes, const int32_t length) const;
+
+  // config detail: {'bit': 16, 'description': 'Current battery voltage (BMS
+  // status)', 'is_signed_var': False, 'len': 16, 'name': 'BATTERY_VOLTAGE',
+  // 'offset': 0.0, 'order': 'intel', 'physical_range': '[0|80]',
+  // 'physical_unit': 'V', 'precision': 0.1, 'type': 'double'}
   double battery_voltage(const std::uint8_t* bytes, const int32_t length) const;
 
-  // config detail: {'description': 'Current battery current (BMS status)',
-  // 'offset': 0.0, 'precision': 0.1, 'len': 16, 'name': 'BATTERY_CURRENT',
-  // 'is_signed_var': True, 'physical_range': '[-60|60]', 'bit': 32, 'type':
-  // 'double', 'order': 'intel', 'physical_unit': 'A'}
+  // config detail: {'bit': 32, 'description': 'Current battery current (BMS
+  // status)', 'is_signed_var': True, 'len': 16, 'name': 'BATTERY_CURRENT',
+  // 'offset': 0.0, 'order': 'intel', 'physical_range': '[-60|60]',
+  // 'physical_unit': 'A', 'precision': 0.1, 'type': 'double'}
   double battery_current(const std::uint8_t* bytes, const int32_t length) const;
 
-  // config detail: {'description': 'Current battery temperature (BMS status)',
-  // 'offset': 0.0, 'precision': 1.0, 'len': 16, 'name': 'BATTERY_TEMPERATURE',
-  // 'is_signed_var': True, 'physical_range': '[-40|110]', 'bit': 48, 'type':
-  // 'int', 'order': 'intel', 'physical_unit': '\xc2\xa1\xc3\x89'}
+  // config detail: {'bit': 48, 'description': 'Current battery temperature (BMS
+  // status)', 'is_signed_var': True, 'len': 16, 'name': 'BATTERY_TEMPERATURE',
+  // 'offset': 0.0, 'order': 'intel', 'physical_range': '[-40|110]',
+  // 'physical_unit': '℃', 'precision': 1.0, 'type': 'int'}
   int battery_temperature(const std::uint8_t* bytes,
                           const int32_t length) const;
 };

--- a/modules/canbus/vehicle/ch/protocol/ecu_status_2_516_test.cc
+++ b/modules/canbus/vehicle/ch/protocol/ecu_status_2_516_test.cc
@@ -41,7 +41,8 @@ TEST_F(Ecustatus2516Test, General) {
   EXPECT_EQ(data[6], 0b00010011);
   EXPECT_EQ(data[7], 0b00010100);
 
-  EXPECT_EQ(cd.ch().ecu_status_2_516().battery_remaining_capacity(), 513);
+  EXPECT_EQ(cd.ch().ecu_status_2_516().battery_soc(), 1);
+  EXPECT_EQ(cd.ch().ecu_status_2_516().battery_capacity(), 2);
   EXPECT_DOUBLE_EQ(cd.ch().ecu_status_2_516().battery_voltage(), 102.7);
   EXPECT_DOUBLE_EQ(cd.ch().ecu_status_2_516().battery_current(),
                    460.90000000000003);

--- a/modules/canbus/vehicle/devkit/devkit_controller.cc
+++ b/modules/canbus/vehicle/devkit/devkit_controller.cc
@@ -184,8 +184,11 @@ Chassis DevkitController::chassis() {
       chassis_detail.devkit().vcu_report_505().has_speed()) {
     chassis_.set_speed_mps(
         static_cast<float>(chassis_detail.devkit().vcu_report_505().speed()));
+    chassis_.set_battery_soc_percentage(
+        chassis_detail.devkit().vcu_report_505().battery_soc());
   } else {
     chassis_.set_speed_mps(0);
+    chassis_.set_battery_soc_percentage(0);
   }
   // 7 no odometer
   // chassis_.set_odometer_m(0);
@@ -480,19 +483,11 @@ bool DevkitController::CheckChassisError() {
         devkit.steering_report_502().steer_flt1()) {
       return true;
     }
-    if (Steering_report_502::STEER_FLT2_STEER_SYSTEM_COMUNICATION_FAULT ==
-        devkit.steering_report_502().steer_flt2()) {
-      return true;
-    }
   }
   // drive fault
   if (devkit.has_throttle_report_500()) {
     if (Throttle_report_500::THROTTLE_FLT1_DRIVE_SYSTEM_HARDWARE_FAULT ==
         devkit.throttle_report_500().throttle_flt1()) {
-      return true;
-    }
-    if (Throttle_report_500::THROTTLE_FLT2_DRIVE_SYSTEM_COMUNICATION_FAULT ==
-        devkit.throttle_report_500().throttle_flt2()) {
       return true;
     }
   }
@@ -502,25 +497,8 @@ bool DevkitController::CheckChassisError() {
         devkit.brake_report_501().brake_flt1()) {
       return true;
     }
-    if (Brake_report_501::BRAKE_FLT2_BRAKE_SYSTEM_COMUNICATION_FAULT ==
-        devkit.brake_report_501().brake_flt2()) {
-      return true;
-    }
   }
-  // gear fault
-  if (devkit.has_gear_report_503()) {
-    if (Gear_report_503::GEAR_FLT_FAULT ==
-        devkit.gear_report_503().gear_flt()) {
-      return true;
-    }
-  }
-  // park fault
-  if (devkit.has_park_report_504()) {
-    if (Park_report_504::PARK_FLT_FAULT ==
-        devkit.park_report_504().park_flt()) {
-      return true;
-    }
-  }
+
   return false;
 }
 

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505.cc
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505.cc
@@ -31,6 +31,8 @@ const int32_t Vcureport505::ID = 0x505;
 
 void Vcureport505::Parse(const std::uint8_t* bytes, int32_t length,
                          ChassisDetail* chassis) const {
+  chassis->mutable_devkit()->mutable_vcu_report_505()->set_battery_soc(
+      battery_soc(bytes, length));
   chassis->mutable_devkit()->mutable_vcu_report_505()->set_vehicle_mode_state(
       vehicle_mode_state(bytes, length));
   chassis->mutable_devkit()->mutable_vcu_report_505()->set_frontcrash_state(
@@ -43,6 +45,17 @@ void Vcureport505::Parse(const std::uint8_t* bytes, int32_t length,
       acc(bytes, length));
   chassis->mutable_devkit()->mutable_vcu_report_505()->set_speed(
       speed(bytes, length));
+}
+
+// config detail: {'name': 'battery_soc', 'offset': 0.0, 'precision': 1.0,
+// 'len': 8, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 47,
+// 'type': 'int', 'order': 'motorola', 'physical_unit': '%'}
+int Vcureport505::battery_soc(const std::uint8_t* bytes, int32_t length) const {
+  Byte t0(bytes + 5);
+  int32_t x = t0.get_byte(0, 8);
+
+  int ret = x;
+  return ret;
 }
 
 // config detail: {'name': 'vehicle_mode_state', 'enum': {0:

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505.h
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505.h
@@ -32,6 +32,11 @@ class Vcureport505 : public ::apollo::drivers::canbus::ProtocolData<
              ChassisDetail* chassis) const override;
 
  private:
+  // config detail: {'name': 'Battery_Soc', 'offset': 0.0, 'precision': 1.0,
+  // 'len': 8, 'is_signed_var': False, 'physical_range': '[0|100]', 'bit': 47,
+  // 'type': 'int', 'order': 'motorola', 'physical_unit': '%'}
+  int battery_soc(const std::uint8_t* bytes, const int32_t length) const;
+
   // config detail: {'name': 'Vehicle_Mode_State', 'enum': {0:
   // 'VEHICLE_MODE_STATE_MANUAL_REMOTE_MODE', 1: 'VEHICLE_MODE_STATE_AUTO_MODE',
   // 2: 'VEHICLE_MODE_STATE_EMERGENCY_MODE', 3:

--- a/modules/canbus/vehicle/devkit/protocol/vcu_report_505_test.cc
+++ b/modules/canbus/vehicle/devkit/protocol/vcu_report_505_test.cc
@@ -42,6 +42,7 @@ TEST_F(Vcureport505Test, General) {
   EXPECT_EQ(data[6], 0b00000100);
   EXPECT_EQ(data[7], 0b00000101);
 
+  EXPECT_EQ(cd.devkit().vcu_report_505().battery_soc(), 3);
   EXPECT_EQ(cd.devkit().vcu_report_505().vehicle_mode_state(), 1);
   EXPECT_EQ(cd.devkit().vcu_report_505().frontcrash_state(), 1);
   EXPECT_EQ(cd.devkit().vcu_report_505().backcrash_state(), 0);


### PR DESCRIPTION
Which are cherry-picked from master:
add the new battery soc info in chassis for vehicle dev_kit
add the battery info in vehicle ch (#12900)