### PR TITLE
Build: package com_google_glog renamed to com_github_google_glog

### DIFF
--- a/cyber/BUILD
+++ b/cyber/BUILD
@@ -106,7 +106,7 @@ cc_library(
         "//cyber/transport",
         "//cyber/transport/rtps:participant",
         "//cyber/transport/rtps:sub_listener",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@com_google_protobuf//:protobuf",
         "@fastrtps",
     ],

--- a/cyber/common/BUILD
+++ b/cyber/common/BUILD
@@ -43,7 +43,7 @@ cc_library(
     hdrs = ["log.h"],
     deps = [
         "//cyber:binary",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
     ],
 )
 

--- a/modules/dreamview/backend/map/BUILD
+++ b/modules/dreamview/backend/map/BUILD
@@ -14,7 +14,7 @@ cc_library(
         "//modules/map/pnc_map",
         "@boost",
         "@com_github_nlohmann_json//:json",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
     ],
 )
 

--- a/modules/localization/msf/BUILD
+++ b/modules/localization/msf/BUILD
@@ -45,7 +45,7 @@ cc_library(
         "//modules/transform:transform_broadcaster",
         "@boost",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/modules/localization/msf/common/util/BUILD
+++ b/modules/localization/msf/common/util/BUILD
@@ -21,7 +21,7 @@ cc_library(
     deps = [
         "//cyber/common:log",
         "@boost",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
         "@fastrtps",
     ],

--- a/modules/localization/msf/local_integ/BUILD
+++ b/modules/localization/msf/local_integ/BUILD
@@ -33,7 +33,7 @@ cc_library(
         "//third_party/localization_msf",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )

--- a/modules/localization/msf/local_pyramid_map/base_map/BUILD
+++ b/modules/localization/msf/local_pyramid_map/base_map/BUILD
@@ -14,7 +14,7 @@ cc_library(
         "//cyber/common",
         "//modules/common/util",
         "//modules/localization/msf/common/util",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -28,7 +28,7 @@ cc_library(
     ],
     deps = [
         "//cyber/common",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
         "@opencv//:imgcodecs",
         "@zlib",
@@ -46,7 +46,7 @@ cc_library(
     deps = [
         ":base_map_config",
         "//cyber/common",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -58,7 +58,7 @@ cc_library(
     deps = [
         ":base_map_node_index",
         "//cyber/common",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -80,7 +80,7 @@ cc_library(
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/common/util:compression",
         "//modules/localization/msf/common/util:file_utility",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -98,7 +98,7 @@ cc_library(
         ":base_map_node_index",
         "//cyber/common",
         "//modules/localization/msf/common/util",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -119,7 +119,7 @@ cc_library(
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/common/util:base_map_cache",
         "//modules/localization/msf/common/util:file_utility",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )

--- a/modules/localization/msf/local_pyramid_map/ndt_map/BUILD
+++ b/modules/localization/msf/local_pyramid_map/ndt_map/BUILD
@@ -9,7 +9,7 @@ cc_library(
     hdrs = ["ndt_map_config.h"],
     deps = [
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_config",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
     ],
 )
 
@@ -22,7 +22,7 @@ cc_library(
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_config",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_matrix",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -35,7 +35,7 @@ cc_library(
         ":ndt_map_config",
         ":ndt_map_matrix",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -46,7 +46,7 @@ cc_library(
     hdrs = ["ndt_map_node_config.h"],
     deps = [
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node_config",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -62,7 +62,7 @@ cc_library(
         ":ndt_map_node_config",
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )

--- a/modules/localization/msf/local_pyramid_map/pyramid_map/BUILD
+++ b/modules/localization/msf/local_pyramid_map/pyramid_map/BUILD
@@ -9,7 +9,7 @@ cc_library(
     hdrs = ["pyramid_map_config.h"],
     deps = [
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_config",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
     ],
 )
 
@@ -25,7 +25,7 @@ cc_library(
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_config",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_matrix",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -38,7 +38,7 @@ cc_library(
         ":pyramid_map_config",
         ":pyramid_map_matrix",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -49,7 +49,7 @@ cc_library(
     hdrs = ["pyramid_map_node_config.h"],
     deps = [
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node_config",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -65,7 +65,7 @@ cc_library(
         ":pyramid_map_node_config",
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_node",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -83,7 +83,7 @@ cc_library(
         "//modules/localization/msf/common/util:base_map_cache",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_config",
         "//modules/localization/msf/local_pyramid_map/base_map:base_map_pool",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )
@@ -98,7 +98,7 @@ cc_library(
         "//modules/localization/msf/common/util",
         "//modules/localization/msf/common/util:base_map_cache",
         "//modules/localization/msf/local_pyramid_map/base_map",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )

--- a/modules/localization/ndt/BUILD
+++ b/modules/localization/ndt/BUILD
@@ -37,7 +37,7 @@ cc_library(
         "//modules/transform:transform_broadcaster",
         "@boost",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
     ],
 )

--- a/modules/localization/ndt/ndt_locator/BUILD
+++ b/modules/localization/ndt/ndt_locator/BUILD
@@ -23,7 +23,7 @@ cc_library(
         "//modules/localization/msf/local_pyramid_map/ndt_map",
         "//modules/localization/msf/local_pyramid_map/ndt_map:ndt_map_pool",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@eigen",
         "@local_config_pcl//:pcl",
     ],

--- a/modules/map/hdmap/BUILD
+++ b/modules/map/hdmap/BUILD
@@ -30,7 +30,7 @@ cc_library(
         "//modules/map/proto:map_cc_proto",
         "//modules/map/relative_map/proto:navigation_cc_proto",
         "@com_google_absl//absl/strings",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
     ],
 )
 
@@ -70,7 +70,7 @@ cc_test(
     deps = [
         ":hdmap",
         "//cyber/common:file",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -85,7 +85,7 @@ cc_test(
     ],
     deps = [
         ":hdmap_util",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/modules/map/hdmap/adapter/BUILD
+++ b/modules/map/hdmap/adapter/BUILD
@@ -25,7 +25,7 @@ cc_library(
     hdrs = ["coordinate_convert_tool.h"],
     deps = [
         "//modules/map/hdmap/adapter/xml_parser:status",
-        "@com_google_glog//:glog",
+        "@com_github_google_glog//:glog",
         "@proj",
     ],
 )

--- a/third_party/glog/workspace.bzl
+++ b/third_party/glog/workspace.bzl
@@ -13,7 +13,7 @@ def clean_dep(dep):
 
 def repo():
     http_archive(
-        name = "com_google_glog",
+        name = "com_github_google_glog",
         sha256 = "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c",
         strip_prefix = "glog-0.4.0",
         url = "https://github.com/google/glog/archive/v0.4.0.tar.gz",


### PR DESCRIPTION
To accord with its upstream name: https://github.com/google/glog#bazel