### PR TITLE
Release build: framework/first attempt on release build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,3 +90,16 @@ grpc_extra_deps()
 #    build_file = "third_party/mklml.BUILD",
 #    path = "/usr/local/apollo/local_third_party/mklml",
 # )
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
+    urls = [
+        "https://apollo-system.cdn.bcebos.com/archive/6.0/rules_pkg-0.3.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/cyber/BUILD
+++ b/cyber/BUILD
@@ -3,14 +3,6 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
-    name = "cyber",
-    linkstatic = False,
-    deps = [
-        "//cyber:cyber_core",
-    ],
-)
-
 cc_binary(
     name = "mainboard",
     srcs = [
@@ -21,9 +13,8 @@ cc_binary(
         "mainboard/module_controller.h",
     ],
     linkopts = ["-pthread"],
-    linkstatic = False,
     deps = [
-        ":cyber_core",
+        ":cyber",
         "//cyber/proto:dag_conf_cc_proto",
     ],
 )
@@ -61,7 +52,7 @@ cc_library(
 )
 
 cc_library(
-    name = "cyber_core",
+    name = "cyber",
     srcs = ["cyber.cc"],
     hdrs = ["cyber.h"],
     linkopts = ["-lrt"],

--- a/cyber/io/BUILD
+++ b/cyber/io/BUILD
@@ -50,7 +50,7 @@ cc_test(
     srcs = ["poller_test.cc"],
     deps = [
         ":poller",
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -69,7 +69,7 @@ cc_binary(
     name = "tcp_echo_client",
     srcs = ["example/tcp_echo_client.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
     ],
 )
 
@@ -77,7 +77,7 @@ cc_binary(
     name = "tcp_echo_server",
     srcs = ["example/tcp_echo_server.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
     ],
 )
 
@@ -85,7 +85,7 @@ cc_binary(
     name = "udp_echo_client",
     srcs = ["example/udp_echo_client.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
     ],
 )
 
@@ -93,7 +93,7 @@ cc_binary(
     name = "udp_echo_server",
     srcs = ["example/udp_echo_server.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
     ],
 )
 

--- a/cyber/python/internal/BUILD
+++ b/cyber/python/internal/BUILD
@@ -17,7 +17,7 @@ cc_library(
     srcs = ["py_cyber.cc"],
     hdrs = ["py_cyber.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],
@@ -48,7 +48,7 @@ cc_library(
     srcs = ["py_record.cc"],
     hdrs = ["py_record.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/message:py_message",
         "//cyber/record",
         "@local_config_python//:python_headers",
@@ -82,7 +82,7 @@ cc_library(
     srcs = ["py_time.cc"],
     hdrs = ["py_time.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@fastrtps",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
@@ -103,7 +103,7 @@ cc_library(
     srcs = ["py_timer.cc"],
     hdrs = ["py_timer.h"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],
@@ -124,7 +124,7 @@ cc_library(
     hdrs = ["py_parameter.h"],
     deps = [
         ":py_cyber",
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@local_config_python//:python_headers",
         "@local_config_python//:python_lib",
     ],

--- a/cyber/sysmo/BUILD
+++ b/cyber/sysmo/BUILD
@@ -8,7 +8,7 @@ cc_test(
     size = "small",
     srcs = ["sysmo_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/scheduler:scheduler_factory",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cyber/task/BUILD
+++ b/cyber/task/BUILD
@@ -16,7 +16,7 @@ cc_test(
     size = "small",
     srcs = ["task_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cyber/timer/BUILD
+++ b/cyber/timer/BUILD
@@ -44,7 +44,7 @@ cc_test(
     size = "small",
     srcs = ["timer_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber:init",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cyber/transport/BUILD
+++ b/cyber/transport/BUILD
@@ -31,7 +31,7 @@ cc_test(
     size = "small",
     srcs = ["transport_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],

--- a/cyber/transport/common/BUILD
+++ b/cyber/transport/common/BUILD
@@ -19,7 +19,7 @@ cc_test(
     size = "small",
     srcs = ["endpoint_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -39,7 +39,7 @@ cc_test(
     size = "small",
     srcs = ["identity_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cyber/transport/dispatcher/BUILD
+++ b/cyber/transport/dispatcher/BUILD
@@ -21,7 +21,7 @@ cc_test(
     size = "small",
     srcs = ["dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
@@ -43,7 +43,7 @@ cc_test(
     size = "small",
     srcs = ["intra_dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
@@ -68,7 +68,7 @@ cc_test(
     size = "small",
     srcs = ["rtps_dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -94,7 +94,7 @@ cc_test(
     size = "small",
     srcs = ["shm_dispatcher_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cyber/transport/integration_test/BUILD
+++ b/cyber/transport/integration_test/BUILD
@@ -6,7 +6,7 @@ cc_test(
     size = "small",
     srcs = ["hybrid_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -17,7 +17,7 @@ cc_test(
     size = "small",
     srcs = ["intra_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
@@ -28,7 +28,7 @@ cc_test(
     size = "small",
     srcs = ["rtps_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],
@@ -39,7 +39,7 @@ cc_test(
     size = "small",
     srcs = ["shm_transceiver_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "//cyber/proto:unit_test_cc_proto",
         "@com_google_googletest//:gtest",
     ],

--- a/cyber/transport/message/BUILD
+++ b/cyber/transport/message/BUILD
@@ -45,7 +45,7 @@ cc_test(
     size = "small",
     srcs = ["message_info_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -55,7 +55,7 @@ cc_test(
     size = "small",
     srcs = ["message_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cyber/transport/rtps/BUILD
+++ b/cyber/transport/rtps/BUILD
@@ -62,7 +62,7 @@ cc_test(
     size = "small",
     srcs = ["rtps_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
         "@fastcdr",
     ],

--- a/cyber/transport/shm/BUILD
+++ b/cyber/transport/shm/BUILD
@@ -135,7 +135,7 @@ cc_test(
     size = "small",
     srcs = ["condition_notifier_test.cc"],
     deps = [
-        "//cyber:cyber_core",
+        "//cyber:cyber",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/dist/BUILD
+++ b/dist/BUILD
@@ -1,0 +1,40 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "apollo-dist",
+    deps = [
+        ":cyber-dist",
+    ],
+)
+
+pkg_tar(
+    name = "cyber-dist",
+    deps = [
+        ":cyber",
+        ":mainboard",
+    ],
+)
+
+pkg_tar(
+    name = "cyber",
+    srcs = [
+        "//cyber",
+    ],
+    mode = "0644",
+    package_dir = "lib",
+    strip_prefix = "/cyber",
+)
+
+pkg_tar(
+    name = "mainboard",
+    srcs = [
+        "//cyber:mainboard",
+    ],
+    mode = "0755",
+    package_dir = "bin",
+    strip_prefix = "/cyber",
+)

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,15 @@
+# Apollo Release Build
+
+This directory contains Bazel rules for packaging Apollo binaries, static/shared
+libraries, scripts, config/data files.
+
+Rules should be grouped by module, like the following:
+
+```text
+apollo-dist
+    - cyber-dist
+    - perception-dist
+    - prediction-dist
+    - planning-dist
+    - ...
+```

--- a/scripts/apollo_build.sh
+++ b/scripts/apollo_build.sh
@@ -114,8 +114,10 @@ function determine_build_targets() {
 
   for component in $@; do
     local build_targets
-    if [ "${component}" = "cyber" ]; then
+    if [[ "${component}" == "cyber" ]]; then
       build_targets="//cyber/... union //modules/tools/visualizer/..."
+    elif [[ "${component}" == "dist" ]]; then
+      build_targets="//dist/..."
     elif [[ -d "${APOLLO_ROOT_DIR}/modules/${component}" ]]; then
       build_targets="//modules/${component}/..."
     else


### PR DESCRIPTION
1) created a top-level directory `dist` to host release-build related bazel rules and scripts. An advantage of this approach is to not mess up with existing Bazel rules.

2) Each module (cyber, perception, planning, etc.) should have its own section in the BUILD file under the `dist` directory. 

All useful binaries, shared/static libraries, config/data files, setup scripts, should be packaged together under the name `modname-dist`.

3) With this PR, you can now generate apollo-dist.tar, cyber-dist.tar under `./bazel-bin/dist` directory with a single comman: 

```
./apollo.sh build dist
```

To check if the binaries, shared libraries, are self content, just run `ldd my_binary/libmy_lib.so` to see that it didn't depend on extra libs/symbols from Apollo.

Run each binary with relative configs to verify that it works well and can be used directly in release build.

4) More to come for other modules, and PRs are highly appreciated.


