### PR TITLE
Use the nvidia-docker2 package for the installation/setting of the NVIDIA container toolkit.

### DIFF
--- a/docs/specs/prerequisite_software_installation_guide.md
+++ b/docs/specs/prerequisite_software_installation_guide.md
@@ -122,7 +122,7 @@ distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 sudo apt-get -y update
-sudo apt-get install -y nvidia-container-toolkit
+sudo apt-get install -y nvidia-docker2
 ```
 
 ![tip_icon](images/tip_icon.png) Don't forget to restart the Docker daemon for


### PR DESCRIPTION
The current command for the installation of NVIDIA container toolkit has been changed into the following:

`
$ sudo apt-get install -y nvidia-docker2`

See [the official document](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit) and this [discussion](https://github.com/NVIDIA/nvidia-docker/issues/1407) filed on nvidia-docker issues list for more info.