### PR TITLE
D-KIT: correct default lidar_extrinsics_file in localization_conf 

### DIFF
--- a/modules/calibration/data/dev_kit_advanced_sne-r/localization_conf/localization.conf
+++ b/modules/calibration/data/dev_kit_advanced_sne-r/localization_conf/localization.conf
@@ -131,8 +131,8 @@
 
 # The lidar extrinsics file
 # type: string
-# default: /apollo/modules/localization/msf/params/velodyne_params/velodyne128_novatel_extrinsics.yaml
---lidar_extrinsics_file=/apollo/modules/localization/msf/params/velodyne_params/velodyne128_novatel_extrinsics.yaml
+# default: /apollo/modules/localization/msf/params/velodyne_params/velodyne16_novatel_extrinsics.yaml
+--lidar_extrinsics_file=/apollo/modules/localization/msf/params/velodyne_params/velodyne16_novatel_extrinsics.yaml
 
 # imu coordinate, true->flu, false->rfu
 # type: bool


### PR DESCRIPTION
correct default lidar_extrinsics_file in localization_conf