### PR TITLE
Build: removed non-existent CUDA SM=7.2 for x86_64 

### DIFF
--- a/docker/build/installers/install_pcl.sh
+++ b/docker/build/installers/install_pcl.sh
@@ -68,7 +68,8 @@ apt_get_update_and_install \
     libtiff-dev \
     liblz4-dev \
     libfreetype6-dev \
-    libpcap-dev
+    libpcap-dev \
+    libqhull-dev
 
 # NOTE(storypku)
 # libglfw3-dev depends on libglfw3,
@@ -135,7 +136,8 @@ apt_get_remove \
     libtiff-dev \
     liblz4-dev \
     libfreetype6-dev \
-    libpcap-dev
+    libpcap-dev \
+    libqhull-dev
 
 # Add runtime-deps for pcl
 apt_get_update_and_install \
@@ -144,7 +146,8 @@ apt_get_update_and_install \
     libfreetype6 \
     libtiff5 \
     libdouble-conversion1 \
-    libpcap0.8
+    libpcap0.8 \
+    libqhull7
 
 # Clean up cache to reduce layer size.
 apt-get clean && \

--- a/docker/build/installers/installer_base.sh
+++ b/docker/build/installers/installer_base.sh
@@ -37,9 +37,9 @@ export LOCAL_HTTP_ADDR="http://172.17.0.1:8388"
 
 if [[ "$(uname -m)" == "x86_64" ]]; then
     if [[ "${APOLLO_DIST}" == "stable" ]]; then
-        export SUPPORTED_NVIDIA_SMS="3.7 5.2 6.0 6.1 7.0 7.2 7.5"
+        export SUPPORTED_NVIDIA_SMS="3.7 5.2 6.0 6.1 7.0 7.5"
     else
-        export SUPPORTED_NVIDIA_SMS="5.2 6.0 6.1 7.0 7.2 7.5 8.0 8.6"
+        export SUPPORTED_NVIDIA_SMS="5.2 6.0 6.1 7.0 7.5 8.0 8.6"
     fi
 else # AArch64
     export SUPPORTED_NVIDIA_SMS="5.3 6.2 7.2"

--- a/modules/perception/camera/app/BUILD
+++ b/modules/perception/camera/app/BUILD
@@ -22,10 +22,9 @@ cc_library(
     deps = [
         ":debug_info",
         "//cyber",
-        "//external:gflags",
         "//modules/common/util:perf_util",
-        "//modules/perception/camera/app/proto:perception_cc_proto",
         "//modules/perception/base",
+        "//modules/perception/camera/app/proto:perception_cc_proto",
         "//modules/perception/camera/common",
         "//modules/perception/camera/lib/calibration_service/online_calibration_service",
         "//modules/perception/camera/lib/calibrator/laneline:laneline_calibrator",
@@ -41,6 +40,7 @@ cc_library(
         "//modules/perception/camera/lib/obstacle/transformer/multicue:multicue_obstacle_transformer",
         "//modules/perception/inference/utils:inference_cuda_util_lib",
         "//modules/perception/inference/utils:inference_util_lib",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 
@@ -70,7 +70,6 @@ cc_library(
     deps = [
         ":debug_info",
         "//cyber",
-        "//external:gflags",
         "//modules/common/util:perf_util",
         "//modules/perception/base",
         "//modules/perception/camera/app/proto:perception_cc_proto",
@@ -84,6 +83,7 @@ cc_library(
         "//modules/perception/camera/lib/lane/postprocessor/denseline:denseline_lane_postprocessor",
         "//modules/perception/inference/utils:inference_cuda_util_lib",
         "//modules/perception/inference/utils:inference_util_lib",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/modules/task_manager/BUILD
+++ b/modules/task_manager/BUILD
@@ -3,14 +3,16 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+TASK_MANAGER_COPTS = ['-DMODULE_NAME=\\"task_manager\\"']
+
 cc_library(
     name = "cycle_routing_manager_lib",
     srcs = ["cycle_routing_manager.cc"],
     hdrs = ["cycle_routing_manager.h"],
-    copts = ['-DMODULE_NAME=\\"task_manager\\"'],
+    copts = TASK_MANAGER_COPTS,
     deps = [
-        "//modules/common/status:status",
-        "//modules/common/monitor_log:monitor_log",
+        "//modules/common/monitor_log",
+        "//modules/common/status",
         "//modules/dreamview/backend/map:map_service",
         "//modules/localization/proto:localization_cc_proto",
         "//modules/task_manager/common:task_manager_gflags",
@@ -22,7 +24,7 @@ cc_library(
     name = "task_manager_component_lib",
     srcs = ["task_manager_component.cc"],
     hdrs = ["task_manager_component.h"],
-    copts = ['-DMODULE_NAME=\\"task_manager\\"'],
+    copts = TASK_MANAGER_COPTS,
     deps = [
         ":cycle_routing_manager_lib",
         "//cyber",


### PR DESCRIPTION
Please don't use `//external:gflags` to specify build dependencies.
