### PR TITLE
Perception: resume camera obstacle detection in sensor fusion

### DIFF
--- a/modules/perception/fusion/app/obstacle_multi_sensor_fusion.cc
+++ b/modules/perception/fusion/app/obstacle_multi_sensor_fusion.cc
@@ -28,7 +28,7 @@ bool ObstacleMultiSensorFusion::Init(
   fusion_ = BaseFusionSystemRegisterer::GetInstanceByName(param.fusion_method);
 
   FusionInitOptions init_options;
-  init_options.main_sensor = param.main_sensor;
+  init_options.main_sensors = param.main_sensors;
   if (fusion_ == nullptr || !fusion_->Init(init_options)) {
     AINFO << "Failed to Get Instance or Initialize " << param.fusion_method;
     return false;

--- a/modules/perception/fusion/app/obstacle_multi_sensor_fusion.h
+++ b/modules/perception/fusion/app/obstacle_multi_sensor_fusion.h
@@ -25,7 +25,7 @@ namespace perception {
 namespace fusion {
 
 struct ObstacleMultiSensorFusionParam {
-  std::string main_sensor;
+  std::vector<std::string> main_sensors;
   std::string fusion_method;
 };
 

--- a/modules/perception/fusion/lib/data_association/hm_data_association/hm_tracks_objects_match.cc
+++ b/modules/perception/fusion/lib/data_association/hm_data_association/hm_tracks_objects_match.cc
@@ -65,6 +65,7 @@ bool HMTrackersObjectsAssociation::Associate(
   double measurement_timestamp = sensor_objects[0]->GetTimestamp();
   track_object_distance_.ResetProjectionCache(measurement_sensor_id,
                                               measurement_timestamp);
+  // TODO(chenjiahao): specify prohibited sensors in config
   bool do_nothing = (sensor_objects[0]->GetSensorId() == "radar_front");
   IdAssign(fusion_tracks, sensor_objects, &association_result->assignments,
            &association_result->unassigned_tracks,

--- a/modules/perception/fusion/lib/dummy/dummy_algorithms.cc
+++ b/modules/perception/fusion/lib/dummy/dummy_algorithms.cc
@@ -21,7 +21,7 @@ namespace fusion {
 
 // class DummyFusionSystem implementation
 bool DummyFusionSystem::Init(const FusionInitOptions& options) {
-  main_sensor_ = options.main_sensor;
+  main_sensors_ = options.main_sensors;
   return true;
 }
 
@@ -33,7 +33,8 @@ bool DummyFusionSystem::Fuse(const FusionOptions& options,
   }
 
   fused_objects->clear();
-  if (sensor_frame->sensor_info.name != main_sensor_) {
+  if (std::find(main_sensors_.begin(), main_sensors_.end(),
+                sensor_frame->sensor_info.name) == main_sensors_.end()) {
     return true;
   }
 

--- a/modules/perception/fusion/lib/dummy/dummy_algorithms_test.cc
+++ b/modules/perception/fusion/lib/dummy/dummy_algorithms_test.cc
@@ -29,7 +29,7 @@ namespace fusion {
 
 TEST(DummyFusionSystemTest, test) {
   FusionInitOptions init_options;
-  init_options.main_sensor = "velodyne64";
+  init_options.main_sensors = std::vector<std::string>{"velodyne64"};
   DummyFusionSystem system;
   EXPECT_TRUE(system.Init(init_options));
 

--- a/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion.cc
+++ b/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion.cc
@@ -43,7 +43,7 @@ ProbabilisticFusion::ProbabilisticFusion() {}
 ProbabilisticFusion::~ProbabilisticFusion() {}
 
 bool ProbabilisticFusion::Init(const FusionInitOptions& init_options) {
-  main_sensor_ = init_options.main_sensor;
+  main_sensors_ = init_options.main_sensors;
 
   BaseInitOptions options;
   if (!GetFusionInitOptions("ProbabilisticFusion", &options)) {
@@ -166,16 +166,13 @@ std::string ProbabilisticFusion::Name() const { return "ProbabilisticFusion"; }
 bool ProbabilisticFusion::IsPublishSensor(
     const base::FrameConstPtr& sensor_frame) const {
   std::string sensor_id = sensor_frame->sensor_info.name;
-  return sensor_id == main_sensor_;
-  // const std::vector<std::string>& pub_sensors =
-  //   params_.publish_sensor_ids;
-  // const auto& itr = std::find(
-  //   pub_sensors.begin(), pub_sensors.end(), sensor_id);
-  // if (itr != pub_sensors.end()) {
-  //   return true;
-  // } else {
-  //   return false;
-  // }
+  const auto& itr = std::find(
+      main_sensors_.begin(), main_sensors_.end(), sensor_id);
+  if (itr != main_sensors_.end()) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 void ProbabilisticFusion::FuseFrame(const SensorFramePtr& frame) {
@@ -352,7 +349,7 @@ void ProbabilisticFusion::RemoveLostTrack() {
     }
   }
   AINFO << "Remove " << foreground_tracks.size() - foreground_track_count
-        << " foreground tracks";
+        << " foreground tracks. " << foreground_track_count << " tracks left.";
   foreground_tracks.resize(foreground_track_count);
   trackers_.resize(foreground_track_count);
 

--- a/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion_test.cc
+++ b/modules/perception/fusion/lib/fusion_system/probabilistic_fusion/probabilistic_fusion_test.cc
@@ -37,7 +37,7 @@ TEST(ProbabliticFusionTest, test_init) {
   sensor_manager->Reset();
   sensor_manager->Init();
   FusionInitOptions init_options;
-  init_options.main_sensor = "velodyne64";
+  init_options.main_sensors = std::vector<std::string>{"velodyne64"};
   ProbabilisticFusion pf;
   EXPECT_TRUE(pf.Init(init_options));
   EXPECT_EQ(pf.Name(), "ProbabilisticFusion");
@@ -106,7 +106,7 @@ TEST(ProbabliticFusionTest, test_update) {
   sensor_manager->Reset();
   sensor_manager->Init();
   FusionInitOptions init_options;
-  init_options.main_sensor = "velodyne64";
+  init_options.main_sensors = std::vector<std::string>{"velodyne64"};
   ProbabilisticFusion pf;
   EXPECT_TRUE(pf.Init(init_options));
   EXPECT_EQ(pf.Name(), "ProbabilisticFusion");
@@ -257,7 +257,7 @@ TEST(ProbabilisticFusionTest, test_collect_sensor_measurement) {
   sensor_manager->Reset();
   sensor_manager->Init();
   FusionInitOptions init_options;
-  init_options.main_sensor = "velodyne64";
+  init_options.main_sensors = std::vector<std::string>{"velodyne64"};
   ProbabilisticFusion pf;
   EXPECT_TRUE(pf.Init(init_options));
   EXPECT_EQ(pf.Name(), "ProbabilisticFusion");

--- a/modules/perception/fusion/lib/gatekeeper/pbf_gatekeeper/pbf_gatekeeper.cc
+++ b/modules/perception/fusion/lib/gatekeeper/pbf_gatekeeper/pbf_gatekeeper.cc
@@ -111,6 +111,7 @@ bool PbfGatekeeper::RadarAbleToPublish(const TrackPtr &track, bool is_night) {
   if (params_.publish_if_has_radar && visible_in_radar &&
       radar_object != nullptr) {
     if (radar_object->GetSensorId() == "radar_front") {
+      // TODO(henjiahao): enable radar front
       return false;
       // if (radar_object->GetBaseObject()->radar_supplement.range >
       //         params_.min_radar_confident_distance &&

--- a/modules/perception/fusion/lib/interface/base_fusion_system.h
+++ b/modules/perception/fusion/lib/interface/base_fusion_system.h
@@ -29,7 +29,7 @@ namespace perception {
 namespace fusion {
 
 struct FusionInitOptions {
-  std::string main_sensor;
+  std::vector<std::string> main_sensors;
 };
 
 struct FusionOptions {};
@@ -54,7 +54,7 @@ class BaseFusionSystem {
   virtual std::string Name() const = 0;
 
  protected:
-  std::string main_sensor_;
+  std::vector<std::string> main_sensors_;
 };
 
 PERCEPTION_REGISTER_REGISTERER(BaseFusionSystem);

--- a/modules/perception/onboard/component/fusion_component.h
+++ b/modules/perception/onboard/component/fusion_component.h
@@ -49,7 +49,7 @@ class FusionComponent : public cyber::Component<SensorFrameMessage> {
   static uint32_t s_seq_num_;
 
   std::string fusion_method_;
-  std::string fusion_main_sensor_;
+  std::vector<std::string> fusion_main_sensors_;
   bool object_in_roi_check_ = false;
   double radius_for_roi_object_check_ = 0;
 

--- a/modules/perception/onboard/proto/fusion_component_config.proto
+++ b/modules/perception/onboard/proto/fusion_component_config.proto
@@ -4,12 +4,12 @@ package apollo.perception.onboard;
 
 message FusionComponentConfig {
   optional string fusion_method = 1;
-  optional string fusion_main_sensor = 2;
+  repeated string fusion_main_sensors = 2;
   optional bool object_in_roi_check = 3;
   optional double radius_for_roi_object_check = 4;
 
   optional string output_obstacles_channel_name = 5
-      [default = "/perception/obstacles"];
+      [default = "/perception/vehicle/obstacles"];
   optional string output_viz_fused_content_channel_name = 6
       [default = "/perception/inner/visualization/FusedObjects"];
 }

--- a/modules/perception/production/conf/perception/camera/fusion_camera_detection_component.pb.txt
+++ b/modules/perception/production/conf/perception/camera/fusion_camera_detection_component.pb.txt
@@ -7,7 +7,7 @@ frame_capacity : 20
 image_channel_num : 3
 enable_undistortion : false
 enable_visualization : false
-output_final_obstacles : true
+output_final_obstacles : false
 output_obstacles_channel_name : "/perception/obstacles"
 camera_perception_viz_message_channel_name : "/perception/inner/camera_viz_msg"
 prefused_channel_name : "/perception/inner/PrefusedObjects"

--- a/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt
+++ b/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt
@@ -1,5 +1,7 @@
 fusion_method: "ProbabilisticFusion"
-fusion_main_sensor: "velodyne128"
+fusion_main_sensors: "velodyne128"
+fusion_main_sensors: "front_6mm"
+fusion_main_sensors: "front_12mm"
 object_in_roi_check: true
 radius_for_roi_object_check: 120
 output_obstacles_channel_name: "/perception/vehicle/obstacles"

--- a/modules/perception/production/dag/dag_motion_service.dag
+++ b/modules/perception/production/dag/dag_motion_service.dag
@@ -3,9 +3,9 @@ module_config {
   components {
     class_name : "MotionService"
     config {
-    name : "camera_motionService"
-    config_file_path : "/apollo/modules/perception/production/conf/perception/camera/motion_service.config"
-    flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
+      name : "camera_motionService"
+      config_file_path : "/apollo/modules/perception/production/conf/perception/camera/motion_service.config"
+      flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
     }
   }
 }

--- a/modules/perception/production/dag/dag_streaming_perception.dag
+++ b/modules/perception/production/dag/dag_streaming_perception.dag
@@ -1,4 +1,16 @@
 module_config {
+  module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_camera.so"
+  components {
+    class_name : "FusionCameraDetectionComponent"
+    config {
+      name: "FusionCameraComponent"
+      config_file_path: "/apollo/modules/perception/production/conf/perception/camera/fusion_camera_detection_component.pb.txt"
+      flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
+    }
+  }
+}
+
+module_config {
   module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_lidar.so"
 
   components {
@@ -8,8 +20,8 @@ module_config {
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
-        }
+        channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
+      }
     }
   }
 
@@ -19,8 +31,8 @@ module_config {
       name: "RecognitionComponent"
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/recognition_conf.pb.txt"
       readers {
-          channel: "/perception/inner/DetectionObjects"
-        }
+        channel: "/perception/inner/DetectionObjects"
+      }
     }
   }
 
@@ -29,9 +41,10 @@ module_config {
     config {
       name: "FrontRadarDetection"
       config_file_path: "/apollo/modules/perception/production/conf/perception/radar/front_radar_component_conf.pb.txt"
+      flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/radar/front"
-        }
+        channel: "/apollo/sensor/radar/front"
+      }
     }
   }
 
@@ -40,9 +53,10 @@ module_config {
     config {
       name: "RearRadarDetection"
       config_file_path: "/apollo/modules/perception/production/conf/perception/radar/rear_radar_component_conf.pb.txt"
+      flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/radar/rear"
-        }
+        channel: "/apollo/sensor/radar/rear"
+      }
     }
   }
 
@@ -52,8 +66,8 @@ module_config {
       name: "SensorFusion"
       config_file_path: "/apollo/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt"
       readers {
-          channel: "/perception/inner/PrefusedObjects"
-        }
+        channel: "/perception/inner/PrefusedObjects"
+      }
     }
   }
 }

--- a/modules/perception/production/dag/dag_streaming_perception.dag
+++ b/modules/perception/production/dag/dag_streaming_perception.dag
@@ -14,10 +14,10 @@ module_config {
   module_library : "/apollo/bazel-bin/modules/perception/onboard/component/libperception_component_lidar.so"
 
   components {
-    class_name : "DetectionComponent"
+    class_name : "SegmentationComponent"
     config {
-      name: "Velodyne128Detection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf.pb.txt"
+      name: "Velodyne128Segmentation"
+      config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_segmentation_conf.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
         channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
@@ -31,7 +31,7 @@ module_config {
       name: "RecognitionComponent"
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/recognition_conf.pb.txt"
       readers {
-        channel: "/perception/inner/DetectionObjects"
+        channel: "/perception/inner/SegmentationObjects"
       }
     }
   }

--- a/modules/perception/production/dag/dag_streaming_perception_lane.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lane.dag
@@ -8,9 +8,8 @@ module_config {
       config_file_path: "/apollo/modules/perception/production/conf/perception/camera/lane_detection_component.config"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/perception/lane_status"
-        }
+        channel: "/apollo/perception/lane_status"
+      }
     }
   }
-
 }

--- a/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lgsvl.dag
@@ -8,8 +8,8 @@ module_config {
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf_lgsvl.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
-        }
+        channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
+      }
     }
   }
 
@@ -19,8 +19,8 @@ module_config {
       name: "RecognitionComponent"
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/recognition_conf.pb.txt"
       readers {
-          channel: "/perception/inner/DetectionObjects"
-        }
+        channel: "/perception/inner/DetectionObjects"
+      }
     }
   }
 
@@ -30,8 +30,8 @@ module_config {
       name: "FrontRadarDetection"
       config_file_path: "/apollo/modules/perception/production/conf/perception/radar/front_radar_component_conf.pb.txt"
       readers {
-          channel: "/apollo/sensor/radar/front"
-        }
+        channel: "/apollo/sensor/radar/front"
+      }
     }
   }
 
@@ -41,8 +41,8 @@ module_config {
       name: "RearRadarDetection"
       config_file_path: "/apollo/modules/perception/production/conf/perception/radar/rear_radar_component_conf.pb.txt"
       readers {
-          channel: "/apollo/sensor/radar/rear"
-        }
+        channel: "/apollo/sensor/radar/rear"
+      }
     }
   }
 
@@ -52,8 +52,8 @@ module_config {
       name: "SensorFusion"
       config_file_path: "/apollo/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt"
       readers {
-          channel: "/perception/inner/PrefusedObjects"
-        }
+        channel: "/perception/inner/PrefusedObjects"
+      }
     }
   }
 }

--- a/modules/perception/production/dag/dag_streaming_perception_lidar.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lidar.dag
@@ -8,8 +8,8 @@ module_config {
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_detection_conf.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
-        }
+        channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
+      }
     }
   }
 
@@ -19,11 +19,10 @@ module_config {
       name: "RecognitionComponent"
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/recognition_conf.pb.txt"
       readers {
-          channel: "/perception/inner/DetectionObjects"
-        }
+        channel: "/perception/inner/DetectionObjects"
+      }
     }
   }
-
 
   components {
     class_name: "FusionComponent"
@@ -31,11 +30,10 @@ module_config {
       name: "SensorFusion"
       config_file_path: "/apollo/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt"
       readers {
-          channel: "/perception/inner/PrefusedObjects"
-        }
+        channel: "/perception/inner/PrefusedObjects"
+      }
     }
   }
-
 }
 
 module_config {

--- a/modules/perception/production/dag/dag_streaming_perception_lidar_segmentation.dag
+++ b/modules/perception/production/dag/dag_streaming_perception_lidar_segmentation.dag
@@ -8,8 +8,8 @@ module_config {
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/velodyne128_segmentation_conf.pb.txt"
       flag_file_path: "/apollo/modules/perception/production/conf/perception/perception_common.flag"
       readers {
-          channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
-        }
+        channel: "/apollo/sensor/lidar128/compensator/PointCloud2"
+      }
     }
   }
 
@@ -19,30 +19,8 @@ module_config {
       name: "RecognitionComponent"
       config_file_path: "/apollo/modules/perception/production/conf/perception/lidar/recognition_conf.pb.txt"
       readers {
-          channel: "/perception/inner/SegmentationObjects"
-        }
-    }
-  }
-
-  components {
-    class_name: "RadarDetectionComponent"
-    config {
-      name: "FrontRadarDetection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/radar/front_radar_component_conf.pb.txt"
-      readers {
-          channel: "/apollo/sensor/radar/front"
-        }
-    }
-  }
-
-  components {
-    class_name: "RadarDetectionComponent"
-    config {
-      name: "RearRadarDetection"
-      config_file_path: "/apollo/modules/perception/production/conf/perception/radar/rear_radar_component_conf.pb.txt"
-      readers {
-          channel: "/apollo/sensor/radar/rear"
-        }
+        channel: "/perception/inner/SegmentationObjects"
+      }
     }
   }
 
@@ -52,8 +30,8 @@ module_config {
       name: "SensorFusion"
       config_file_path: "/apollo/modules/perception/production/conf/perception/fusion/fusion_component_conf.pb.txt"
       readers {
-          channel: "/perception/inner/PrefusedObjects"
-        }
+        channel: "/perception/inner/PrefusedObjects"
+      }
     }
   }
 }

--- a/modules/perception/production/launch/perception.launch
+++ b/modules/perception/production/launch/perception.launch
@@ -16,13 +16,6 @@
         <version>1.0.0</version>
     </module>
     <module>
-        <name>perception_camera</name>
-        <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_camera.dag</dag_conf>
-        <!-- if not set, use default process -->
-        <process_name>camera_perception</process_name>
-        <version>1.0.0</version>
-    </module>
-    <module>
         <name>motion_service</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_motion_service.dag</dag_conf>
         <!-- if not set, use default process -->

--- a/modules/perception/production/launch/perception_all.launch
+++ b/modules/perception/production/launch/perception_all.launch
@@ -15,14 +15,6 @@
         <version>1.0.0</version>
     </module>
     <module>
-        <name>perception_camera</name>
-        <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_camera.dag</dag_conf>
-        <!-- if not set, use default process -->
-        <process_name>perception</process_name>
-        <version>1.0.0</version>
-    </module>
-
-    <module>
         <name>perception_traffic_light</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_trafficlights.dag</dag_conf>
         <!-- if not set, use default process -->


### PR DESCRIPTION
1. Enable Camera & Lidar fusion.
2. Add camera obstacle detection to Perception module's default dag.