### PR TITLE
tools: fix bug for cannot input command multi times

### DIFF
--- a/modules/tools/vehicle_calibration/data_collector.py
+++ b/modules/tools/vehicle_calibration/data_collector.py
@@ -99,6 +99,7 @@ class DataCollector(object):
         self.controlcmd.gear_location = chassis_pb2.Chassis.GEAR_DRIVE
 
         self.canmsg_received = False
+        self.case = 'a'
 
         while self.in_session:
             now = cyber_time.Time.now().to_sec()


### PR DESCRIPTION
## reason
When input a command like "15 2 -20", the car will accelerate first, then decelerate and stop at last , then exit the loop and waiting for the next command. But the `self.case` is `d` and not init to 'a' again. when we input the next command because the d-kit's speed is 0, it will enter the `case d` and immediately exit!!!

## fix
when we input the next command init the `self.case` to `a`.