### PR TITLE
Docker: Hide message 'Error: No such container:'

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -140,7 +140,7 @@ function stop_all_apollo_containers_for_user() {
             info "Now stop container ${container} ..."
             if docker stop "${container}" >/dev/null; then
                 if [[ "${force}" == "-f" || "${force}" == "--force" ]]; then
-                    docker rm -f "${container}" >/dev/null
+                    docker rm -f "${container}" 2>/dev/null
                 fi
                 info "Done."
             else


### PR DESCRIPTION
When stopping containers using `dev_start.sh stop`, the following message appears: 'Error: No such container:'

```bash
$ docker/scripts/dev_start.sh stop
[INFO] Now stop container apollo_dev_user ...
[INFO] Done.
[INFO] Now stop container apollo_smoke_volume_user ...
Error: No such container: apollo_smoke_volume_user
[INFO] Done.
[INFO] Now stop container apollo_faster_rcnn_volume_user ...
Error: No such container: apollo_faster_rcnn_volume_user
...
```