### PR TITLE
Cyber: bugfix for dlopen operations in SharedLibrary impl

### DIFF
--- a/cyber/class_loader/shared_library/shared_library.cc
+++ b/cyber/class_loader/shared_library/shared_library.cc
@@ -29,6 +29,8 @@ namespace apollo {
 namespace cyber {
 namespace class_loader {
 
+std::mutex SharedLibrary::mutex_;
+
 SharedLibrary::SharedLibrary(const std::string& path) { Load(path, 0); }
 
 SharedLibrary::SharedLibrary(const std::string& path, int flags) {
@@ -43,9 +45,9 @@ void SharedLibrary::Load(const std::string& path, int flags) {
 
   int real_flag = RTLD_LAZY;
   if (flags & SHLIB_LOCAL) {
-    real_flag |= SHLIB_LOCAL;
+    real_flag |= RTLD_LOCAL;
   } else {
-    real_flag |= SHLIB_GLOBAL;
+    real_flag |= RTLD_GLOBAL;
   }
   handle_ = dlopen(path.c_str(), real_flag);
   if (!handle_) {

--- a/cyber/class_loader/shared_library/shared_library.h
+++ b/cyber/class_loader/shared_library/shared_library.h
@@ -114,7 +114,7 @@ class SharedLibrary {
  private:
   void* handle_ = nullptr;
   std::string path_;
-  std::mutex mutex_;
+  static std::mutex mutex_;
 };
 
 }  // namespace class_loader

--- a/docker/build/installers/install_dreamview_deps.sh
+++ b/docker/build/installers/install_dreamview_deps.sh
@@ -24,7 +24,9 @@ CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 . ${CURR_DIR}/installer_base.sh
 
 apt_get_update_and_install \
-    libtinyxml2-dev
+    libtinyxml2-dev \
+    libpng-dev \
+    nasm
 
 # NodeJS
 info "Installing nodejs ..."


### PR DESCRIPTION
@daohu527 
@JackFu123 

Without this PR, running `mainboard -d modules/planning/dag/planning.dag` will complains:
    
```text
    INTEL MKL ERROR: /usr/local/lib/libmkl_avx2.so: undefined symbol: mkl_sparse_optimize_bsr_trsm_i8.
    Intel MKL FATAL ERROR: Cannot load libmkl_avx2.so or libmkl_def.so.
```