### PR TITLE
D-KIT: modify planning configs

### DIFF
--- a/modules/calibration/data/dev_kit/planning_conf/planning_config.pb.txt
+++ b/modules/calibration/data/dev_kit/planning_conf/planning_config.pb.txt
@@ -7,7 +7,7 @@ default_task_config: {
   task_type: PIECEWISE_JERK_PATH_OPTIMIZER
   piecewise_jerk_path_config {
     default_path_config {
-      l_weight: 1.0
+      l_weight: 30.0
       dl_weight: 20.0
       ddl_weight: 1000.0
       dddl_weight: 50000.0

--- a/modules/calibration/data/dev_kit_advanced_ne-b/planning_conf/planning_config.pb.txt
+++ b/modules/calibration/data/dev_kit_advanced_ne-b/planning_conf/planning_config.pb.txt
@@ -7,7 +7,7 @@ default_task_config: {
   task_type: PIECEWISE_JERK_PATH_OPTIMIZER
   piecewise_jerk_path_config {
     default_path_config {
-      l_weight: 1.0
+      l_weight: 30.0
       dl_weight: 20.0
       ddl_weight: 1000.0
       dddl_weight: 50000.0

--- a/modules/calibration/data/dev_kit_advanced_ne-s/planning_conf/planning_config.pb.txt
+++ b/modules/calibration/data/dev_kit_advanced_ne-s/planning_conf/planning_config.pb.txt
@@ -7,7 +7,7 @@ default_task_config: {
   task_type: PIECEWISE_JERK_PATH_OPTIMIZER
   piecewise_jerk_path_config {
     default_path_config {
-      l_weight: 1.0
+      l_weight: 30.0
       dl_weight: 20.0
       ddl_weight: 1000.0
       dddl_weight: 50000.0

--- a/modules/calibration/data/dev_kit_advanced_sne-r/planning_conf/planning_config.pb.txt
+++ b/modules/calibration/data/dev_kit_advanced_sne-r/planning_conf/planning_config.pb.txt
@@ -7,7 +7,7 @@ default_task_config: {
   task_type: PIECEWISE_JERK_PATH_OPTIMIZER
   piecewise_jerk_path_config {
     default_path_config {
-      l_weight: 1.0
+      l_weight: 30.0
       dl_weight: 20.0
       ddl_weight: 1000.0
       dddl_weight: 50000.0

--- a/modules/calibration/data/dev_kit_standard/planning_conf/planning_config.pb.txt
+++ b/modules/calibration/data/dev_kit_standard/planning_conf/planning_config.pb.txt
@@ -7,7 +7,7 @@ default_task_config: {
   task_type: PIECEWISE_JERK_PATH_OPTIMIZER
   piecewise_jerk_path_config {
     default_path_config {
-      l_weight: 1.0
+      l_weight: 30.0
       dl_weight: 20.0
       ddl_weight: 1000.0
       dddl_weight: 50000.0


### PR DESCRIPTION
modify planning configs to make vehicle follow the center of the road by default