### PR TITLE
[Planning]Update navi_planning.cc

### DIFF
--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -670,22 +670,11 @@ void NavigationLane::ConvertLaneMarkerToPath(
 
   double path_c0 = (left_lane.c0_position() + right_lane.c0_position()) / 2.0;
 
-  double left_quality = left_lane.quality() + 0.001;
-  double right_quality = right_lane.quality() + 0.001;
+  double path_c1 = left_lane.c1_heading_angle() + right_lane.c1_heading_angle();
 
-  double quality_divider = left_quality + right_quality;
+  double path_c2 = left_lane.c2_curvature() + right_lane.c2_curvature();
 
-  double path_c1 = (left_lane.c1_heading_angle() * left_quality +
-                    right_lane.c1_heading_angle() * right_quality) /
-                   quality_divider;
-
-  double path_c2 = (left_lane.c2_curvature() * left_quality +
-                    right_lane.c2_curvature() * right_quality) /
-                   quality_divider;
-
-  double path_c3 = (left_lane.c3_curvature_derivative() * left_quality +
-                    right_lane.c3_curvature_derivative() * right_quality) /
-                   quality_divider;
+  double path_c3 = left_lane.c3_curvature_derivative() + right_lane.c3_curvature_derivative();
 
   const double current_speed =
       vehicle_state_provider_->vehicle_state().linear_velocity();

--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -670,11 +670,11 @@ void NavigationLane::ConvertLaneMarkerToPath(
 
   double path_c0 = (left_lane.c0_position() + right_lane.c0_position()) / 2.0;
 
-  double path_c1 = left_lane.c1_heading_angle() + right_lane.c1_heading_angle();
+  double path_c1 = (left_lane.c1_heading_angle() + right_lane.c1_heading_angle())/2.0;
 
-  double path_c2 = left_lane.c2_curvature() + right_lane.c2_curvature();
+  double path_c2 = (left_lane.c2_curvature() + right_lane.c2_curvature())/2.0;
 
-  double path_c3 = left_lane.c3_curvature_derivative() + right_lane.c3_curvature_derivative();
+  double path_c3 = (left_lane.c3_curvature_derivative() + right_lane.c3_curvature_derivative())/2.0;
 
   const double current_speed =
       vehicle_state_provider_->vehicle_state().linear_velocity();

--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -678,7 +678,7 @@ void NavigationLane::ConvertLaneMarkerToPath(
   double path_c3 = (left_lane.c3_curvature_derivative() +
                     right_lane.c3_curvature_derivative()) /
                    2.0;
-  
+
   const double current_speed =
       vehicle_state_provider_->vehicle_state().linear_velocity();
   double path_range =

--- a/modules/map/relative_map/navigation_lane.cc
+++ b/modules/map/relative_map/navigation_lane.cc
@@ -670,12 +670,15 @@ void NavigationLane::ConvertLaneMarkerToPath(
 
   double path_c0 = (left_lane.c0_position() + right_lane.c0_position()) / 2.0;
 
-  double path_c1 = (left_lane.c1_heading_angle() + right_lane.c1_heading_angle())/2.0;
+  double path_c1 =
+      (left_lane.c1_heading_angle() + right_lane.c1_heading_angle()) / 2.0;
 
-  double path_c2 = (left_lane.c2_curvature() + right_lane.c2_curvature())/2.0;
+  double path_c2 = (left_lane.c2_curvature() + right_lane.c2_curvature()) / 2.0;
 
-  double path_c3 = (left_lane.c3_curvature_derivative() + right_lane.c3_curvature_derivative())/2.0;
-
+  double path_c3 = (left_lane.c3_curvature_derivative() +
+                    right_lane.c3_curvature_derivative()) /
+                   2.0;
+  
   const double current_speed =
       vehicle_state_provider_->vehicle_state().linear_velocity();
   double path_range =

--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -199,6 +199,7 @@ void NaviPlanning::RunOnce(const LocalView& local_view,
       FLAGS_trajectory_stitching_preserved_length, true,
       last_publishable_trajectory_.get(), &replan_reason);
 
+  injector_->ego_info()->Update(stitching_trajectory.back(), vehicle_state);
   const uint32_t frame_num = static_cast<uint32_t>(seq_num_++);
   status = InitFrame(frame_num, stitching_trajectory.back(), vehicle_state);
 
@@ -212,8 +213,6 @@ void NaviPlanning::RunOnce(const LocalView& local_view,
     FillPlanningPb(start_timestamp, trajectory_pb);
     return;
   }
-
-  injector_->ego_info()->Update(stitching_trajectory.back(), vehicle_state);
 
   if (FLAGS_enable_record_debug) {
     frame_->RecordInputDebug(trajectory_pb->mutable_debug());


### PR DESCRIPTION
ego_info should be updated before initframe(). Because in initframe(), it will use ego_info->ego_box() to find collision obstacles. Otherwise it will get errors at first frame running.