### PR TITLE
config: fix error in modules\drivers\lidar\velodyne\launch and improve other launch

### DIFF
--- a/modules/calibration/data/dev_kit/perception_launch/dev_kit_perception_lidar.launch
+++ b/modules/calibration/data/dev_kit/perception_launch/dev_kit_perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_dev_kit_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/calibration/data/dev_kit_advanced_ne-b/perception_launch/dev_kit_perception_lidar.launch
+++ b/modules/calibration/data/dev_kit_advanced_ne-b/perception_launch/dev_kit_perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_dev_kit_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/calibration/data/dev_kit_advanced_ne-s/perception_launch/dev_kit_perception_lidar.launch
+++ b/modules/calibration/data/dev_kit_advanced_ne-s/perception_launch/dev_kit_perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_dev_kit_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/calibration/data/dev_kit_advanced_sne-r/perception_launch/dev_kit_perception_lidar.launch
+++ b/modules/calibration/data/dev_kit_advanced_sne-r/perception_launch/dev_kit_perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_dev_kit_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/calibration/data/dev_kit_standard/perception_launch/dev_kit_perception_lidar.launch
+++ b/modules/calibration/data/dev_kit_standard/perception_launch/dev_kit_perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_dev_kit_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/drivers/lidar/velodyne/launch/velodyne128.launch
+++ b/modules/drivers/lidar/velodyne/launch/velodyne128.launch
@@ -1,7 +1,7 @@
 <cyber>
     <module>
-        <name>gnss</name>
+        <name>velodyne128</name>
         <dag_conf>/apollo/modules/drivers/lidar/velodyne/dag/velodyne128.dag</dag_conf>
-        <process_name>gnss</process_name>
+        <process_name>velodyne</process_name>
     </module>
 </cyber>

--- a/modules/drivers/lidar/velodyne/launch/velodyne16.launch
+++ b/modules/drivers/lidar/velodyne/launch/velodyne16.launch
@@ -1,6 +1,6 @@
 <cyber>
     <module>
-        <name>gnss</name>
+        <name>velodyne16</name>
         <dag_conf>/apollo/modules/drivers/lidar/velodyne/dag/velodyne16.dag</dag_conf>
         <process_name>velodyne</process_name>
     </module>

--- a/modules/drivers/lidar/velodyne/launch/velodyne64_16.launch
+++ b/modules/drivers/lidar/velodyne/launch/velodyne64_16.launch
@@ -1,6 +1,6 @@
 <cyber>
     <module>
-        <name>velodyne</name>
+        <name>velodyne64</name>
         <dag_conf>/apollo/modules/drivers/lidar/velodyne/dag/velodyne_64_16.dag</dag_conf>
         <process_name>velodyne</process_name>
     </module>

--- a/modules/perception/production/launch/perception.launch
+++ b/modules/perception/production/launch/perception.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module>
     <module>

--- a/modules/perception/production/launch/perception_all.launch
+++ b/modules/perception/production/launch/perception_all.launch
@@ -15,7 +15,7 @@
         <version>1.0.0</version>
     </module>
     <module>
-        <name>perception_traffic_light</name>
+        <name>perception_trafficlights</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_trafficlights.dag</dag_conf>
         <!-- if not set, use default process -->
         <process_name>perception_trafficlights</process_name>

--- a/modules/perception/production/launch/perception_lidar.launch
+++ b/modules/perception/production/launch/perception_lidar.launch
@@ -9,10 +9,10 @@
          ./conf/dag_streaming_0.conf -->
 
     <module>
-        <name>perception</name>
+        <name>perception_lidar</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_lidar.dag</dag_conf>
         <!-- if not set, use default process -->
-        <process_name>lidar_perception</process_name>
+        <process_name>perception_lidar</process_name>
         <version>1.0.0</version>
     </module> 
 </cyber>

--- a/modules/perception/production/launch/perception_trafficlight.launch
+++ b/modules/perception/production/launch/perception_trafficlight.launch
@@ -11,7 +11,7 @@
          ./conf/dag_streaming.conf -->
 
     <module>
-        <name>perception_traffic_light</name>
+        <name>perception_trafficlights</name>
         <dag_conf>/apollo/modules/perception/production/dag/dag_streaming_perception_trafficlights.dag</dag_conf>
         <!-- if not set, use default process -->
         <process_name>perception_trafficlights</process_name>

--- a/modules/perception/production/launch/perception_trafficlight_viz.launch
+++ b/modules/perception/production/launch/perception_trafficlight_viz.launch
@@ -11,7 +11,7 @@
          ./conf/dag_streaming.conf -->
 
     <module>
-        <name>perception_traffic_light</name>
+        <name>perception_trafficlights</name>
         <dag_conf>dag_streaming_perception_trafficlights.dag</dag_conf>
         <!-- if not set, use default process -->
         <process_name>perception_trafficlights</process_name>


### PR DESCRIPTION
## fix error 
fix error  in `modules/drivers/lidar/velodyne/launch` 

## improve other launch
Uniform and standardized naming 
```
lidar_perception to perception_lidar
perception_traffic_light to perception_trafficlights
```