### PR TITLE
Docker: Change doxygen package version to find resource

### DIFF
--- a/docker/build/installers/install_doxygen.sh
+++ b/docker/build/installers/install_doxygen.sh
@@ -30,8 +30,7 @@ apt_get_update_and_install \
     graphviz
 
 # Build doxygen from source to reduce image size
-
-VERSION="1.8.19"
+VERSION="1.9.1"
 PKG_NAME="doxygen-${VERSION}.src.tar.gz"
 CHECKSUM="ac15d111615251ec53d3f0e54ac89c9d707538f488be57184245adef057778d3"
 DOWNLOAD_LINK="http://doxygen.nl/files/${PKG_NAME}"

--- a/docker/build/installers/install_doxygen.sh
+++ b/docker/build/installers/install_doxygen.sh
@@ -32,7 +32,7 @@ apt_get_update_and_install \
 # Build doxygen from source to reduce image size
 VERSION="1.9.1"
 PKG_NAME="doxygen-${VERSION}.src.tar.gz"
-CHECKSUM="da8a393b7f8b7442653475a0a4bc6eaa9ce60623440d14a82fef4e8d99da4b85"
+CHECKSUM="67aeae1be4e1565519898f46f1f7092f1973cce8a767e93101ee0111717091d1"
 DOWNLOAD_LINK="http://doxygen.nl/files/${PKG_NAME}"
 
 download_if_not_cached "${PKG_NAME}" "${CHECKSUM}" "${DOWNLOAD_LINK}"

--- a/docker/build/installers/install_doxygen.sh
+++ b/docker/build/installers/install_doxygen.sh
@@ -32,7 +32,7 @@ apt_get_update_and_install \
 # Build doxygen from source to reduce image size
 VERSION="1.9.1"
 PKG_NAME="doxygen-${VERSION}.src.tar.gz"
-CHECKSUM="ac15d111615251ec53d3f0e54ac89c9d707538f488be57184245adef057778d3"
+CHECKSUM="da8a393b7f8b7442653475a0a4bc6eaa9ce60623440d14a82fef4e8d99da4b85"
 DOWNLOAD_LINK="http://doxygen.nl/files/${PKG_NAME}"
 
 download_if_not_cached "${PKG_NAME}" "${CHECKSUM}" "${DOWNLOAD_LINK}"


### PR DESCRIPTION
When I try to install the doxygen package using the install_doxygen.sh script, an error occurs:

```bash
[INFO] Start to download doxygen-1.8.19.src.tar.gz from http://doxygen.nl/files/doxygen-1.8.19.src.tar.gz ...
--2021-02-04 09:59:13--  http://doxygen.nl/files/doxygen-1.8.19.src.tar.gz
Resolving doxygen.nl (doxygen.nl)... 195.5.163.171
Connecting to doxygen.nl (doxygen.nl)|195.5.163.171|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.doxygen.nl/files/doxygen-1.8.19.src.tar.gz [following]
--2021-02-04 09:59:13--  https://www.doxygen.nl/files/doxygen-1.8.19.src.tar.gz
Resolving www.doxygen.nl (www.doxygen.nl)... 195.5.163.171
Connecting to www.doxygen.nl (www.doxygen.nl)|195.5.163.171|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-02-04 09:59:16 ERROR 404: Not Found.
```

This is because a new version (1.9.1) has been released and the old one (1.8.19) is not available. Another way to fix the problem is to download version 1.8.19 from [SourceForge](https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.src.tar.gz/download):
```bash
...
VERSION="1.8.19"
PKG_NAME="doxygen-${VERSION}.src.tar.gz"
CHECKSUM="ac15d111615251ec53d3f0e54ac89c9d707538f488be57184245adef057778d3"
DOWNLOAD_LINK="https://sourceforge.net/projects/doxygen/files/rel-${VERSION}/${PKG_NAME}/download"
...
```