### PR TITLE
Docker: Fix errors when installing GPU-enabled OpenCV package

### DIFF
--- a/docker/build/installers/install_opencv.sh
+++ b/docker/build/installers/install_opencv.sh
@@ -31,7 +31,7 @@ if [ -z "${WORKHORSE}" ]; then
     WORKHORSE="cpu"
 fi
 
-# Note(all): It seems that opencv_contrib is not used in Apollo
+# Note(all): opencv_contrib is not required in cpu mode
 BUILD_CONTRIB="no"
 
 # 1) Install OpenCV via apt
@@ -68,14 +68,6 @@ DOWNLOAD_LINK="https://github.com/opencv/opencv/archive/${VERSION}.tar.gz"
 download_if_not_cached "${PKG_OCV}" "${CHECKSUM}" "${DOWNLOAD_LINK}"
 tar xzf ${PKG_OCV}
 
-if [ "${BUILD_CONTRIB}" = "yes" ]; then
-    PKG_CONTRIB="opencv_contrib-${VERSION}.tar.gz"
-    CHECKSUM="a69772f553b32427e09ffbfd0c8d5e5e47f7dab8b3ffc02851ffd7f912b76840"
-    DOWNLOAD_LINK="https://github.com/opencv/opencv_contrib/archive/${VERSION}.tar.gz"
-    download_if_not_cached "${PKG_CONTRIB}" "${CHECKSUM}" "${DOWNLOAD_LINK}"
-    tar xzf ${PKG_CONTRIB}
-fi
-
 # https://stackoverflow.com/questions/12427928/configure-and-build-opencv-to-custom-ffmpeg-install
 export LD_LIBRARY_PATH=${SYSROOT_DIR}/lib
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${SYSROOT_DIR}/lib/pkgconfig
@@ -88,10 +80,19 @@ GPU_OPTIONS=
 if [ "${WORKHORSE}" = "gpu" ]; then
     GPU_OPTIONS="-DWITH_CUDA=ON -DWITH_CUFFT=ON -DWITH_CUBLAS=ON -DWITH_CUDNN=ON"
     GPU_OPTIONS="${GPU_OPTIONS} -DCUDA_PROPAGATE_HOST_FLAGS=OFF"
-    GPU_OPTIONS="${GPU_OPTIONS} -DCUDA_ARCH_BIN=\"${SUPPORTED_NVIDIA_SMS}\""
+    GPU_OPTIONS="${GPU_OPTIONS} -DCUDA_ARCH_BIN=${SUPPORTED_NVIDIA_SMS// /,}"
     # GPU_OPTIONS="${GPU_OPTIONS} -DWITH_NVCUVID=ON"
+    BUILD_CONTRIB="yes"
 else
     GPU_OPTIONS="-DWITH_CUDA=OFF"
+fi
+
+if [ "${BUILD_CONTRIB}" = "yes" ]; then
+    PKG_CONTRIB="opencv_contrib-${VERSION}.tar.gz"
+    CHECKSUM="a69772f553b32427e09ffbfd0c8d5e5e47f7dab8b3ffc02851ffd7f912b76840"
+    DOWNLOAD_LINK="https://github.com/opencv/opencv_contrib/archive/${VERSION}.tar.gz"
+    download_if_not_cached "${PKG_CONTRIB}" "${CHECKSUM}" "${DOWNLOAD_LINK}"
+    tar xzf ${PKG_CONTRIB}
 fi
 
 TARGET_ARCH="$(uname -m)"
@@ -102,60 +103,59 @@ if [ "${TARGET_ARCH}" = "x86_64" ]; then
 fi
 
 if [ "${BUILD_CONTRIB}" = "yes" ]; then
-    EXTRA_OPTIONS="${EXTRA_OPTIONS} -DOPENCV_EXTRA_MODULES_PATH=\"../../opencv_contrib-${VERSION}/modules\""
+    EXTRA_OPTIONS="${EXTRA_OPTIONS} -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${VERSION}/modules"
+else 
+    EXTRA_OPTIONS="${EXTRA_OPTIONS} -DBUILD_opencv_world=OFF"
 fi
 
 # -DBUILD_LIST=core,highgui,improc
 pushd "opencv-${VERSION}"
-mkdir build && cd build
-cmake .. \
-    -DCMAKE_INSTALL_PREFIX="${SYSROOT_DIR}" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=ON \
-    -DENABLE_PRECOMPILED_HEADERS=OFF \
-    -DOPENCV_GENERATE_PKGCONFIG=ON \
-    -DBUILD_EXAMPLES=OFF \
-    -DBUILD_DOCS=OFF \
-    -DBUILD_TESTS=OFF \
-    -DBUILD_PERF_TESTS=OFF \
-    -DBUILD_JAVA=OFF \
-    -DBUILD_PROTOBUF=OFF \
-    -DPROTOBUF_UPDATE_FILES=ON \
-    -DINSTALL_C_EXAMPLES=OFF \
-    -DWITH_GTK=OFF \
-    -DWITH_IPP=OFF \
-    -DWITH_ITT=OFF \
-    -DWITH_TBB=OFF \
-    -DWITH_EIGEN=ON \
-    -DWITH_FFMPEG=ON \
-    -DWITH_LIBV4L=ON \
-    -DWITH_OPENMP=ON \
-    -DWITH_OPENNI=ON \
-    -DWITH_OPENCL=ON \
-    -DWITH_WEBP=ON \
-    -DOpenGL_GL_PREFERENCE=GLVND \
-    -DBUILD_opencv_python2=OFF \
-    -DBUILD_opencv_python3=ON \
-    -DBUILD_NEW_PYTHON_SUPPORT=ON \
-    -DPYTHON_DEFAULT_EXECUTABLE="$(which python3)" \
-    -DOPENCV_PYTHON3_INSTALL_PATH="/usr/local/lib/python$(py3_version)/dist-packages" \
-    -DOPENCV_ENABLE_NONFREE=ON \
-    -DCV_TRACE=OFF \
-    ${GPU_OPTIONS} \
-    ${EXTRA_OPTIONS}
-
-make -j$(nproc)
-make install
+    [[ ! -e build ]] && mkdir build 
+    pushd build
+        cmake .. \
+            -DCMAKE_INSTALL_PREFIX="${SYSROOT_DIR}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DENABLE_PRECOMPILED_HEADERS=OFF \
+            -DOPENCV_GENERATE_PKGCONFIG=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_DOCS=OFF \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_PERF_TESTS=OFF \
+            -DBUILD_JAVA=OFF \
+            -DBUILD_PROTOBUF=OFF \
+            -DPROTOBUF_UPDATE_FILES=ON \
+            -DINSTALL_C_EXAMPLES=OFF \
+            -DWITH_GTK=OFF \
+            -DWITH_IPP=OFF \
+            -DWITH_ITT=OFF \
+            -DWITH_TBB=OFF \
+            -DWITH_EIGEN=ON \
+            -DWITH_FFMPEG=ON \
+            -DWITH_LIBV4L=ON \
+            -DWITH_OPENMP=ON \
+            -DWITH_OPENNI=ON \
+            -DWITH_OPENCL=ON \
+            -DWITH_WEBP=ON \
+            -DOpenGL_GL_PREFERENCE=GLVND \
+            -DBUILD_opencv_python2=OFF \
+            -DBUILD_opencv_python3=ON \
+            -DBUILD_NEW_PYTHON_SUPPORT=ON \
+            -DPYTHON_DEFAULT_EXECUTABLE="$(which python3)" \
+            -DOPENCV_PYTHON3_INSTALL_PATH="/usr/local/lib/python$(py3_version)/dist-packages" \
+            -DOPENCV_ENABLE_NONFREE=ON \
+            -DCV_TRACE=OFF \
+            ${GPU_OPTIONS} \
+            ${EXTRA_OPTIONS}
+        make -j$(nproc)
+        make install
+    popd
 popd
 
 ldconfig
 ok "Successfully installed OpenCV ${VERSION}."
 
-rm -rf "${PKG_OCV}" "opencv-${VERSION}"
-
-if [ "${BUILD_CONTRIB}" = "yes" ]; then
-    rm -rf "${PKG_CONTRIB}" "opencv_contrib-${VERSION}"
-fi
+rm -rf opencv*
 
 if [[ -n "${CLEAN_DEPS}" ]]; then
     apt_get_remove \


### PR DESCRIPTION
The errors occurs when installing GPU enabled OpenCV package:
1. `# bash install_opencv.sh gpu`
```bash
...
/tmp/installers/opencv-4.4.0 /tmp/installers
CMake Error: The source directory "/tmp/installers/opencv-4.4.0/build/8.6"" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
```
2. `# bash install_opencv.sh gpu`
```bash
...
CMake Error at modules/core/CMakeLists.txt:40 (message):
  CUDA: OpenCV requires enabled 'cudev' module from 'opencv_contrib'
  repository: https://github.com/opencv/opencv_contrib
```