### PR TITLE
Docker: Fix typo into build_docker.sh

### DIFF
--- a/docker/build/build_docker.sh
+++ b/docker/build/build_docker.sh
@@ -186,7 +186,7 @@ function print_usage() {
     echo "${TAB}-h,--help   Show this message and exit"
     echo "E.g.,"
     echo "${TAB}${prog} -f cyber.x86_64.dockerfile -m build -g cn"
-    echo "${TAB}${prog} -f dev.aarch64.dockerfile -m download -b testing"
+    echo "${TAB}${prog} -f dev.aarch64.dockerfile -m download -d testing"
 }
 
 function check_opt_arg() {


### PR DESCRIPTION
There is no `-b `argument, but the example specifies it:
```bash
...
echo "${TAB}${prog} -f dev.aarch64.dockerfile -m download -b testing"
...
```
Must be fixed to` -d`