### PR TITLE
I think here should be an add instead of minus

### DIFF
--- a/modules/control/common/trajectory_analyzer.cc
+++ b/modules/control/common/trajectory_analyzer.cc
@@ -130,7 +130,7 @@ void TrajectoryAnalyzer::ToTrajectoryFrame(const double x, const double y,
 
   *ptr_d_dot = v * sin_delta_theta;
 
-  double one_minus_kappa_r_d = 1 - ref_point.kappa() * (*ptr_d);
+  double one_minus_kappa_r_d = 1 + ref_point.kappa() * (*ptr_d);
   if (one_minus_kappa_r_d <= 0.0) {
     AERROR << "TrajectoryAnalyzer::ToTrajectoryFrame "
               "found fatal reference and actual difference. "


### PR DESCRIPTION
I think here should use add. Because if we suppose that the vehicle should driving in clockwise，means the ref traj like a circle，and the real point of our car is outside the circle .Then if we use cross product of the (cos_ref_theta, sin_ref_theta) and (dx, dy) , the result is a positive num. But the fuction here want it to be a negative one, because that make the one_minus_kappa_r_d = R_real / R_ref， the R_real is bigger than R_ref