### PR TITLE
Scripts: re-enable buggy core pattern

### DIFF
--- a/scripts/docker_start_user.sh
+++ b/scripts/docker_start_user.sh
@@ -87,6 +87,14 @@ function setup_apollo_directories() {
   # chown -R "${uid}:${gid}" "${apollo_dir}"
 }
 
+# FIXME(infra): This will change core pattern on the host also,
+# where the `/apollo` directory may not exist.
+function setup_core_pattern() {
+  if [ -e /proc/sys/kernel ]; then
+    echo "/apollo/data/core/core_%e.%p" > /proc/sys/kernel/core_pattern
+  fi
+}
+
 ##===================== Main ==============================##
 function main() {
   local user_name="$1"
@@ -103,6 +111,7 @@ function main() {
   setup_user_account_if_not_exist "$@"
   setup_apollo_directories "${uid}" "${gid}"
   grant_device_permissions "${user_name}"
+  setup_core_pattern
 }
 
 main "${DOCKER_USER}" "${DOCKER_USER_ID}" "${DOCKER_GRP}" "${DOCKER_GRP_ID}"


### PR DESCRIPTION
The tricky part with setting core dump path under `/apollo` is as follows:

Changing core pattern inside Docker will change also that on the host. However, there may not exist a top level directory named `/apollo`.

Of course we can change core pattern to something like `/tmp/core/core_%e.%p`, which will be lost when Apollo container restarts.

What's your opinion? @zhoujie5517 @xiaoxq 