### PR TITLE
scripts: write core_pattern only when it's writable

### DIFF
--- a/scripts/docker_start_user.sh
+++ b/scripts/docker_start_user.sh
@@ -90,7 +90,7 @@ function setup_apollo_directories() {
 # FIXME(infra): This will change core pattern on the host also,
 # where the `/apollo` directory may not exist.
 function setup_core_pattern() {
-  if [ -e /proc/sys/kernel ]; then
+  if [[ -w /proc/sys/kernel/core_pattern ]]; then
     echo "/apollo/data/core/core_%e.%p" > /proc/sys/kernel/core_pattern
   fi
 }


### PR DESCRIPTION
Fix https://github.com/ApolloAuto/apollo/pull/13622

Without this, it seems to fail on host
```
 ---> Running in 427e7861043d
Adding group `apollo' (GID 1001) ...
Done.
Adding user `apollo' ...
Adding new user `apollo' (1001) with group `apollo' ...
Creating home directory `/home/apollo' ...
Copying files from `/etc/skel' ...
/apollo/scripts/docker_start_user.sh: line 96: /proc/sys/kernel/core_pattern: Read-only file system
The command '/bin/sh -c /apollo/scripts/docker_start_user.sh' returned a non-zero code: 1
```