### PR TITLE
control: delete redundant judgment conditions in set_gear_location

### DIFF
--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -359,7 +359,6 @@ Status LonController::ComputeControlCommand(
 
   if (std::fabs(injector_->vehicle_state()->linear_velocity()) <=
           vehicle_param_.max_abs_speed_when_stopped() ||
-      chassis->gear_location() == trajectory_message_->gear() ||
       chassis->gear_location() == canbus::Chassis::GEAR_NEUTRAL) {
     cmd->set_gear_location(trajectory_message_->gear());
   } else {

--- a/modules/control/controller/mpc_controller.cc
+++ b/modules/control/controller/mpc_controller.cc
@@ -515,7 +515,6 @@ Status MPCController::ComputeControlCommand(
 
   if (std::fabs(vehicle_state->linear_velocity()) <=
           vehicle_param_.max_abs_speed_when_stopped() ||
-      chassis->gear_location() == planning_published_trajectory->gear() ||
       chassis->gear_location() == canbus::Chassis::GEAR_NEUTRAL) {
     cmd->set_gear_location(planning_published_trajectory->gear());
   } else {


### PR DESCRIPTION
If `chassis->gear_location() == trajectory_message_->gear()` then we don't need to change the gear, so we can simplify the judgment condition