### PR TITLE
control: fix vehicle_state pitch error

### DIFF
--- a/modules/common/vehicle_state/vehicle_state_provider.cc
+++ b/modules/common/vehicle_state/vehicle_state_provider.cc
@@ -143,8 +143,8 @@ bool VehicleStateProvider::ConstructExceptLinearVelocity(
   }
 
   if (localization.pose().has_euler_angles()) {
-    vehicle_state_.set_roll(localization.pose().euler_angles().x());
-    vehicle_state_.set_pitch(localization.pose().euler_angles().y());
+    vehicle_state_.set_roll(localization.pose().euler_angles().y());
+    vehicle_state_.set_pitch(localization.pose().euler_angles().x());
     vehicle_state_.set_yaw(localization.pose().euler_angles().z());
   } else {
     math::EulerAnglesZXYd euler_angle(orientation.qw(), orientation.qx(),

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -255,14 +255,14 @@ Status LonController::ComputeControlCommand(
         speed_leadlag_controller_.InnerstateSaturationStatus());
   }
 
-  double slope_offset_compenstaion = digital_filter_pitch_angle_.Filter(
+  double slope_offset_compensation = digital_filter_pitch_angle_.Filter(
       GRA_ACC * std::sin(injector_->vehicle_state()->pitch()));
 
-  if (std::isnan(slope_offset_compenstaion)) {
-    slope_offset_compenstaion = 0;
+  if (std::isnan(slope_offset_compensation)) {
+    slope_offset_compensation = 0;
   }
 
-  debug->set_slope_offset_compensation(slope_offset_compenstaion);
+  debug->set_slope_offset_compensation(slope_offset_compensation);
 
   double acceleration_cmd =
       acceleration_cmd_closeloop + debug->preview_acceleration_reference() +


### PR DESCRIPTION
The vehicle coordinates of Apollo are as [link](https://github.com/ApolloAuto/apollo/blob/master/docs/specs/coordination_cn.md)

And you can find in localzation module
https://github.com/ApolloAuto/apollo/blob/770eba2024ceca51f6e771fe9caa6f42ad66eaa7/modules/localization/ndt/ndt_localization.cc#L287-L289
