### PR TITLE
avoid protobuf warning when using ParseFromString

### DIFF
--- a/cyber/proto/parameter.proto
+++ b/cyber/proto/parameter.proto
@@ -19,7 +19,7 @@ message Param {
     bool bool_value = 4;
     int64 int_value = 5;
     double double_value = 6;
-    string string_value = 7;
+    bytes string_value = 7;
   }
   optional bytes proto_desc = 8;
 }


### PR DESCRIPTION
If we use parameter module to get/set proto type msg. We should parse the proto msg using ParseFromString. If the proto message contains string element, it will cause error like below.

[libprotobuf ERROR external/com_google_protobuf/src/google/protobuf/wire_format_lite.cc:577] String field 'apollo.cyber.proto.Param.string_value' contains invalid UTF-8 data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.