### PR TITLE
perception: fix linking issue

### DIFF
--- a/modules/perception/inference/tensorrt/plugins/BUILD
+++ b/modules/perception/inference/tensorrt/plugins/BUILD
@@ -37,6 +37,7 @@ cuda_library(
         "nms_cuda.cu",
     ],
     hdrs = ["kernels.h"],
+    alwayslink = True,
     deps = [
         "//modules/perception/base:common",
         "@local_config_cuda//cuda:cudart",


### PR DESCRIPTION
This option was needed to build apollo simulator.
