### PR TITLE
Map: Limit projected s with max value of total length.

### DIFF
--- a/modules/dreamview/backend/map/map_service.cc
+++ b/modules/dreamview/backend/map/map_service.cc
@@ -450,6 +450,11 @@ bool MapService::ConstructLaneWayPointWithLaneId(
     return false;
   }
 
+  // Limit s with max value of the length of the lane, or not the laneWayPoint may be invalid.
+  if (s > lane->lane().length()) {
+    s = lane->lane().length();
+  }
+
   laneWayPoint->set_id(id);
   laneWayPoint->set_s(s);
   auto *pose = laneWayPoint->mutable_pose();


### PR DESCRIPTION
Fix #IDG-Apollo-4319
Limit the total length of LaneInfo as also as the projected s with the max value of total length.