### PR TITLE
Dreamview: Limit "s" of laneWayPoint.

### DIFF
--- a/modules/dreamview/backend/map/map_service.cc
+++ b/modules/dreamview/backend/map/map_service.cc
@@ -450,6 +450,11 @@ bool MapService::ConstructLaneWayPointWithLaneId(
     return false;
   }
 
+  // Limit s with max value of the length of the lane, or not the laneWayPoint may be invalid.
+  if (s > lane->lane().length()) {
+    s = lane->lane().length();
+  }
+
   laneWayPoint->set_id(id);
   laneWayPoint->set_s(s);
   auto *pose = laneWayPoint->mutable_pose();


### PR DESCRIPTION
Fix [IDG-Apollo-4319].
Limit "s" of laneWayPoint with max value of the length of the lane. If
laneWayPoint->s > lane.length(), the BinarySearchCheckValidSIndex will
fail and thus cause routing failed.