### PR TITLE
localization: cyber_record_parser add decompresses multiple files

### DIFF
--- a/modules/localization/msf/local_tool/data_extraction/cyber_record_parser.cc
+++ b/modules/localization/msf/local_tool/data_extraction/cyber_record_parser.cc
@@ -29,7 +29,7 @@ using apollo::localization::msf::PCDExporter;
 int main(int argc, char **argv) {
   boost::program_options::options_description boost_desc("Allowed options");
   boost_desc.add_options()("help", "produce help message")(
-      "bag_file", boost::program_options::value<std::string>(),
+      "bag_files", boost::program_options::value<std::vector<std::string>>(),
       "provide the bag file")("out_folder",
                               boost::program_options::value<std::string>(),
                               "provide the output folder")(
@@ -60,13 +60,14 @@ int main(int argc, char **argv) {
       boost_args);
   boost::program_options::notify(boost_args);
 
-  if (boost_args.count("help") || !boost_args.count("bag_file") ||
+  if (boost_args.count("help") || !boost_args.count("bag_files") ||
       !boost_args.count("out_folder")) {
     AERROR << boost_desc;
     return 0;
   }
 
-  const std::string bag_file = boost_args["bag_file"].as<std::string>();
+  const std::vector<std::string> bag_files =
+      boost_args["bag_files"].as<std::vector<std::string>>();
   const std::string pcd_folder =
       boost_args["out_folder"].as<std::string>() + "/pcd";
   if (!boost::filesystem::exists(pcd_folder)) {
@@ -108,7 +109,7 @@ int main(int argc, char **argv) {
     loc_exporter->OdometryLocCallback(msg);
   });
 
-  reader.Read(bag_file);
+  reader.Read(bag_files);
 
   return 0;
 }

--- a/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.cc
+++ b/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.cc
@@ -36,16 +36,20 @@ void CyberRecordReader::Subscribe(
   topics_.push_back(topic);
 }
 
+void CyberRecordReader::Read(const std::string &file_name) {
+  RecordReader reader(file_name);
+  cyber::record::RecordMessage message;
+  while (reader.ReadMessage(&message)) {
+    auto itr = call_back_map_.find(message.channel_name);
+    if (itr != call_back_map_.end()) {
+      itr->second(message.content);
+    }
+  }
+}
+
 void CyberRecordReader::Read(const std::vector<std::string> &file_names) {
   for (const std::string &file_name : file_names) {
-    RecordReader reader(file_name);
-    cyber::record::RecordMessage message;
-    while (reader.ReadMessage(&message)) {
-      auto itr = call_back_map_.find(message.channel_name);
-      if (itr != call_back_map_.end()) {
-        itr->second(message.content);
-      }
-    }
+    Read(file_name);
   }
 }
 

--- a/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.cc
+++ b/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.cc
@@ -36,13 +36,15 @@ void CyberRecordReader::Subscribe(
   topics_.push_back(topic);
 }
 
-void CyberRecordReader::Read(const std::string &file_name) {
-  RecordReader reader(file_name);
-  cyber::record::RecordMessage message;
-  while (reader.ReadMessage(&message)) {
-    auto itr = call_back_map_.find(message.channel_name);
-    if (itr != call_back_map_.end()) {
-      itr->second(message.content);
+void CyberRecordReader::Read(const std::vector<std::string> &file_names) {
+  for (const std::string &file_name : file_names) {
+    RecordReader reader(file_name);
+    cyber::record::RecordMessage message;
+    while (reader.ReadMessage(&message)) {
+      auto itr = call_back_map_.find(message.channel_name);
+      if (itr != call_back_map_.end()) {
+        itr->second(message.content);
+      }
     }
   }
 }

--- a/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.h
+++ b/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.h
@@ -36,6 +36,7 @@ class CyberRecordReader {
 
   void Subscribe(const std::string& topic,
                  const std::function<void(const std::string&)> call_back);
+  void Read(const std::string& file_name);
   void Read(const std::vector<std::string> &file_names);
 
  private:

--- a/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.h
+++ b/modules/localization/msf/local_tool/data_extraction/cyber_record_reader.h
@@ -36,7 +36,7 @@ class CyberRecordReader {
 
   void Subscribe(const std::string& topic,
                  const std::function<void(const std::string&)> call_back);
-  void Read(const std::string& file_name);
+  void Read(const std::vector<std::string> &file_names);
 
  private:
   std::vector<std::string> topics_;


### PR DESCRIPTION
cyber_record_parser can only decompress one file, add the function of decompressing multiple files.

## motivation
Because the recorded bag is cut according to 60s, if the recording time exceeds 60s, we need to decompress multiple files