### PR TITLE
Fix vehicle display bug and ignore safety check when using SimControl.

### DIFF
--- a/modules/dreamview/backend/map/map_service.cc
+++ b/modules/dreamview/backend/map/map_service.cc
@@ -450,7 +450,8 @@ bool MapService::ConstructLaneWayPointWithLaneId(
     return false;
   }
 
-  // Limit s with max value of the length of the lane, or not the laneWayPoint may be invalid.
+  // Limit s with max value of the length of the lane, or not the laneWayPoint
+  // may be invalid.
   if (s > lane->lane().length()) {
     s = lane->lane().length();
   }

--- a/modules/dreamview/frontend/src/store/hmi.js
+++ b/modules/dreamview/frontend/src/store/hmi.js
@@ -230,8 +230,8 @@ export default class HMI {
     this.vehicleParam = vehicleParam;
     RENDERER.adc.resizeCarScale(
       this.vehicleParam.length / this.defaultVehicleSize.length,
-      this.vehicleParam.width / this.defaultVehicleSize.width,
       this.vehicleParam.height / this.defaultVehicleSize.height,
+      this.vehicleParam.width / this.defaultVehicleSize.width,
     );
   }
 

--- a/modules/monitor/common/monitor_manager.cc
+++ b/modules/monitor/common/monitor_manager.cc
@@ -101,6 +101,11 @@ bool MonitorManager::CheckAutonomousDriving(const double current_time) {
     return false;
   }
 
+  // If SimControl is used, return false to ignore safety check.
+  if (chassis->header().module_name() == "SimControl") {
+    return false;
+  }
+
   // Ignore old messages which are likely from playback.
   const double msg_time = chassis->header().timestamp_sec();
   if (msg_time + FLAGS_system_status_lifetime_seconds < current_time) {


### PR DESCRIPTION
Dreamview: The size of vehicle doesn't display correctly.
Monitor: Ignore safety check when using SimControl.