### PR TITLE
Release Build: Installation ready for modules/common/vehicle_model

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@ install(
         "//modules/audio:install",
         "//modules/bridge:install",
         "//modules/canbus:install",
-        "//modules/common/data:install",
+        "//modules/common:install",
         "//modules/contrib/cyber_bridge:install",
         "//modules/control:install",
         "//modules/dreamview:install",

--- a/modules/common/BUILD
+++ b/modules/common/BUILD
@@ -1,0 +1,13 @@
+load("//tools/install:install.bzl", "install")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    deps = [
+        "//modules/common/data:install",
+        "//modules/common/vehicle_model:install",
+    ],
+)

--- a/modules/common/vehicle_model/BUILD
+++ b/modules/common/vehicle_model/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//tools/install:install.bzl", "install")
 load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
@@ -35,6 +36,18 @@ filegroup(
     srcs = glob([
         "testdata/*.txt",
     ]),
+)
+
+filegroup(
+    name = "vehicle_model_config_data",
+    srcs = ["conf/vehicle_model_config.pb.txt"],
+)
+
+install(
+    name = "install",
+    data = [
+        ":vehicle_model_config_data",
+    ],
 )
 
 cpplint()


### PR DESCRIPTION
* add another BUILD in modules/common
* install /apollo/modules/common/vehicle_model/conf/vehicle_model_config.pb.txt
  because without it, the Planning module fails to run in Release Build with:
```
  W0527 13:22:21.034180 169970 protobuf_factory.cc:218] [modules/perception/proto/traffic_light_detection.proto] A file with this name is already in the pool.
  E0527 13:22:32.143956 169769 on_lane_planning.cc:147] Failed to create reference line
  E0527 13:22:32.143985 169769 on_lane_planning.cc:313] PLANNING_ERROR: Failed to create reference line
  E0527 13:22:39.902437 169767 trajectory_stitcher.cc:208] the distance between matched point and actual position is too large. Replan is triggered. lon_diff = 2.7352
  E0527 13:22:39.902480 169767 file.cc:73] Failed to open file /apollo/modules/common/vehicle_model/conf/vehicle_model_config.pb.txt in text mode.
  E0527 13:22:39.902495 169767 file.cc:99] Failed to open file /apollo/modules/common/vehicle_model/conf/vehicle_model_config.pb.txt in binary mode.
  F0527 13:22:39.902501 169767 vehicle_model.cc:88] Check failed: cyber::common::GetProtoFromFile(FLAGS_vehicle_model_config_filename, &vehicle_model_config) Failed to load vehicle model config file /apollo/modules/common/vehicle_model/conf/vehicle_model_config.pb.txt
```

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>