### PR TITLE
Routing: Fix bug of vertical parking failure.

### DIFF
--- a/modules/map/hdmap/hdmap_common.cc
+++ b/modules/map/hdmap/hdmap_common.cc
@@ -192,14 +192,17 @@ void LaneInfo::GetWidth(const double s, double *left_width,
 }
 
 double LaneInfo::Heading(const double s) const {
-  const double kEpsilon = 0.001;
-  if (s + kEpsilon < accumulated_s_.front()) {
-    AERROR << "s:" << s << " should be >= " << accumulated_s_.front();
+  if (accumulated_s_.empty()) {
     return 0.0;
   }
+  const double kEpsilon = 0.001;
+  if (s + kEpsilon < accumulated_s_.front()) {
+    AWARN << "s:" << s << " should be >= " << accumulated_s_.front();
+    return headings_.front();
+  }
   if (s - kEpsilon > accumulated_s_.back()) {
-    AERROR << "s:" << s << " should be <= " << accumulated_s_.back();
-    return 0.0;
+    AWARN << "s:" << s << " should be <= " << accumulated_s_.back();
+    return headings_.back();
   }
 
   auto iter = std::lower_bound(accumulated_s_.begin(), accumulated_s_.end(), s);

--- a/modules/map/pnc_map/pnc_map.cc
+++ b/modules/map/pnc_map/pnc_map.cc
@@ -479,48 +479,29 @@ bool PncMap::GetRouteSegments(const VehicleState &vehicle_state,
 
 bool PncMap::GetNearestPointFromRouting(const VehicleState &state,
                                         LaneWaypoint *waypoint) const {
-  const double kMaxDistance = 10.0;  // meters.
-  const double kHeadingBuffer = M_PI / 10.0;
   waypoint->lane = nullptr;
   std::vector<LaneInfoConstPtr> lanes;
   const auto point = PointFactory::ToPointENU(state);
-  const int status =
-      hdmap_->GetLanesWithHeading(point, kMaxDistance, state.heading(),
-                                  M_PI / 2.0 + kHeadingBuffer, &lanes);
-  ADEBUG << "lanes:" << lanes.size();
-  if (status < 0) {
-    AERROR << "Failed to get lane from point: " << point.ShortDebugString();
-    return false;
-  }
-  if (lanes.empty()) {
-    AERROR << "No valid lane found within " << kMaxDistance
-           << " meters with heading " << state.heading();
-    return false;
-  }
   std::vector<LaneInfoConstPtr> valid_lanes;
-  std::copy_if(lanes.begin(), lanes.end(), std::back_inserter(valid_lanes),
-               [&](LaneInfoConstPtr ptr) {
-                 return range_lane_ids_.count(ptr->lane().id().id()) > 0;
-               });
-  if (valid_lanes.empty()) {
-    std::copy_if(lanes.begin(), lanes.end(), std::back_inserter(valid_lanes),
-                 [&](LaneInfoConstPtr ptr) {
-                   return all_lane_ids_.count(ptr->lane().id().id()) > 0;
-                 });
+  for (auto lane_id : all_lane_ids_) {
+    hdmap::Id id = hdmap::MakeMapId(lane_id);
+    auto lane = hdmap_->GetLaneById(id);
+    if (nullptr != lane) {
+      valid_lanes.emplace_back(lane);
+    }
   }
 
   // Get nearest_waypoints for current position
-  double min_distance = std::numeric_limits<double>::infinity();
+  std::vector<LaneWaypoint> valid_way_points;
   for (const auto &lane : valid_lanes) {
     if (range_lane_ids_.count(lane->id().id()) == 0) {
       continue;
     }
+    double s = 0.0;
+    double l = 0.0;
     {
-      double s = 0.0;
-      double l = 0.0;
       if (!lane->GetProjection({point.x(), point.y()}, &s, &l)) {
-        AERROR << "fail to get projection";
-        return false;
+        continue;
       }
       // Use large epsilon to allow projection diff
       static constexpr double kEpsilon = 0.5;
@@ -528,27 +509,61 @@ bool PncMap::GetNearestPointFromRouting(const VehicleState &state,
         continue;
       }
     }
-    double distance = 0.0;
-    common::PointENU map_point =
-        lane->GetNearestPoint({point.x(), point.y()}, &distance);
-    if (distance < min_distance) {
-      min_distance = distance;
-      double s = 0.0;
-      double l = 0.0;
-      if (!lane->GetProjection({map_point.x(), map_point.y()}, &s, &l)) {
-        AERROR << "Failed to get projection for map_point: "
-               << map_point.DebugString();
-        return false;
-      }
-      waypoint->lane = lane;
-      waypoint->s = s;
-    }
-    ADEBUG << "distance" << distance;
+
+    valid_way_points.emplace_back();
+    auto &last = valid_way_points.back();
+    last.lane = lane;
+    last.s = s;
+    last.l = l;
+    ADEBUG << "distance:" << std::fabs(l);
   }
-  if (waypoint->lane == nullptr) {
+  if (valid_way_points.empty()) {
     AERROR << "Failed to find nearest point: " << point.ShortDebugString();
+    return false;
   }
-  return waypoint->lane != nullptr;
+
+  // Choose the lane with the right heading if there is more than one candiate
+  // lanes. If there is no lane with the right heading, choose the closest one.
+  size_t closest_index = 0;
+  int right_heading_index = -1;
+  // The distance as the sum of the lateral and longitude distance, to estimate
+  // the distance from the vehicle to the lane.
+  double distance = std::numeric_limits<double>::max();
+  double lane_heading = 0.0;
+  double vehicle_heading = state.heading();
+  for (size_t i = 0; i < valid_way_points.size(); i++) {
+    double distance_to_lane = std::fabs(valid_way_points[i].l);
+    if (valid_way_points[i].s > valid_way_points[i].lane->total_length()) {
+      distance_to_lane +=
+          (valid_way_points[i].s - valid_way_points[i].lane->total_length());
+    } else if (valid_way_points[i].s < 0.0) {
+      distance_to_lane -= valid_way_points[i].s;
+    }
+    if (distance > distance_to_lane) {
+      distance = distance_to_lane;
+      closest_index = i;
+    }
+    lane_heading = valid_way_points[i].lane->Heading(valid_way_points[i].s);
+    if (common::math::NormalizeAngle(lane_heading - vehicle_heading) < M_PI_2) {
+      // Choose the lane with the closest distance to the vehicle and with the
+      // right heading.
+      if (-1 == right_heading_index || closest_index == i) {
+        waypoint->lane = valid_way_points[i].lane;
+        waypoint->s = valid_way_points[i].s;
+        waypoint->l = valid_way_points[i].l;
+        right_heading_index = i;
+      }
+    }
+  }
+  // Use the lane with the closest distance to the current position of the
+  // vehicle.
+  if (-1 == right_heading_index) {
+    waypoint->lane = valid_way_points[closest_index].lane;
+    waypoint->s = valid_way_points[closest_index].s;
+    waypoint->l = valid_way_points[closest_index].l;
+    AWARN << "Find no lane with the right heading, use the cloesest lane!";
+  }
+  return true;
 }
 
 LaneInfoConstPtr PncMap::GetRouteSuccessor(LaneInfoConstPtr lane) const {

--- a/modules/planning/on_lane_planning.cc
+++ b/modules/planning/on_lane_planning.cc
@@ -139,6 +139,16 @@ Status OnLanePlanning::InitFrame(const uint32_t sequence_num,
     return Status(ErrorCode::PLANNING_ERROR, "Fail to init frame: nullptr.");
   }
 
+  // Get the parking space information from routing request of local view.
+  auto& routing_request = local_view_.routing->routing_request();
+  if (routing_request.has_parking_info() &&
+      routing_request.parking_info().has_parking_space_id()) {
+    *(frame_->mutable_open_space_info()->mutable_target_parking_spot_id()) =
+        routing_request.parking_info().parking_space_id();
+  } else {
+    ADEBUG << "No parking space id from routing";
+  }
+
   std::list<ReferenceLine> reference_lines;
   std::list<hdmap::RouteSegments> segments;
   if (!reference_line_provider_->GetReferenceLines(&reference_lines,

--- a/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.cc
+++ b/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.cc
@@ -1216,10 +1216,7 @@ bool OpenSpaceRoiDecider::GetParkingSpot(Frame *const frame,
     return false;
   }
 
-  auto point = common::util::PointFactory::ToPointENU(vehicle_state_);
   LaneInfoConstPtr nearest_lane;
-  double vehicle_lane_s = 0.0;
-  double vehicle_lane_l = 0.0;
   // Check if last frame lane is available
   const auto &ptr_last_frame = injector_->frame_history()->Latest();
 
@@ -1230,18 +1227,83 @@ bool OpenSpaceRoiDecider::GetParkingSpot(Frame *const frame,
   }
 
   const auto &previous_open_space_info = ptr_last_frame->open_space_info();
+  const auto &parking_spot_id_string =
+      frame->open_space_info().target_parking_spot_id();
   if (previous_open_space_info.target_parking_lane() != nullptr &&
       previous_open_space_info.target_parking_spot_id() ==
-          frame->open_space_info().target_parking_spot_id()) {
+          parking_spot_id_string) {
     nearest_lane = previous_open_space_info.target_parking_lane();
   } else {
-    int status = HDMapUtil::BaseMap().GetNearestLaneWithHeading(
-        point, 10.0, vehicle_state_.heading(), M_PI / 2.0, &nearest_lane,
-        &vehicle_lane_s, &vehicle_lane_l);
-    if (status != 0) {
-      AERROR
-          << "Getlane failed at OpenSpaceRoiDecider::GetParkingSpotFromMap()";
+    hdmap::Id parking_spot_id = hdmap::MakeMapId(parking_spot_id_string);
+    auto parking_spot = hdmap_->GetParkingSpaceById(parking_spot_id);
+    if (nullptr == parking_spot) {
+      AERROR << "The parking spot id is invalid!";
       return false;
+    }
+    auto parking_space = parking_spot->parking_space();
+    auto overlap_ids = parking_space.overlap_id();
+    if (overlap_ids.empty()) {
+      AERROR << "There is no lane overlaps with the parking spot: "
+             << parking_spot_id_string;
+      return false;
+    }
+    std::vector<routing::LaneSegment> lane_segments;
+    GetAllLaneSegments(*(frame->local_view().routing), lane_segments);
+    bool has_found_nearest_lane = false;
+    size_t nearest_lane_index = 0;
+    for (auto id : overlap_ids) {
+      auto overlaps = hdmap_->GetOverlapById(id)->overlap();
+      for (auto object : overlaps.object()) {
+        if (!object.has_lane_overlap_info()) {
+          continue;
+        }
+        nearest_lane = hdmap_->GetLaneById(object.id());
+        if (nearest_lane == nullptr) {
+          continue;
+        }
+        // Check if the lane is contained in the routing response.
+        for (auto &segment : lane_segments) {
+          if (segment.id() == nearest_lane->id().id()) {
+            has_found_nearest_lane = true;
+            break;
+          }
+          ++nearest_lane_index;
+        }
+        if (has_found_nearest_lane) {
+          break;
+        }
+      }
+    }
+    if (!has_found_nearest_lane) {
+      AERROR << "Cannot find the lane nearest to the parking spot when "
+                "GetParkingSpot!";
+    }
+
+    // Get the lane nearest to the current position of the vehicle. If the
+    // vehicle has not reached the nearest lane to the parking spot, set the
+    // lane nearest to the vehicle as "nearest_lane".
+    LaneInfoConstPtr nearest_lane_to_vehicle;
+    auto point = common::util::PointFactory::ToPointENU(vehicle_state_);
+    double vehicle_lane_s = 0.0;
+    double vehicle_lane_l = 0.0;
+    int status = hdmap_->GetNearestLaneWithHeading(
+        point, 10.0, vehicle_state_.heading(), M_PI / 2.0,
+        &nearest_lane_to_vehicle, &vehicle_lane_s, &vehicle_lane_l);
+    if (status == 0) {
+      size_t nearest_lane_to_vehicle_index = 0;
+      bool has_found_nearest_lane_to_vehicle = false;
+      for (auto &segment : lane_segments) {
+        if (segment.id() == nearest_lane_to_vehicle->id().id()) {
+          has_found_nearest_lane_to_vehicle = true;
+          break;
+        }
+        ++nearest_lane_to_vehicle_index;
+      }
+      // The vehicle has not reached the nearest lane to the parking spot。
+      if (has_found_nearest_lane_to_vehicle &&
+          nearest_lane_to_vehicle_index < nearest_lane_index) {
+        nearest_lane = nearest_lane_to_vehicle;
+      }
     }
   }
   frame->mutable_open_space_info()->set_target_parking_lane(nearest_lane);
@@ -1752,6 +1814,19 @@ void OpenSpaceRoiDecider::GetParkSpotFromMap(
   Vec2d tmp = (*vertices)[0];
   ADEBUG << "Parking Lot";
   ADEBUG << "parking_lot_vertices: (" << tmp.x() << ", " << tmp.y() << ")";
+}
+
+void OpenSpaceRoiDecider::GetAllLaneSegments(
+    const routing::RoutingResponse &routing_response,
+    std::vector<routing::LaneSegment> &routing_segments) {
+  routing_segments.clear();
+  for (const auto &road : routing_response.road()) {
+    for (const auto &passage : road.passage()) {
+      for (const auto &segment : passage.segment()) {
+        routing_segments.emplace_back(segment);
+      }
+    }
+  }
 }
 
 }  // namespace planning

--- a/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.h
+++ b/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.h
@@ -197,6 +197,15 @@ class OpenSpaceRoiDecider : public Decider {
   void GetParkSpotFromMap(hdmap::ParkingSpaceInfoConstPtr parking_lot,
                           std::array<common::math::Vec2d, 4> *vertices);
 
+  /**
+   * @brief Collect all the lane segments in the routing reponse.
+   *
+   * @param routing_response The routing response containing the lane segments.
+   * @param routing_segments The output vector of lane segments.
+   */
+  void GetAllLaneSegments(const routing::RoutingResponse &routing_response,
+                          std::vector<routing::LaneSegment> &routing_segments);
+
  private:
   // @brief parking_spot_id from routing
   std::string target_parking_spot_id_;

--- a/modules/routing/routing.cc
+++ b/modules/routing/routing.cc
@@ -14,12 +14,13 @@
  * limitations under the License.
  *****************************************************************************/
 
+#include "modules/routing/routing.h"
+
 #include <limits>
 #include <unordered_map>
 
-#include "modules/routing/routing.h"
-
 #include "modules/common/util/point_factory.h"
+#include "modules/map/hdmap/hdmap_common.h"
 #include "modules/routing/common/routing_gflags.h"
 
 namespace apollo {
@@ -166,6 +167,151 @@ bool Routing::FillParkingID(RoutingResponse* routing_response) {
   return false;
 }
 
+bool Routing::SupplementParkingRequest(
+    RoutingResponse* const routing_response) const {
+  const auto& routing_request = routing_response->routing_request();
+  const bool has_parking_info = routing_request.has_parking_info();
+  if (!has_parking_info) {
+    return true;
+  }
+
+  // 1. Get the nearest lane along the parking spot, called "parking spot
+  // lane". Calculate the center point of the parking spot, to find out the
+  // lane with which the parking spot overlaps.
+  const auto& points = routing_request.parking_info().corner_point();
+  double headings[4];
+  const common::PointENU* corner_points[4];
+  for (size_t i = 0; i < 4; i++) {
+    corner_points[i] = &(points.point().at(i));
+  }
+  headings[0] = std::atan2(corner_points[1]->y() - corner_points[0]->y(),
+                           corner_points[1]->x() - corner_points[0]->x());
+  headings[1] = std::atan2(corner_points[2]->y() - corner_points[1]->y(),
+                           corner_points[2]->x() - corner_points[1]->x());
+  headings[2] = headings[0] + M_PI;
+  headings[3] = headings[1] + M_PI;
+  // The distance range when searching the lanes along the parking spot.
+  static const double kMaxHeadingDistance = M_PI_4;
+  double distance_search_range = 5.0;
+  double nearest_s;
+  double nearest_l = std::numeric_limits<double>::max();
+  hdmap::LaneInfoConstPtr nearest_lane;
+  bool has_found_nearest_lane = false;
+  // Get all the object overlap with the parking spot.
+  std::vector<std::string> overlap_object_ids;
+  const auto parking_space_id =
+      hdmap::MakeMapId(routing_request.parking_info().parking_space_id());
+  GetAllOverlapObjectIds(parking_space_id, overlap_object_ids);
+  for (size_t i = 0; i < 4; i++) {
+    double temp_nearest_s;
+    double temp_nearest_l;
+    hdmap::LaneInfoConstPtr temp_nearest_lane;
+    common::PointENU temp_point = common::util::PointFactory::ToPointENU(
+        corner_points[i]->x(), corner_points[i]->y());
+    // Find the nearest lane with the current heading.
+    if (0 != hdmap_->GetNearestLaneWithHeading(
+                 temp_point, distance_search_range, headings[i],
+                 kMaxHeadingDistance, &temp_nearest_lane, &temp_nearest_s,
+                 &temp_nearest_l) ||
+        0 == std::count(overlap_object_ids.begin(), overlap_object_ids.end(),
+                        temp_nearest_lane->id().id())) {
+      // Find the nearest lane with the opposite heading on the same segment.
+      size_t next_index = i + 1;
+      if (next_index > 3) {
+        next_index = 0;
+      }
+      temp_point = common::util::PointFactory::ToPointENU(
+          corner_points[next_index]->x(), corner_points[next_index]->y());
+      if (0 != hdmap_->GetNearestLaneWithHeading(
+                   temp_point, distance_search_range, headings[i] - M_PI,
+                   kMaxHeadingDistance, &temp_nearest_lane, &temp_nearest_s,
+                   &temp_nearest_l) ||
+          0 == std::count(overlap_object_ids.begin(), overlap_object_ids.end(),
+                          temp_nearest_lane->id().id())) {
+        continue;
+      }
+    }
+    if (std::fabs(nearest_l) > std::fabs(temp_nearest_l)) {
+      nearest_l = temp_nearest_l;
+      nearest_lane = temp_nearest_lane;
+      nearest_s = temp_nearest_s;
+      if (distance_search_range > std::fabs(temp_nearest_l)) {
+        distance_search_range = std::fabs(temp_nearest_l);
+      }
+      has_found_nearest_lane = true;
+    }
+  }
+  if (!has_found_nearest_lane) {
+    AWARN << "Supplement Parking Request but no nearest lane found!";
+    return true;
+  }
+
+  // 2. If the RoadSegments of the routing_response contain the "parking spot
+  // lane", make sure the distance range of the segment contains the border
+  // of the parking spot
+  for (auto& road : *(routing_response->mutable_road())) {
+    for (auto& passage_region : *(road.mutable_passage())) {
+      for (auto& segment : *(passage_region.mutable_segment())) {
+        if (segment.id() == nearest_lane->id().id()) {
+          // Make sure the segment range contain the all the corner points of
+          // the parking spot.
+          if (segment.start_s() > nearest_s) {
+            segment.set_start_s(nearest_s);
+          }
+          return true;
+        }
+      }
+    }
+  }
+
+  // 3. In case the RoadSegments of the routing_response don't contain the
+  // "parking spot lane", set it as the start point of the routing request
+  // and do the rerouting.
+  auto waypoints =
+      routing_response->mutable_routing_request()->mutable_waypoint();
+  // Add the point to the beginning of the waypoints list.
+  waypoints->Add();
+  for (size_t i = waypoints->size() - 1; i > 0; --i) {
+    waypoints->SwapElements(i, i - 1);
+  }
+  auto first_way_point = waypoints->Mutable(0);
+  first_way_point->set_id(nearest_lane->id().id());
+  first_way_point->set_s(nearest_s);
+  common::PointENU point = nearest_lane->GetSmoothPoint(nearest_s);
+  auto* pose = first_way_point->mutable_pose();
+  pose->set_x(point.x());
+  pose->set_y(point.y());
+
+  RoutingResponse routing_response_temp;
+  if (navigator_ptr_->SearchRoute(routing_response->routing_request(),
+                                  &routing_response_temp)) {
+    routing_response->CopyFrom(routing_response_temp);
+    return true;
+  }
+  return false;
+}
+
+void Routing::GetAllOverlapObjectIds(
+    const hdmap::Id& parking_spot_id,
+    std::vector<std::string>& object_ids) const {
+  object_ids.clear();
+  auto parking_spot_info = hdmap_->GetParkingSpaceById(parking_spot_id);
+  if (nullptr == parking_spot_info) {
+    return;
+  }
+  auto overlap_ids = parking_spot_info->parking_space().overlap_id();
+  for (auto& id : overlap_ids) {
+    auto overlap_info = hdmap_->GetOverlapById(id);
+    if (nullptr == overlap_info) {
+      continue;
+    }
+    auto overlap = overlap_info->overlap();
+    for (auto object : overlap.object()) {
+      object_ids.emplace_back(object.id().id());
+    }
+  }
+}
+
 bool Routing::Process(const std::shared_ptr<RoutingRequest>& routing_request,
                       RoutingResponse* const routing_response) {
   CHECK_NOTNULL(routing_response);
@@ -185,7 +331,8 @@ bool Routing::Process(const std::shared_ptr<RoutingRequest>& routing_request,
     }
     FillParkingID(routing_response);
   }
-  if (min_routing_length < std::numeric_limits<double>::max()) {
+  if (min_routing_length < std::numeric_limits<double>::max() &&
+      SupplementParkingRequest(routing_response)) {
     monitor_logger_buffer_.INFO("Routing success!");
     return true;
   }

--- a/modules/routing/routing.h
+++ b/modules/routing/routing.h
@@ -68,6 +68,23 @@ class Routing {
 
   bool FillParkingID(RoutingResponse *routing_response);
 
+  /**
+   * @brief Add the lane nearest to the parking spot if it is not contained in
+   *  the routing response.
+   * @param routing_response The routing response to be modified.
+   * @return Return true if no error occurs; return false otherwise.
+   */
+  bool SupplementParkingRequest(RoutingResponse *const routing_response) const;
+
+  /**
+   * @brief Get all the objects that overlap with the parking spot.
+   * @param parking_spot_id The id of the parking spot.
+   * @param lane_ids The id list of all the objects overlap with the parking
+   * spot.
+   */
+  void GetAllOverlapObjectIds(const hdmap::Id &parking_spot_id,
+                              std::vector<std::string> &lane_ids) const;
+
  private:
   std::unique_ptr<Navigator> navigator_ptr_;
   common::monitor::MonitorLogBuffer monitor_logger_buffer_;


### PR DESCRIPTION
Fix $[IDG-Apollo-4346].
When the vehicle is in front of the parking spot, and on the lane next
to the nearest lane to the parking spot, the parking action will fail
because of the following error:
Failed to extract segments from routing.
and the relative error of pnc map like:
Failed to find nearest point: x: 437868.09950172278 y: 4433040.1114324955 z: 0

Cause:
The lane segments of the routing response don't contain the lane nearest
to the parking spot because the vehicle is in front of the parking spot.
When the vehicle approach to the parking spot, no project point can be
found on the routing segments and thus CreateReferenceLine failed.

Solution:
1. Add SupplementParkingRequest function. When the routing segements
doesn't contain the lane nearest to the parking spot, add it into the
sgement list.
2. Modify the way of searching the parking spot according to the vehicle
state as well as the way of searching the nearest lane to the
vehicle(GetNearestPointFromRouting).