### PR TITLE
chore: Add MODULE_NAME definitions in BUILD file.

### DIFF
--- a/modules/canbus/common/BUILD
+++ b/modules/canbus/common/BUILD
@@ -3,11 +3,13 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "canbus_common",
     srcs = ["canbus_gflags.cc"],
     hdrs = ["canbus_gflags.h"],
-    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    copts = CANBUS_COPTS,
     deps = [
         "@com_github_gflags_gflags//:gflags",
     ],

--- a/modules/canbus/vehicle/ch/BUILD
+++ b/modules/canbus/vehicle/ch/BUILD
@@ -3,10 +3,13 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "ch_vehicle_factory",
     srcs = ["ch_vehicle_factory.cc"],
     hdrs = ["ch_vehicle_factory.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":ch_controller",
         ":ch_message_manager",
@@ -18,6 +21,7 @@ cc_library(
     name = "ch_message_manager",
     srcs = ["ch_message_manager.cc"],
     hdrs = ["ch_message_manager.h"],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/ch/protocol:canbus_ch_protocol",
@@ -30,6 +34,7 @@ cc_library(
     name = "ch_controller",
     srcs = ["ch_controller.cc"],
     hdrs = ["ch_controller.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":ch_message_manager",
         "//modules/canbus/proto:canbus_conf_cc_proto",

--- a/modules/canbus/vehicle/devkit/BUILD
+++ b/modules/canbus/vehicle/devkit/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "devkit_vehicle_factory",
     srcs = [
@@ -11,6 +13,7 @@ cc_library(
     hdrs = [
         "devkit_vehicle_factory.h",
     ],
+    copts = CANBUS_COPTS,
     deps = [
         ":devkit_controller",
         ":devkit_message_manager",
@@ -32,6 +35,7 @@ cc_library(
     name = "devkit_message_manager",
     srcs = ["devkit_message_manager.cc"],
     hdrs = ["devkit_message_manager.h"],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/devkit/protocol:canbus_devkit_protocol",
@@ -54,6 +58,7 @@ cc_library(
     name = "devkit_controller",
     srcs = ["devkit_controller.cc"],
     hdrs = ["devkit_controller.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":devkit_message_manager",
         "//modules/canbus/common:canbus_common",

--- a/modules/canbus/vehicle/ge3/BUILD
+++ b/modules/canbus/vehicle/ge3/BUILD
@@ -3,10 +3,13 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "ge3_vehicle_factory",
     srcs = ["ge3_vehicle_factory.cc"],
     hdrs = ["ge3_vehicle_factory.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":ge3_controller",
         ":ge3_message_manager",
@@ -29,6 +32,7 @@ cc_library(
     name = "ge3_message_manager",
     srcs = ["ge3_message_manager.cc"],
     hdrs = ["ge3_message_manager.h"],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/ge3/protocol:canbus_ge3_protocol_pc_bcm_201",
@@ -51,6 +55,7 @@ cc_library(
     name = "ge3_controller",
     srcs = ["ge3_controller.cc"],
     hdrs = ["ge3_controller.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":ge3_message_manager",
         "//modules/canbus/proto:chassis_detail_cc_proto",

--- a/modules/canbus/vehicle/gem/protocol/BUILD
+++ b/modules/canbus/vehicle/gem/protocol/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "canbus_gem_protocol",
     srcs = [
@@ -69,7 +71,7 @@ cc_library(
         "wiper_rpt_91.h",
         "yaw_rate_rpt_81.h",
     ],
-    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/drivers/canbus/can_comm:message_manager_base",

--- a/modules/canbus/vehicle/lexus/protocol/BUILD
+++ b/modules/canbus/vehicle/lexus/protocol/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "canbus_lexus_protocol",
     srcs = glob([
@@ -11,7 +13,7 @@ cc_library(
     hdrs = glob([
         "*.h",
     ]),
-    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/drivers/canbus/can_comm:message_manager_base",

--- a/modules/canbus/vehicle/lincoln/protocol/BUILD
+++ b/modules/canbus/vehicle/lincoln/protocol/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "canbus_lincoln_protocol",
     srcs = [
@@ -55,7 +57,7 @@ cc_library(
         "version_7f.h",
         "wheelspeed_6a.h",
     ],
-    copts = ["-DMODULE_NAME=\\\"canbus\\\""],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/drivers/canbus/can_comm:message_manager_base",

--- a/modules/canbus/vehicle/neolix_edu/BUILD
+++ b/modules/canbus/vehicle/neolix_edu/BUILD
@@ -3,6 +3,8 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "neolix_edu_vehicle_factory",
     srcs = [
@@ -11,6 +13,7 @@ cc_library(
     hdrs = [
         "neolix_edu_vehicle_factory.h",
     ],
+    copts = CANBUS_COPTS,
     deps = [
         ":neolix_edu_controller",
         ":neolix_edu_message_manager",
@@ -26,6 +29,7 @@ cc_library(
     hdrs = [
         "neolix_edu_message_manager.h",
     ],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/neolix_edu/protocol:canbus_neolix_edu_protocol",
@@ -42,6 +46,7 @@ cc_library(
     hdrs = [
         "neolix_edu_controller.h",
     ],
+    copts = CANBUS_COPTS,
     deps = [
         ":neolix_edu_message_manager",
         "//modules/canbus/proto:chassis_detail_cc_proto",

--- a/modules/canbus/vehicle/wey/BUILD
+++ b/modules/canbus/vehicle/wey/BUILD
@@ -3,10 +3,13 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "wey_vehicle_factory",
     srcs = ["wey_vehicle_factory.cc"],
     hdrs = ["wey_vehicle_factory.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":wey_controller",
         ":wey_message_manager",
@@ -28,6 +31,7 @@ cc_library(
     name = "wey_message_manager",
     srcs = ["wey_message_manager.cc"],
     hdrs = ["wey_message_manager.h"],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/wey/protocol:canbus_wey_protocol",
@@ -50,6 +54,7 @@ cc_library(
     name = "wey_controller",
     srcs = ["wey_controller.cc"],
     hdrs = ["wey_controller.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":wey_message_manager",
         "//modules/canbus/proto:canbus_conf_cc_proto",

--- a/modules/canbus/vehicle/zhongyun/BUILD
+++ b/modules/canbus/vehicle/zhongyun/BUILD
@@ -3,10 +3,13 @@ load("//tools:cpplint.bzl", "cpplint")
 
 package(default_visibility = ["//visibility:public"])
 
+CANBUS_COPTS = ["-DMODULE_NAME=\\\"canbus\\\""]
+
 cc_library(
     name = "zhongyun_vehicle_factory",
     srcs = ["zhongyun_vehicle_factory.cc"],
     hdrs = ["zhongyun_vehicle_factory.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":zhongyun_controller",
         ":zhongyun_message_manager",
@@ -18,6 +21,7 @@ cc_library(
     name = "zhongyun_message_manager",
     srcs = ["zhongyun_message_manager.cc"],
     hdrs = ["zhongyun_message_manager.h"],
+    copts = CANBUS_COPTS,
     deps = [
         "//modules/canbus/proto:chassis_detail_cc_proto",
         "//modules/canbus/vehicle/zhongyun/protocol:canbus_zhongyun_protocol",
@@ -30,6 +34,7 @@ cc_library(
     name = "zhongyun_controller",
     srcs = ["zhongyun_controller.cc"],
     hdrs = ["zhongyun_controller.h"],
+    copts = CANBUS_COPTS,
     deps = [
         ":zhongyun_message_manager",
         "//modules/canbus/proto:chassis_detail_cc_proto",

--- a/modules/planning/BUILD
+++ b/modules/planning/BUILD
@@ -41,6 +41,7 @@ cc_library(
     hdrs = ["planning_base.h"],
     copts = [
         "-fopenmp",
+        "-DMODULE_NAME=\\\"planning\\\""
     ],
     deps = [
         "//cyber",
@@ -76,6 +77,7 @@ cc_library(
     hdrs = ["navi_planning.h"],
     copts = [
         "-fopenmp",
+        "-DMODULE_NAME=\\\"planning\\\""
     ],
     deps = [
         ":planning_base",
@@ -88,6 +90,7 @@ cc_library(
     hdrs = ["on_lane_planning.h"],
     copts = [
         "-fopenmp",
+        "-DMODULE_NAME=\\\"planning\\\""
     ],
     deps = [
         ":planning_base",


### PR DESCRIPTION
Add MODULE_NAME definitions so that the relative log can be written in the log of the module instead of mainboard.