### PR TITLE
Planning: Planning failed when routing succeeded.

### DIFF
--- a/modules/planning/on_lane_planning.cc
+++ b/modules/planning/on_lane_planning.cc
@@ -262,6 +262,8 @@ void OnLanePlanning::RunOnce(const LocalView& local_view,
     vehicle_state = AlignTimeStamp(vehicle_state, start_timestamp);
   }
 
+  // Update reference line provider and reset pull over if necessary
+  reference_line_provider_->UpdateVehicleState(vehicle_state);
   if (util::IsDifferentRouting(last_routing_, *local_view_.routing)) {
     last_routing_ = *local_view_.routing;
     ADEBUG << "last_routing_:" << last_routing_.ShortDebugString();
@@ -288,9 +290,6 @@ void OnLanePlanning::RunOnce(const LocalView& local_view,
     GenerateStopTrajectory(ptr_trajectory_pb);
     return;
   }
-
-  // Update reference line provider and reset pull over if necessary
-  reference_line_provider_->UpdateVehicleState(vehicle_state);
 
   // planning is triggered by prediction data, but we can still use an estimated
   // cycle time for stitching

--- a/modules/planning/reference_line/reference_line_provider.cc
+++ b/modules/planning/reference_line/reference_line_provider.cc
@@ -207,6 +207,7 @@ void ReferenceLineProvider::GenerateThread() {
     const double end_time = Clock::NowInSeconds();
     std::lock_guard<std::mutex> lock(reference_lines_mutex_);
     last_calculation_time_ = end_time - start_time;
+    is_reference_line_updated_ = true;
   }
 }
 


### PR DESCRIPTION
Fix [IDG-Apollo-4289].
Sometimes routing succeeds but no planning trajectory shows up and the
vehicle won't move. In the planning.log output error like the following:
Failed to find nearest point: ***
Rebooting the planning module will resolve this problem.

Cause:
The function reference_line_provider_->UpdateVehicleState will be nerver
invoked once the ReferenceLineProvider::CreateRouteSegments failed
caused by the wrong vehicle state(Usually the vehicle state is not
updated yet by the SimControl for the sequential factor). And this will
make the failure of ReferenceLineProvider::CreateRouteSegments into an
endless loop. Only rebooting the planning module can resolve this
problem.

Solution:
Change the order of invoking
reference_line_provider_->UpdateVehicleState to remove the endless loop.