### PR TITLE
[bridge]解决了接收多个帧时无法将数据发布给相应的话题

### DIFF
--- a/modules/bridge/common/bridge_proto_diserialized_buf.h
+++ b/modules/bridge/common/bridge_proto_diserialized_buf.h
@@ -137,6 +137,8 @@ template <typename T>
 bool BridgeProtoDiserializedBuf<T>::Initialize(const BridgeHeader &header) {
   total_size_ = header.GetMsgSize();
   total_frames_ = header.GetTotalFrames();
+  proto_name_ = header.GetMsgName();
+  sequence_num_ = header.GetMsgID();
   if (total_frames_ == 0) {
     return false;
   }


### PR DESCRIPTION
当我使用Apollo的bridge模块测试数据的接收与发送时，发现了一个问题：当客户端发送单帧数据时，服务端可以顺利解析并发布到相关的话题，但是当protobuf数据过大，需要客户端将protobuf数据分为多帧进行发送时，服务端却无法将接收数据并发送至相关话题。
经过排查，发现`BridgeProtoDiserializedBuf`的数据成员`sequence_num_`和`proto_name_`没有进行初始化，导致`BridgeProtoDiserializedBuf<T>::IsTheProto`函数无法判断该帧属于哪个protobuf数据，因此需要在`BridgeProtoDiserializedBuf<T>::Initialize`当中对其进行初始化，这样就可以接收多帧的数据并将其发送至相关话题。