### PR TITLE
Planning: Add scale_factor of turning radius.

### DIFF
--- a/modules/common/configs/proto/vehicle_config.proto
+++ b/modules/common/configs/proto/vehicle_config.proto
@@ -81,22 +81,24 @@ message VehicleParam {
   optional double steer_ratio = 16 [default = nan];
   // the distance between the front and back wheels
   optional double wheel_base = 17 [default = nan];
+  // the scale factor of minimum radius for turning for parking trajectory planning
+  optional double turning_radius_scale_factor = 18 [default = 1.0];
   // Tire effective rolling radius (vertical distance between the wheel center
   // and the ground).
-  optional double wheel_rolling_radius = 18 [default = nan];
+  optional double wheel_rolling_radius = 19 [default = nan];
 
   // minimum differentiable vehicle speed, in m/s
-  optional float max_abs_speed_when_stopped = 19 [default = nan];
+  optional float max_abs_speed_when_stopped = 20 [default = nan];
 
   // minimum value get from chassis.brake, in percentage
-  optional double brake_deadzone = 20 [default = nan];
+  optional double brake_deadzone = 21 [default = nan];
   // minimum value get from chassis.throttle, in percentage
-  optional double throttle_deadzone = 21 [default = nan];
+  optional double throttle_deadzone = 22 [default = nan];
 
   // vehicle latency parameters
-  optional LatencyParam steering_latency_param = 22;
-  optional LatencyParam throttle_latency_param = 23;
-  optional LatencyParam brake_latency_param = 24;
+  optional LatencyParam steering_latency_param = 23;
+  optional LatencyParam throttle_latency_param = 24;
+  optional LatencyParam brake_latency_param = 25;
 }
 
 message VehicleConfig {

--- a/modules/planning/open_space/coarse_trajectory_generator/reeds_shepp_path.cc
+++ b/modules/planning/open_space/coarse_trajectory_generator/reeds_shepp_path.cc
@@ -29,7 +29,8 @@ ReedShepp::ReedShepp(const common::VehicleParam& vehicle_param,
       planner_open_space_config_(open_space_conf) {
   max_kappa_ = std::tan(vehicle_param_.max_steer_angle() /
                         vehicle_param_.steer_ratio()) /
-               vehicle_param_.wheel_base();
+               (vehicle_param_.wheel_base() *
+                vehicle_param_.turning_radius_scale_factor());
   AINFO_IF(FLAGS_enable_parallel_hybrid_a) << "parallel REEDShepp";
 }
 


### PR DESCRIPTION
Fix [IDG-Apollo-4350].
The vehicle cannot parking in the spot sometimes and the lateral error
is too big(about the width of the parking spot).

Cause:
The lateral error of the control is too big before the vehicle reverses
into the parking spot. And the radius of the planning trajectory is
exactly the minimum turning radius of the vehicle. The vehicle cannot
reach the end point even the steering ratio set to 100%.

Solution:
Limit the minimum value of the turning radius when planning the arc
trajectory for parking by divide it with the scale factor of the turning
radius.