### PR TITLE
Control:add set station PID and reset integral

### DIFF
--- a/modules/control/common/pid_controller.cc
+++ b/modules/control/common/pid_controller.cc
@@ -58,6 +58,11 @@ double PIDController::Control(const double error, const double dt) {
   return output;
 }
 
+void PIDController::Reset_integral() {
+  integral_ = 0.0;
+  integrator_saturation_status_ = 0;
+}
+
 void PIDController::Reset() {
   previous_error_ = 0.0;
   previous_output_ = 0.0;

--- a/modules/control/common/pid_controller.h
+++ b/modules/control/common/pid_controller.h
@@ -54,6 +54,11 @@ class PIDController {
    * @brief reset variables for pid controller
    */
   void Reset();
+  
+  /**
+   * @brief reset integral for pid controller
+   */
+  void Reset_integral();
 
   /**
    * @brief compute control value based on the error

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -218,8 +218,10 @@ Status LonController::ComputeControlCommand(
     }
   } else if (injector_->vehicle_state()->linear_velocity() <=
              lon_controller_conf.switch_speed()) {
+    station_pid_controller_.SetPID(lon_controller_conf.station_pid_conf());
     speed_pid_controller_.SetPID(lon_controller_conf.low_speed_pid_conf());
   } else {
+    station_pid_controller_.SetPID(lon_controller_conf.station_pid_conf());
     speed_pid_controller_.SetPID(lon_controller_conf.high_speed_pid_conf());
   }
 

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -257,6 +257,12 @@ Status LonController::ComputeControlCommand(
         speed_leadlag_controller_.InnerstateSaturationStatus());
   }
 
+  if(chassis->gear_location() == canbus::Chassis::GEAR_NEUTRAL)
+  {
+    speed_pid_controller_.Reset_integral();
+    station_pid_controller_.Reset_integral();
+  }
+  
   double slope_offset_compenstaion = digital_filter_pitch_angle_.Filter(
       GRA_ACC * std::sin(injector_->vehicle_state()->pitch()));
 
@@ -290,6 +296,8 @@ Status LonController::ComputeControlCommand(
                        lon_controller_conf.standstill_acceleration());
     ADEBUG << "Stop location reached";
     debug->set_is_full_stop(true);
+    speed_pid_controller_.Reset_integral();
+    station_pid_controller_.Reset_integral();
   }
 
   double throttle_lowerbound =


### PR DESCRIPTION
Control: Reset integral when GEAR_NEUTRAL or full_stop.

Fix [IDG-Apollo-4329].
Move too fast after shifting or when entering self-driving.

Cause:
After shifting or entering autonomous driving, no integral zeroing
is carried out, resulting in excessive initial control when re-entering control

Solution:
Reset integral when GEAR_NEUTRAL or full_stop.

Control: Reset the Station PID after switching from reverse to forward.

Fix [IDG-Apollo-4330].
The Station PID parameter is reset in reverse gear, but the Station PID
is not reset after switching from reverse to forward, only the Speed PID
parameter is reset

Solution:
Reset the Station PID after switching from reverse to forward