### PR TITLE
Dreamview: Remove heading check of end point.

### DIFF
--- a/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
+++ b/modules/dreamview/backend/simulation_world/simulation_world_updater.cc
@@ -529,7 +529,7 @@ bool SimulationWorldUpdater::ConstructRoutingRequest(
     AERROR << "Failed to prepare a routing request: invalid end point.";
     return false;
   }
-  if (ContainsKey(end, "id") && !ContainsKey(end, "heading")) {
+  if (ContainsKey(end, "id")) {
     if (!map_service_->ConstructLaneWayPointWithLaneId(
             end["x"], end["y"], end["id"], routing_request->add_waypoint())) {
       AERROR << "Failed to prepare a routing request with lane id: "


### PR DESCRIPTION
Dreamview: Remove heading check of end point.
    
The heading of the end point is added by mistake in previous commit.
It should be reverted because the id of the end point will be calculated
for parking action and it is unnecessary to check the heading in this
case.
