### PR TITLE
control:add ADCTrajectory SPEED_FALLBACK when full_stop.

### DIFF
--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -280,8 +280,10 @@ Status LonController::ComputeControlCommand(
 
   // At near-stop stage, replace the brake control command with the standstill
   // acceleration if the former is even softer than the latter
-  if ((trajectory_message_->trajectory_type() ==
-       apollo::planning::ADCTrajectory::NORMAL) &&
+  if (((trajectory_message_->trajectory_type() ==
+       apollo::planning::ADCTrajectory::NORMAL)||
+       (trajectory_message_->trajectory_type() ==
+       apollo::planning::ADCTrajectory::SPEED_FALLBACK)) &&
       ((std::fabs(debug->preview_acceleration_reference()) <=
             control_conf_->max_acceleration_when_stopped() &&
         std::fabs(debug->preview_speed_reference()) <=


### PR DESCRIPTION
Control:Reset the Station PID after switching from reverse to forward
    
Fix [IDG-Apollo-4330].
The Station PID parameter is reset in reverse gear, but the Station PID
is not reset after switching from reverse to forward, only the Speed PID
parameter is reset

Solution:
Reset the Station PID after switching from reverse to forward