### PR TITLE
Improve control performance and compensate imu translation for localization.

### DIFF
--- a/modules/control/common/pid_controller.cc
+++ b/modules/control/common/pid_controller.cc
@@ -58,6 +58,11 @@ double PIDController::Control(const double error, const double dt) {
   return output;
 }
 
+void PIDController::Reset_integral() {
+  integral_ = 0.0;
+  integrator_saturation_status_ = 0;
+}
+
 void PIDController::Reset() {
   previous_error_ = 0.0;
   previous_output_ = 0.0;

--- a/modules/control/common/pid_controller.h
+++ b/modules/control/common/pid_controller.h
@@ -54,6 +54,11 @@ class PIDController {
    * @brief reset variables for pid controller
    */
   void Reset();
+  
+  /**
+   * @brief reset integral for pid controller
+   */
+  void Reset_integral();
 
   /**
    * @brief compute control value based on the error

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -218,8 +218,10 @@ Status LonController::ComputeControlCommand(
     }
   } else if (injector_->vehicle_state()->linear_velocity() <=
              lon_controller_conf.switch_speed()) {
+    station_pid_controller_.SetPID(lon_controller_conf.station_pid_conf());
     speed_pid_controller_.SetPID(lon_controller_conf.low_speed_pid_conf());
   } else {
+    station_pid_controller_.SetPID(lon_controller_conf.station_pid_conf());
     speed_pid_controller_.SetPID(lon_controller_conf.high_speed_pid_conf());
   }
 

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -280,8 +280,10 @@ Status LonController::ComputeControlCommand(
 
   // At near-stop stage, replace the brake control command with the standstill
   // acceleration if the former is even softer than the latter
-  if ((trajectory_message_->trajectory_type() ==
-       apollo::planning::ADCTrajectory::NORMAL) &&
+  if (((trajectory_message_->trajectory_type() ==
+       apollo::planning::ADCTrajectory::NORMAL)||
+       (trajectory_message_->trajectory_type() ==
+       apollo::planning::ADCTrajectory::SPEED_FALLBACK)) &&
       ((std::fabs(debug->preview_acceleration_reference()) <=
             control_conf_->max_acceleration_when_stopped() &&
         std::fabs(debug->preview_speed_reference()) <=

--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -257,6 +257,12 @@ Status LonController::ComputeControlCommand(
         speed_leadlag_controller_.InnerstateSaturationStatus());
   }
 
+  if(chassis->gear_location() == canbus::Chassis::GEAR_NEUTRAL)
+  {
+    speed_pid_controller_.Reset_integral();
+    station_pid_controller_.Reset_integral();
+  }
+  
   double slope_offset_compenstaion = digital_filter_pitch_angle_.Filter(
       GRA_ACC * std::sin(injector_->vehicle_state()->pitch()));
 
@@ -290,6 +296,8 @@ Status LonController::ComputeControlCommand(
                        lon_controller_conf.standstill_acceleration());
     ADEBUG << "Stop location reached";
     debug->set_is_full_stop(true);
+    speed_pid_controller_.Reset_integral();
+    station_pid_controller_.Reset_integral();
   }
 
   double throttle_lowerbound =

--- a/modules/localization/msf/msf_localization.cc
+++ b/modules/localization/msf/msf_localization.cc
@@ -18,13 +18,14 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include "modules/drivers/gnss/proto/config.pb.h"
+
 #include "cyber/common/file.h"
 #include "cyber/time/clock.h"
 #include "modules/common/configs/config_gflags.h"
 #include "modules/common/math/euler_angles_zxy.h"
 #include "modules/common/math/math_utils.h"
 #include "modules/common/math/quaternion.h"
-#include "modules/drivers/gnss/proto/config.pb.h"
 #include "modules/localization/common/localization_gflags.h"
 #include "modules/localization/msf/msf_localization_component.h"
 
@@ -94,6 +95,9 @@ void MSFLocalization::InitParams() {
   imu_vehicle_quat_.y() = FLAGS_imu_vehicle_qy;
   imu_vehicle_quat_.z() = FLAGS_imu_vehicle_qz;
   imu_vehicle_quat_.w() = FLAGS_imu_vehicle_qw;
+  imu_vehicle_translation_[0] = 0.0;
+  imu_vehicle_translation_[1] = 0.0;
+  imu_vehicle_translation_[2] = 0.0;
   // try to load imu vehicle quat from file
   if (FLAGS_if_vehicle_imu_from_file) {
     double qx = 0.0;
@@ -102,7 +106,8 @@ void MSFLocalization::InitParams() {
     double qw = 0.0;
 
     AINFO << "Vehile imu file: " << FLAGS_vehicle_imu_file;
-    if (LoadImuVehicleExtrinsic(FLAGS_vehicle_imu_file, &qx, &qy, &qz, &qw)) {
+    if (LoadImuVehicleExtrinsic(FLAGS_vehicle_imu_file, &qx, &qy, &qz, &qw,
+                                imu_vehicle_translation_)) {
       imu_vehicle_quat_.x() = qx;
       imu_vehicle_quat_.y() = qy;
       imu_vehicle_quat_.z() = qz;
@@ -344,6 +349,14 @@ void MSFLocalization::CompensateImuVehicleExtrinsic(
   eulerangles->set_x(euler_angle.pitch());
   eulerangles->set_y(euler_angle.roll());
   eulerangles->set_z(euler_angle.yaw());
+
+  // Compensate the translation between imu and vehicle center.
+  apollo::common::PointENU *position = posepb_loc->mutable_position();
+  Eigen::Vector3d compensated_position =
+      quat_vehicle_world.toRotationMatrix() * imu_vehicle_translation_;
+  position->set_x(position->x() + compensated_position[0]);
+  position->set_y(position->y() + compensated_position[1]);
+  position->set_z(position->z() + compensated_position[2]);
 }
 
 bool MSFLocalization::LoadGnssAntennaExtrinsic(
@@ -373,22 +386,31 @@ bool MSFLocalization::LoadGnssAntennaExtrinsic(
 
 bool MSFLocalization::LoadImuVehicleExtrinsic(const std::string &file_path,
                                               double *quat_qx, double *quat_qy,
-                                              double *quat_qz,
-                                              double *quat_qw) {
+                                              double *quat_qz, double *quat_qw,
+                                              Eigen::Vector3d &translation) {
+  for (size_t i = 0; i < 3; ++i) {
+    translation[i] = 0.0;
+  }
   if (!cyber::common::PathExists(file_path)) {
     return false;
   }
   YAML::Node config = YAML::LoadFile(file_path);
   if (config["transform"]) {
-    if (config["transform"]["translation"]) {
-      if (config["transform"]["rotation"]) {
+    if (config["transform"]["rotation"]) {
         *quat_qx = config["transform"]["rotation"]["x"].as<double>();
         *quat_qy = config["transform"]["rotation"]["y"].as<double>();
         *quat_qz = config["transform"]["rotation"]["z"].as<double>();
         *quat_qw = config["transform"]["rotation"]["w"].as<double>();
+      }
+      else {
+        return false;
+      }
+      if (config["transform"]["translation"]) {
+        translation[0] = config["transform"]["translation"]["x"].as<double>();
+        translation[1] = config["transform"]["translation"]["y"].as<double>();
+        translation[2] = config["transform"]["translation"]["z"].as<double>();
         return true;
       }
-    }
   }
   return false;
 }

--- a/modules/localization/msf/msf_localization.h
+++ b/modules/localization/msf/msf_localization.h
@@ -86,7 +86,7 @@ class MSFLocalization {
                                 double *uncertainty_z);
   bool LoadImuVehicleExtrinsic(const std::string &file_path, double *quat_qx,
                                double *quat_qy, double *quat_qz,
-                               double *quat_qw);
+                               double *quat_qw, Eigen::Vector3d &translation);
   bool LoadZoneIdFromFolder(const std::string &folder_path, int *zone_id);
   void CompensateImuVehicleExtrinsic(LocalizationEstimate *local_result);
 
@@ -101,6 +101,7 @@ class MSFLocalization {
 
   // rotation from the vehicle coord to imu coord
   Eigen::Quaternion<double> imu_vehicle_quat_;
+  Eigen::Vector3d imu_vehicle_translation_;
 
   std::shared_ptr<LocalizationMsgPublisher> publisher_;
   std::shared_ptr<drivers::gnss::Imu> raw_imu_msg_;


### PR DESCRIPTION
Control: add ADCTrajectory SPEED_FALLBACK when full_stop.
Control: Reset integral when GEAR_NEUTRAL or full_stop. 
Control:Reset the Station PID after switching from reverse to forward.
Localization: Compensate the translation between imu and center.