### PR TITLE
Routing: Routing module receives wrong RoutingRequest history.

### DIFF
--- a/modules/dreamview/backend/simulation_world/simulation_world_service.cc
+++ b/modules/dreamview/backend/simulation_world/simulation_world_service.cc
@@ -327,9 +327,9 @@ void SimulationWorldService::InitWriters() {
     // reliable transfer
     qos->set_reliability(
         apollo::cyber::proto::QosReliabilityPolicy::RELIABILITY_RELIABLE);
-    // when writer find new readers, send all its history messsage
+    // Don't send the history message when new readers are found.
     qos->set_durability(
-        apollo::cyber::proto::QosDurabilityPolicy::DURABILITY_TRANSIENT_LOCAL);
+        apollo::cyber::proto::QosDurabilityPolicy::DURABILITY_SYSTEM_DEFAULT);
     routing_request_writer_ =
         node_->CreateWriter<RoutingRequest>(routing_request_attr);
   }

--- a/modules/task_manager/task_manager_component.cc
+++ b/modules/task_manager/task_manager_component.cc
@@ -60,8 +60,9 @@ bool TaskManagerComponent::Init() {
   qos->set_history(apollo::cyber::proto::QosHistoryPolicy::HISTORY_KEEP_LAST);
   qos->set_reliability(
       apollo::cyber::proto::QosReliabilityPolicy::RELIABILITY_RELIABLE);
+  // Don't send the history message when new readers are found.
   qos->set_durability(
-      apollo::cyber::proto::QosDurabilityPolicy::DURABILITY_TRANSIENT_LOCAL);
+      apollo::cyber::proto::QosDurabilityPolicy::DURABILITY_SYSTEM_DEFAULT);
   request_writer_ = node_->CreateWriter<RoutingRequest>(attr);
   return true;
 }


### PR DESCRIPTION
Fix: [IDG-Apollo-4349].
The routing module receives wrong RoutingRequest history when do the
following steps:
1. Send a normal RoutingRequest along the road from a start to end
point, wait util the planning finishes.
2. Send a ParkingRoutingRequest and shutdown the planning and routing
module, make sure the routing segment of the parking routing doesn't
coincide with that of the first normal RoutingRequest.
3. Reboot the planning and routing module.
The planning module will do the planning without click the button of
"Send Routing Request" but fail. Because the routing module will receive
2 RoutingRequest at this time. The first is the ParkingRoutingRequest
and the second is the normal RoutingRequest.

Cause:
The normal RoutingRequest and ParkingRoutingRequest are sent seperately
with 2 Writers: RoutingRequest writer and Task writer. Both their
attributes is set as HISTORY_KEEP_LAST and DURABILITY_TRANSIENT_LOCAL.
Thus when the routing module is reboot, both the writers will send the
last topic to the routing module.

Solution:
Set the atrributes of the 2 writer as DURABILITY_SYSTEM_DEFAULT to
forbidden the resending of the topic from history.