### PR TITLE
Drivers:fix  a potential null pointer problem

### DIFF
--- a/modules/drivers/lidar/lidar_driver_component.cc
+++ b/modules/drivers/lidar/lidar_driver_component.cc
@@ -31,7 +31,7 @@ bool LidarDriverComponent::Init() {
   AINFO << "conf:" << conf_.DebugString();
   LidarDriverFactory::Instance()->RegisterLidarClients();
   driver_ = LidarDriverFactory::Instance()->CreateLidarDriver(node_, conf_);
-  if (!driver_->Init()) {
+  if (driver_ == nullptr || !driver_->Init()) {
     AERROR << "driver init error";
     return false;
   }


### PR DESCRIPTION
`LidarDriverFactory::Instance()->CreateLidarDriver` may return  nullptr. 

```
std::unique_ptr<LidarDriver> LidarDriverFactory::CreateLidarDriver(
    const std::shared_ptr<::apollo::cyber::Node>& node,
    const apollo::drivers::lidar::config& parameter) {
  auto factory = CreateObject(parameter.brand(), node, parameter);
  if (!factory) {
    AERROR << "Failed to create lidar with parameter: "
           << parameter.DebugString();
  }
  return factory;
}
```