### PR TITLE
[canbus]修复canbus_test.cc的一个bug

### DIFF
--- a/modules/canbus/tools/canbus_tester.cc
+++ b/modules/canbus/tools/canbus_tester.cc
@@ -32,7 +32,6 @@ using apollo::cyber::Reader;
 using apollo::cyber::Writer;
 
 int main(int32_t argc, char **argv) {
-  google::InitGoogleLogging(argv[0]);
   google::ParseCommandLineFlags(&argc, &argv, true);
   FLAGS_alsologtostderr = true;
 


### PR DESCRIPTION
When using the `canbus_tester.sh` script, I found an error at run time：
```bash
F0709 10:40:12.055003  7701 utilities.cc:346] Check failed: !IsGoogleLoggingInitialized() You called InitGoogleLogging() twice!
*** Check failure stack trace: ***
scripts/canbus_tester.sh: line 24:  7701 Aborted                 (core dumped) ./bazel-bin/modules/canbus/tools/canbus_tester --canbus_test_file=modules/canbus/testdata/canbus_test.pb.txt
```
In the `modules/canbus/tools/canbus_tester. cc `file, I found the function of`Google: : InitGoogleLogging `called twice, once in line 35, once in the `apollo: : cyber: : Init`.
When the first call is deleted, the program runs normally.
