### PR TITLE
[tools]The record_extractor.py script was not built

### DIFF
--- a/modules/tools/navigator/BUILD
+++ b/modules/tools/navigator/BUILD
@@ -11,3 +11,12 @@ py_binary(
     name = "viewer_smooth",
     srcs = ["viewer_smooth.py"],
 )
+
+py_binary(
+    name = "record_extractor",
+    srcs = ["record_extractor.py"],
+    deps = [
+        "//cyber/python/cyber_py3:record",
+        "//modules/localization/proto:localization_py_pb2",
+    ],
+)


### PR DESCRIPTION
In Apollo 6.0 and master, Python scripts was managed by Bazel.
However, The `record_extractor.py` script was not built by Bazel.
So in the `modules/tools/navigator/BUILD` files,  the building rule of  `record_extractor. py` script should be added