### PR TITLE
Fix: The relative map can not be created. (#13937)

### DIFF
--- a/modules/planning/reference_line/spiral_smoother_util.cc
+++ b/modules/planning/reference_line/spiral_smoother_util.cc
@@ -145,7 +145,7 @@ class SpiralSmootherUtil {
       ofs << std::fixed << "{\"kappa\": " << point.kappa()
           << ", \"s\": " << point.s() << ", \"theta\": " << point.theta()
           << ", \"x\":" << point.x() << ", \"y\":" << point.y()
-          << ", \"dkappa\":" << point.dkappa() << "}";
+          << ", \"dkappa\":" << point.dkappa() << "}" << '\n';
     }
     ofs.close();
     AINFO << "Smoothed result saved to " << filename;


### PR DESCRIPTION
This problem is due to the format of smoothed data in `xxxx.record.txt.smoothed` file. As we can see,the `xxxx.record.txt.smoothed` file generated from the `smooth.sh` script has only one line, which causes the data in JSON format cannot be parsed by the `navigator.sh` script.
The solution is to insert "\n" in the right place.