### PR TITLE
Bazel: unified --repository_cache for bazel sync

### DIFF
--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -207,7 +207,7 @@ def setup_common_dirs(environ_cp):
 
     write_to_bazelrc('startup --output_user_root="{}/bazel"'.format(cache_dir))
     write_to_bazelrc('common --distdir="{}"'.format(dist_dir))
-    write_to_bazelrc('build --repository_cache="{}/repos"'.format(cache_dir))
+    write_to_bazelrc('common --repository_cache="{}/repos"'.format(cache_dir))
     write_to_bazelrc('build --disk_cache="{}/build"'.format(cache_dir))
     write_to_bazelrc('')
 


### PR DESCRIPTION
If we specify `--repository_cache` for the `build` command rather than
a `common` option, commands like `bazel sync` will not respect the
settings there.

Ref:
https://docs.bazel.build/versions/main/guide.html#option-defaults