### PR TITLE
Planning:fix a bug in PathBoundsDecider

### DIFF
--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -578,8 +578,8 @@ int PathBoundsDecider::IsPointWithinPathBound(
   }else{
     ADEBUG << "The idx_after = " << idx_after;
     ADEBUG << "The boundary is: "
-          << "[" << std::get<1>(path_bound[idx_after]) << ", "
-          << std::get<2>(path_bound[idx_after]) << "].";
+           << "[" << std::get<1>(path_bound[idx_after]) << ", "
+           << std::get<2>(path_bound[idx_after]) << "].";
     ADEBUG << "The point is at: " << point_sl.l();
     int idx_before = idx_after - 1;
     if (std::get<1>(path_bound[idx_before]) <= point_sl.l() &&

--- a/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
+++ b/modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc
@@ -572,17 +572,22 @@ int PathBoundsDecider::IsPointWithinPathBound(
          std::get<0>(path_bound[idx_after]) < point_sl.s()) {
     ++idx_after;
   }
-  ADEBUG << "The idx_after = " << idx_after;
-  ADEBUG << "The boundary is: "
-         << "[" << std::get<1>(path_bound[idx_after]) << ", "
-         << std::get<2>(path_bound[idx_after]) << "].";
-  ADEBUG << "The point is at: " << point_sl.l();
-  int idx_before = idx_after - 1;
-  if (std::get<1>(path_bound[idx_before]) <= point_sl.l() &&
-      std::get<2>(path_bound[idx_before]) >= point_sl.l() &&
-      std::get<1>(path_bound[idx_after]) <= point_sl.l() &&
-      std::get<2>(path_bound[idx_after]) >= point_sl.l()) {
+  if (idx_after == 0)
+  {
     return idx_after;
+  }else{
+    ADEBUG << "The idx_after = " << idx_after;
+    ADEBUG << "The boundary is: "
+          << "[" << std::get<1>(path_bound[idx_after]) << ", "
+          << std::get<2>(path_bound[idx_after]) << "].";
+    ADEBUG << "The point is at: " << point_sl.l();
+    int idx_before = idx_after - 1;
+    if (std::get<1>(path_bound[idx_before]) <= point_sl.l() &&
+        std::get<2>(path_bound[idx_before]) >= point_sl.l() &&
+        std::get<1>(path_bound[idx_after]) <= point_sl.l() &&
+        std::get<2>(path_bound[idx_after]) >= point_sl.l()) {
+      return idx_after;
+    }
   }
   ADEBUG << "Laterally outside the boundary.";
   return -1;


### PR DESCRIPTION
According to the following code pieces in `PathBoundsDecider::IsPointWithinPathBound`(modules/planning/tasks/deciders/path_bounds_decider/path_bounds_decider.cc), the valid range of `point_sl.s()` is [`std::get<0>(path_bound.front()) - kPathBoundsDeciderResolution * 2`, `std::get<0>(path_bound.back())`].

```
  if (point_sl.s() > std::get<0>(path_bound.back()) ||
      point_sl.s() <
          std::get<0>(path_bound.front()) - kPathBoundsDeciderResolution * 2) {
    ADEBUG << "Longitudinally outside the boundary;
    return -1;
  }
```

Since `point_sl.s()` may be smaller than std::get<0>(path_bound[0]), the following loop may end with `idx_after==0`, further causing the `idx_before` to be set as an invalid value `-1`.

```
  while (idx_after < static_cast<int>(path_bound.size()) &&
         std::get<0>(path_bound[idx_after]) < point_sl.s()) {
    ++idx_after;
  }
  ...
  ...
    int idx_before = idx_after - 1;
    if (std::get<1>(path_bound[idx_before]) <= point_sl.l() &&
        std::get<2>(path_bound[idx_before]) >= point_sl.l() &&
        std::get<1>(path_bound[idx_after]) <= point_sl.l() &&
        std::get<2>(path_bound[idx_after]) >= point_sl.l()) {
      return idx_after;
    }
```

PS: A similar issue already fixed in [issue#12302](https://github.com/ApolloAuto/apollo/pull/12302/files)
