### PR TITLE
[scheduler] fix: a croutine should be able to remove itself from the scheduler

### DIFF
--- a/cyber/scheduler/policy/choreography_context.cc
+++ b/cyber/scheduler/policy/choreography_context.cc
@@ -29,7 +29,7 @@ namespace scheduler {
 
 using apollo::cyber::base::ReadLockGuard;
 using apollo::cyber::base::WriteLockGuard;
-
+using apollo::cyber::croutine::CRoutine;
 using apollo::cyber::croutine::RoutineState;
 
 std::shared_ptr<CRoutine> ChoreographyContext::NextRoutine() {
@@ -88,7 +88,7 @@ bool ChoreographyContext::RemoveCRoutine(uint64_t crid) {
     auto cr = it->second;
     if (cr->id() == crid) {
       cr->Stop();
-      while (!cr->Acquire()) {
+      while (cr.get() != CRoutine::GetCurrentRoutine() && !cr->Acquire()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         AINFO_EVERY(1000) << "waiting for task " << cr->name() << " completion";
       }

--- a/cyber/scheduler/policy/classic_context.cc
+++ b/cyber/scheduler/policy/classic_context.cc
@@ -106,7 +106,7 @@ bool ClassicContext::RemoveCRoutine(const std::shared_ptr<CRoutine>& cr) {
     if ((*it)->id() == crid) {
       auto cr = *it;
       cr->Stop();
-      while (!cr->Acquire()) {
+      while (cr.get() != CRoutine::GetCurrentRoutine() && !cr->Acquire()) {
         std::this_thread::sleep_for(std::chrono::microseconds(1));
         AINFO_EVERY(1000) << "waiting for task " << cr->name() << " completion";
       }


### PR DESCRIPTION
Before this change, a croutine is not able to remove itself from the scheduler. Because it will always be stucked at this busy waiting loop:

```
while (!cr->Acquire()) {
  std::this_thread::sleep_for(std::chrono::milliseconds(1));
  AINFO_EVERY(1000) << "waiting for task " << cr->name() << " completion";
}
```

Signed-off-by: hans <hans@dkmt.io>