### PR TITLE
Control:According to the steering wheel corner feedback, if the steering is not in place, the throttle and brakes are not output.

### DIFF
--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -278,6 +278,16 @@ Status LonController::ComputeControlCommand(
   debug->set_is_full_stop(false);
   GetPathRemain(debug);
 
+  if (trajectory_message_->trajectory_type() ==
+       apollo::planning::ADCTrajectory::UNKNOWN) && 
+       std::abs(cmd->steering_target()-chassis->steering_percentage())>20){
+    acceleration_cmd =0;
+    ADEBUG << "Steering not reached";
+    debug->set_is_full_stop(true);
+    speed_pid_controller_.Reset_integral();
+    station_pid_controller_.Reset_integral();
+  }  
+
   // At near-stop stage, replace the brake control command with the standstill
   // acceleration if the former is even softer than the latter
   if (((trajectory_message_->trajectory_type() ==


### PR DESCRIPTION
According to the steering wheel corner feedback, if the steering
is not in place, the throttle and brakes are not output.

Fix [IDG_Apollo-4395].
When the steering wheel is not in place, the trolley starts to move,
which is prone to lateral error

Cause:
In the parking phase, when switching from forward to backward,
it is generally necessary to turn the steering wheel in the opposite
direction, but the steering wheel angle is not considered in the
longitudinal direction. Once switching to the backward track,
the vehicle will immediately reverse. At this time, the steering wheel
is not in place, resulting in lateral error.

Solution:
According to the steering wheel corner feedback, if the steering
is not in place, the throttle and brakes are not output.