### PR TITLE
[cyber] Add a callback to Poller::Unregister()

### DIFF
--- a/cyber/io/poll_data.h
+++ b/cyber/io/poll_data.h
@@ -43,6 +43,7 @@ struct PollCtrlParam {
   int operation;
   int fd;
   epoll_event event;
+  std::function<void()> callback = nullptr;
 };
 
 }  // namespace io

--- a/cyber/io/poll_handler.cc
+++ b/cyber/io/poll_handler.cc
@@ -58,9 +58,9 @@ bool PollHandler::Block(int timeout_ms, bool is_read) {
   return result;
 }
 
-bool PollHandler::Unblock() {
+bool PollHandler::Unblock(const std::function<void()>& callback) {
   is_blocking_.store(false);
-  return Poller::Instance()->Unregister(request_);
+  return Poller::Instance()->Unregister(request_, callback);
 }
 
 bool PollHandler::Check(int timeout_ms) {

--- a/cyber/io/poll_handler.h
+++ b/cyber/io/poll_handler.h
@@ -33,7 +33,7 @@ class PollHandler {
   virtual ~PollHandler() = default;
 
   bool Block(int timeout_ms, bool is_read);
-  bool Unblock();
+  bool Unblock(const std::function<void()>& callback);
 
   int fd() const { return fd_; }
   void set_fd(int fd) { fd_ = fd; }

--- a/cyber/io/poller.h
+++ b/cyber/io/poller.h
@@ -44,7 +44,9 @@ class Poller {
   void Shutdown();
 
   bool Register(const PollRequest& req);
-  bool Unregister(const PollRequest& req);
+  bool Unregister(
+    const PollRequest& req,
+    const std::function<void()>& callback = nullptr);
 
  private:
   bool Init();

--- a/cyber/io/session.cc
+++ b/cyber/io/session.cc
@@ -86,13 +86,14 @@ int Session::Connect(const struct sockaddr *addr, socklen_t addrlen) {
   return res;
 }
 
-int Session::Close() {
+void Session::Close() {
   ACHECK(fd_ != -1);
 
-  poll_handler_->Unblock();
-  int res = close(fd_);
+  poll_handler_->Unblock([fd = fd_]() {
+    ACHECK(close(fd) == 0);
+  });
   fd_ = -1;
-  return res;
+  return;
 }
 
 ssize_t Session::Recv(void *buf, size_t len, int flags, int timeout_ms) {

--- a/cyber/io/session.h
+++ b/cyber/io/session.h
@@ -44,7 +44,7 @@ class Session {
   int Bind(const struct sockaddr *addr, socklen_t addrlen);
   SessionPtr Accept(struct sockaddr *addr, socklen_t *addrlen);
   int Connect(const struct sockaddr *addr, socklen_t addrlen);
-  int Close();
+  void Close();
 
   // timeout_ms < 0, keep trying until the operation is successfully
   // timeout_ms == 0, try once


### PR DESCRIPTION
`close(fd)` must happen after the fd is removed from `epoll_fd` (via `epoll_ctl()`). Since `epoll_ctl()` is invoked in the Poller thread, a callback is needed to ensure that `close(fd)` happens after `epoll_ctl()`.

https://github.com/ApolloAuto/apollo/issues/13990

Signed-off-by: hans <hans@dkmt.io>