### PR TITLE
[cyber] implement a timerfd based timer

### DIFF
--- a/cyber/io/BUILD
+++ b/cyber/io/BUILD
@@ -65,6 +65,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "timer",
+    srcs = ["timer.cc"],
+    hdrs = ["timer.h"],
+    deps = [
+        ":poll_handler",
+        "//cyber/common:log",
+    ],
+)
+
 cc_binary(
     name = "tcp_echo_client",
     srcs = ["example/tcp_echo_client.cc"],
@@ -93,6 +103,15 @@ cc_binary(
     name = "udp_echo_server",
     srcs = ["example/udp_echo_server.cc"],
     deps = [
+        "//cyber:cyber_core",
+    ],
+)
+
+cc_binary(
+    name = "timer_example",
+    srcs = ["example/timer_example.cc"],
+    deps = [
+        ":timer",
         "//cyber:cyber_core",
     ],
 )

--- a/cyber/io/example/timer_example.cc
+++ b/cyber/io/example/timer_example.cc
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright 2021 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "cyber/cyber.h"
+#include "cyber/croutine/croutine.h"
+#include "cyber/init.h"
+#include "cyber/io/session.h"
+#include "cyber/io/timer.h"
+#include "cyber/scheduler/scheduler_factory.h"
+
+int main(int argc, char* argv[]) {
+  using apollo::cyber::croutine::CRoutine;
+  using apollo::cyber::croutine::RoutineState;
+  using apollo::cyber::io::Timer;
+  using apollo::cyber::scheduler::Scheduler;
+  apollo::cyber::Init(argv[0]);
+  apollo::cyber::scheduler::Instance()->CreateTask(
+    []() {
+      while (true) {
+        auto t0 = std::chrono::system_clock::now();
+        Timer::WaitFor(std::chrono::microseconds(500000));
+        auto t1 = std::chrono::system_clock::now();
+        auto duration =
+          std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
+        AINFO << "task1 sleep duration " << duration.count() << "ms";
+      }
+    },
+    "timer_task1");
+  apollo::cyber::scheduler::Instance()->CreateTask(
+    []() {
+      while (true) {
+        auto t0 = std::chrono::system_clock::now();
+        Timer::WaitFor(std::chrono::microseconds(300000));
+        auto t1 = std::chrono::system_clock::now();
+        auto duration =
+          std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
+        AINFO << "task2 sleep duration " << duration.count() << "ms";
+      }
+    },
+    "timer_task2");
+  apollo::cyber::WaitForShutdown();
+  return 0;
+}

--- a/cyber/io/poll_data.h
+++ b/cyber/io/poll_data.h
@@ -43,6 +43,7 @@ struct PollCtrlParam {
   int operation;
   int fd;
   epoll_event event;
+  std::function<void()> callback = nullptr;
 };
 
 }  // namespace io

--- a/cyber/io/poll_handler.cc
+++ b/cyber/io/poll_handler.cc
@@ -58,9 +58,9 @@ bool PollHandler::Block(int timeout_ms, bool is_read) {
   return result;
 }
 
-bool PollHandler::Unblock() {
+bool PollHandler::Unblock(const std::function<void()>& callback) {
   is_blocking_.store(false);
-  return Poller::Instance()->Unregister(request_);
+  return Poller::Instance()->Unregister(request_, callback);
 }
 
 bool PollHandler::Check(int timeout_ms) {

--- a/cyber/io/poll_handler.h
+++ b/cyber/io/poll_handler.h
@@ -33,7 +33,7 @@ class PollHandler {
   virtual ~PollHandler() = default;
 
   bool Block(int timeout_ms, bool is_read);
-  bool Unblock();
+  bool Unblock(const std::function<void()>& callback);
 
   int fd() const { return fd_; }
   void set_fd(int fd) { fd_ = fd; }

--- a/cyber/io/poller.h
+++ b/cyber/io/poller.h
@@ -44,7 +44,9 @@ class Poller {
   void Shutdown();
 
   bool Register(const PollRequest& req);
-  bool Unregister(const PollRequest& req);
+  bool Unregister(
+    const PollRequest& req,
+    const std::function<void()>& callback = nullptr);
 
  private:
   bool Init();

--- a/cyber/io/session.cc
+++ b/cyber/io/session.cc
@@ -86,13 +86,14 @@ int Session::Connect(const struct sockaddr *addr, socklen_t addrlen) {
   return res;
 }
 
-int Session::Close() {
+void Session::Close() {
   ACHECK(fd_ != -1);
 
-  poll_handler_->Unblock();
-  int res = close(fd_);
+  poll_handler_->Unblock([fd = fd_]() {
+    ACHECK(close(fd) == 0);
+  });
   fd_ = -1;
-  return res;
+  return;
 }
 
 ssize_t Session::Recv(void *buf, size_t len, int flags, int timeout_ms) {

--- a/cyber/io/session.h
+++ b/cyber/io/session.h
@@ -44,7 +44,7 @@ class Session {
   int Bind(const struct sockaddr *addr, socklen_t addrlen);
   SessionPtr Accept(struct sockaddr *addr, socklen_t *addrlen);
   int Connect(const struct sockaddr *addr, socklen_t addrlen);
-  int Close();
+  void Close();
 
   // timeout_ms < 0, keep trying until the operation is successfully
   // timeout_ms == 0, try once

--- a/cyber/io/timer.cc
+++ b/cyber/io/timer.cc
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright 2021 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include <assert.h>
+#include <sys/timerfd.h>
+#include <stdint.h>
+
+#include "cyber/io/poll_handler.h"
+#include "cyber/io/timer.h"
+
+namespace apollo {
+namespace cyber {
+namespace io {
+
+void Timer::WaitFor(const std::chrono::microseconds& duration) {
+  auto micro = duration.count();
+  itimerspec timer_spec;
+  timer_spec.it_interval.tv_sec = 0;
+  timer_spec.it_interval.tv_nsec = 0;
+  timer_spec.it_value.tv_sec = micro / 1000000;
+  timer_spec.it_value.tv_nsec = (micro % 1000000) * 1000;
+  int timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+  assert(timer_fd >= 0);
+  int rc = timerfd_settime(timer_fd, 0, &timer_spec, nullptr);
+  ACHECK(rc == 0);
+  PollHandler poll_handler(timer_fd);
+  ACHECK(poll_handler.Block(-1, true));
+  poll_handler.Unblock([timer_fd]() {
+    ACHECK(close(timer_fd) == 0);
+  });
+}
+
+}  // namespace io
+}  // namespace cyber
+}  // namespace apollo

--- a/cyber/io/timer.h
+++ b/cyber/io/timer.h
@@ -1,0 +1,35 @@
+/******************************************************************************
+ * Copyright 2021 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#ifndef CYBER_IO_TIMER_H_
+#define CYBER_IO_TIMER_H_
+
+#include <chrono>
+
+namespace apollo {
+namespace cyber {
+namespace io {
+
+class Timer final {
+ public:
+  static void WaitFor(const std::chrono::microseconds& duration);
+};
+
+}  // namespace io
+}  // namespace cyber
+}  // namespace apollo
+
+#endif  // CYBER_IO_TIMER_H_


### PR DESCRIPTION
 `CRoutine::Sleep()` can't sleep for less than 1 second. This change adds a timerfd based timer to sleep for a shorter period. The timer fd is added to epoll so that it won't block the processor thread.