### PR TITLE
Control:Fix bug

### DIFF
--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -278,7 +278,7 @@ Status LonController::ComputeControlCommand(
   debug->set_is_full_stop(false);
   GetPathRemain(debug);
 
-  if (trajectory_message_->trajectory_type() ==
+  if((trajectory_message_->trajectory_type() ==
        apollo::planning::ADCTrajectory::UNKNOWN) && 
        std::abs(cmd->steering_target()-chassis->steering_percentage())>20){
     acceleration_cmd =0;


### PR DESCRIPTION
Control:According to the steering wheel corner feedback, if the steering is 
not in place, the throttle and brakes are not output.

Fix [IDG_Apollo-4395].
When the steering wheel is not in place, the trolley starts to move,
which is prone to lateral error

Cause:
In the parking phase, when switching from forward to backward,
it is generally necessary to turn the steering wheel in the opposite
direction, but the steering wheel angle is not considered in the
longitudinal direction. Once switching to the backward track,
the vehicle will immediately reverse. At this time, the steering wheel
is not in place, resulting in lateral error.

Solution:
According to the steering wheel corner feedback, if the steering
is not in place, the throttle and brakes are not output.