### PR TITLE
dreamview: fix bug at sim control (#13727)

### DIFF
--- a/modules/dreamview/backend/sim_control/sim_control.cc
+++ b/modules/dreamview/backend/sim_control/sim_control.cc
@@ -113,9 +113,9 @@ void SimControl::InitTimerAndIO() {
       false));
 }
 
-void SimControl::Init(bool set_start_point, double start_velocity,
+void SimControl::Init(double start_velocity,
                       double start_acceleration) {
-  if (set_start_point && !FLAGS_use_navigation_mode) {
+  if (!FLAGS_use_navigation_mode) {
     InitStartPoint(start_velocity, start_acceleration);
   }
 }
@@ -278,8 +278,7 @@ void SimControl::Start() {
     // When localization is already available, we do not need to
     // reset/override the start point.
     localization_reader_->Observe();
-    Init(localization_reader_->Empty(),
-         next_point_.has_v() ? next_point_.v() : 0.0,
+    Init(next_point_.has_v() ? next_point_.v() : 0.0,
          next_point_.has_a() ? next_point_.a() : 0.0);
 
     InternalReset();

--- a/modules/dreamview/backend/sim_control/sim_control.h
+++ b/modules/dreamview/backend/sim_control/sim_control.h
@@ -62,7 +62,7 @@ class SimControl : SimControlInterface {
    * @brief setup callbacks and timer
    * @param set_start_point initialize localization.
    */
-  void Init(bool set_start_point, double start_velocity = 0.0,
+  void Init(double start_velocity = 0.0,
             double start_acceleration = 0.0) override;
 
   /**

--- a/modules/dreamview/backend/sim_control/sim_control_interface.h
+++ b/modules/dreamview/backend/sim_control/sim_control_interface.h
@@ -38,7 +38,7 @@ class SimControlInterface {
   /**
    * @brief Initialization.
    */
-  virtual void Init(bool set_start_point, double start_velocity = 0.0,
+  virtual void Init(double start_velocity = 0.0,
                     double start_acceleration = 0.0) = 0;
 
   /**


### PR DESCRIPTION
*merge a fix from master
* dreamview: fix bug at sim control

InitStartPoint() can handle  using localization point and using dummy point.if localization is not empty, program will jump here.

* Update sim_control.h

* Update sim_control_interface.h

* Update sim_control.cc