### PR TITLE
[bridge] fix multiframe message communication such as PointCloud

### DIFF
--- a/modules/bridge/BUILD
+++ b/modules/bridge/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "//modules/common/monitor_log",
         "//modules/common/util",
         "//modules/planning/proto:planning_cc_proto",
+        "//modules/drivers/proto:pointcloud_cc_proto",
         "@com_github_gflags_gflags//:gflags",
     ],
 )

--- a/modules/bridge/common/bridge_proto_diserialized_buf.h
+++ b/modules/bridge/common/bridge_proto_diserialized_buf.h
@@ -137,6 +137,8 @@ template <typename T>
 bool BridgeProtoDiserializedBuf<T>::Initialize(const BridgeHeader &header) {
   total_size_ = header.GetMsgSize();
   total_frames_ = header.GetTotalFrames();
+  proto_name_ = header.GetMsgName();
+  sequence_num_ = header.GetMsgID();
   if (total_frames_ == 0) {
     return false;
   }

--- a/modules/bridge/conf/udp_bridge_receiver_pointcloud.pb.txt
+++ b/modules/bridge/conf/udp_bridge_receiver_pointcloud.pb.txt
@@ -1,0 +1,4 @@
+topic_name: "/apollo/sensor/lidar/PointCloud"
+bind_port: 8904
+proto_name: "PointCloud"
+enable_timeout: false

--- a/modules/bridge/conf/udp_bridge_sender_pointcloud.pb.txt
+++ b/modules/bridge/conf/udp_bridge_sender_pointcloud.pb.txt
@@ -1,0 +1,3 @@
+remote_ip: "127.0.0.1"
+remote_port: 8904
+proto_name: "PointCloud"

--- a/modules/bridge/dag/bridge_receiver_pointcloud.dag
+++ b/modules/bridge/dag/bridge_receiver_pointcloud.dag
@@ -1,0 +1,12 @@
+module_config {
+    module_library: "/apollo/bazel-bin/modules/bridge/libudp_bridge_receiver_component.so"
+
+    components {
+
+        class_name: "UDPBridgeReceiverComponent<drivers::PointCloud>"
+        config {
+            name: "bridge_receiver_PointCloud"
+            config_file_path: "/apollo/modules/bridge/conf/udp_bridge_receiver_pointcloud.pb.txt"
+      }
+    }
+}

--- a/modules/bridge/dag/bridge_sender_pointcloud.dag
+++ b/modules/bridge/dag/bridge_sender_pointcloud.dag
@@ -1,0 +1,15 @@
+module_config {
+    module_library: "/apollo/bazel-bin/modules/bridge/libudp_bridge_sender_component.so"
+
+    components {
+
+        class_name: "UDPBridgeSenderComponent<drivers::PointCloud>"
+        config {
+            name: "bridge_sender_PointCloud"
+            config_file_path: "/apollo/modules/bridge/conf/udp_bridge_sender_pointcloud.pb.txt"
+            readers {
+                channel: "/apollo/sensor/lidar/PointCloud"
+            }
+      }
+   }
+}

--- a/modules/bridge/udp_bridge_receiver_component.h
+++ b/modules/bridge/udp_bridge_receiver_component.h
@@ -26,6 +26,7 @@
 
 #include "modules/bridge/proto/udp_bridge_remote_info.pb.h"
 #include "modules/canbus/proto/chassis.pb.h"
+#include "modules/drivers/proto/pointcloud.pb.h"
 
 #include "cyber/class_loader/class_loader.h"
 #include "cyber/component/component.h"
@@ -80,5 +81,6 @@ class UDPBridgeReceiverComponent final : public cyber::Component<> {
 };
 
 RECEIVER_BRIDGE_COMPONENT_REGISTER(canbus::Chassis)
+RECEIVER_BRIDGE_COMPONENT_REGISTER(drivers::PointCloud)
 }  // namespace bridge
 }  // namespace apollo

--- a/modules/bridge/udp_bridge_sender_component.cc
+++ b/modules/bridge/udp_bridge_sender_component.cc
@@ -87,6 +87,7 @@ bool UDPBridgeSenderComponent<T>::Proc(const std::shared_ptr<T> &pb_msg) {
 
 BRIDGE_IMPL(LocalizationEstimate);
 BRIDGE_IMPL(planning::ADCTrajectory);
+BRIDGE_IMPL(drivers::PointCloud);
 
 }  // namespace bridge
 }  // namespace apollo

--- a/modules/bridge/udp_bridge_sender_component.h
+++ b/modules/bridge/udp_bridge_sender_component.h
@@ -27,6 +27,7 @@
 
 #include "modules/bridge/proto/udp_bridge_remote_info.pb.h"
 #include "modules/planning/proto/planning.pb.h"
+#include "modules/drivers/proto/pointcloud.pb.h"
 
 #include "cyber/class_loader/class_loader.h"
 #include "cyber/component/component.h"
@@ -65,6 +66,7 @@ class UDPBridgeSenderComponent final : public cyber::Component<T> {
 
 BRIDGE_COMPONENT_REGISTER(planning::ADCTrajectory)
 BRIDGE_COMPONENT_REGISTER(localization::LocalizationEstimate)
+BRIDGE_COMPONENT_REGISTER(drivers::PointCloud)
 
 }  // namespace bridge
 }  // namespace apollo


### PR DESCRIPTION
The Bridge UDP receiver uses edge-triggered **epoll_wake()**. Each event-triggered receiving thread needs to process all data, otherwise it will block. Thus I put **recvfrom()** in to a loop. The codes have been tested through two laptops, which run "mainboard -d modules/bridge/dag/bridge_sender_pointcloud.dag" and "mainboard -d modules/bridge/dag/bridge_receiver_pointcloud.dag" separately. 