### PR TITLE
[HDMap] reset the input param  nearest_lane in GetNearestLaneWithHeading

### DIFF
--- a/modules/map/hdmap/hdmap_impl.cc
+++ b/modules/map/hdmap/hdmap_impl.cc
@@ -554,6 +554,7 @@ int HDMapImpl::GetNearestLaneWithHeading(
   size_t s_index = 0;
   Vec2d map_point;
   double min_distance = distance;
+  nearest_lane->reset();
   for (const auto& lane : lanes) {
     double s_offset = 0.0;
     int s_offset_index = 0;


### PR DESCRIPTION
The input param nearest_lane should be reset in advance, so that we can check ` (*nearest_lane) == nullptr ` to return -1.
When the input param ` *nearest_lane != nullptr `, the function may return 0 with nearest_lane holding its original value.