### PR TITLE
fix a logical bug

### DIFF
--- a/modules/perception/lidar/app/lidar_obstacle_detection.cc
+++ b/modules/perception/lidar/app/lidar_obstacle_detection.cc
@@ -46,7 +46,7 @@ bool LidarObstacleDetection::Init(
   ACHECK(cyber::common::GetProtoFromFile(config_file, &config));
   use_map_manager_ = config.use_map_manager();
   use_object_filter_bank_ = config.use_object_filter_bank();
-  use_object_builder_ = ("PointPillarsDetection" != config.detector() ||
+  use_object_builder_ = ("PointPillarsDetection" != config.detector() &&
                          "MaskPillarsDetection" != config.detector());
 
   use_map_manager_ = use_map_manager_ && options.enable_hdmap_input;


### PR DESCRIPTION
```
use_object_builder_ = ("PointPillarsDetection" != config.detector() ||
                         "MaskPillarsDetection" != config.detector());
```
use_object_builder_  will always be True.