### PR TITLE
docker_base.sh: compare only major version of docker to avoid depende…

### DIFF
--- a/docker/scripts/docker_base.sh
+++ b/docker/scripts/docker_base.sh
@@ -63,12 +63,12 @@ function determine_gpu_use_host() {
     local nv_docker_doc="https://github.com/NVIDIA/nvidia-docker/blob/master/README.md"
     if [[ "${USE_GPU_HOST}" -eq 1 ]]; then
         if [[ -x "$(which nvidia-container-toolkit)" ]]; then
-            local docker_version
-            docker_version="$(docker version --format '{{.Server.Version}}')"
-            if dpkg --compare-versions "${docker_version}" "ge" "19.03"; then
+            local docker_major_version
+            docker_major_version="$(docker version --format '{{.Server.Version}}' | cut -d. -f1)"
+            if [[ "${docker_major_version}" -ge "19" ]] ; then
                 DOCKER_RUN_CMD="docker run --gpus all"
             else
-                warning "Please upgrade to docker-ce 19.03+ to access GPU from container."
+                warning "Please upgrade to docker-ce 20+ to access GPU from container."
                 USE_GPU_HOST=0
             fi
         elif [[ -x "$(which nvidia-docker)" ]]; then


### PR DESCRIPTION
…ncy on dpkg

* on rpm based distributions dpkg typically won't be installed and in that
  case apollo will use only CPU and disable GPU usage, even when docker
  is new enough and nvidia drivers installed, just because
  'dpkg --compare-versions' fails with command-not-found

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>