### PR TITLE
update tensorrt to 8.2 on aarch64

### DIFF
--- a/modules/localization/BUILD
+++ b/modules/localization/BUILD
@@ -1,5 +1,6 @@
 load("//tools:cpplint.bzl", "cpplint")
 load("//tools/install:install.bzl", "install", "install_files")
+load("//tools/platform:build_defs.bzl", "if_x86_64")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,10 +26,10 @@ install(
     ],
     deps = [
         ":pb_localization",
-        "//modules/localization/msf:install",
         "//modules/localization/ndt:install",
         "//modules/localization/rtk:install",
-    ],
+# remove from condition when `third_party/localization_msf/aarch64` is ready
+    ] + if_x86_64(["//modules/localization/msf:install"]),
 )
 
 install_files(

--- a/modules/perception/common/i_lib/pc/i_ground.cc
+++ b/modules/perception/common/i_lib/pc/i_ground.cc
@@ -1241,13 +1241,25 @@ bool PlaneFitGroundDetector::Detect(const float *point_cloud,
   assert(nr_points <= param_.nr_points_max);
   assert(nr_point_elements >= 3);
   // setup the fine voxel grid
+#ifdef __aarch64__
+  if (!vg_fine_->Set(point_cloud, nr_points, nr_point_elements)) {
+    return false;
+  }
+#else
   if (!vg_fine_->SetS(point_cloud, nr_points, nr_point_elements)) {
     return false;
   }
+#endif
   // setup the coarse voxel grid
+#ifdef __aarch64__
+  if (!vg_coarse_->Set(point_cloud, nr_points, nr_point_elements)) {
+    return false;
+  }
+#else
   if (!vg_coarse_->SetS(point_cloud, nr_points, nr_point_elements)) {
     return false;
   }
+#endif
   // int nr_candis = 0;
   // int nr_valid_grid = 0;
   unsigned int r = 0;

--- a/modules/perception/common/i_lib/pc/i_struct_s.h
+++ b/modules/perception/common/i_lib/pc/i_struct_s.h
@@ -306,8 +306,10 @@ class VoxelGridXY {
            unsigned int nr_point_element);
 
   // sse2 version: only for float type input Data
+#ifndef __aarch64__
   bool SetS(const float *data, unsigned int nr_points,
             unsigned int nr_point_element);
+#endif
 
   bool Set(const T *data, unsigned int nr_points, unsigned int nr_point_element,
            unsigned int nr_voxel_x, unsigned int nr_voxel_y,
@@ -709,6 +711,7 @@ bool VoxelGridXY<T>::Set(const T *data, unsigned int nr_points,
   return (initialized_);
 }
 
+#ifndef __aarch64__
 template <typename T>
 bool VoxelGridXY<T>::SetS(const float *data, unsigned int nr_points,
                           unsigned int nr_point_element) {
@@ -848,6 +851,7 @@ bool VoxelGridXY<T>::SetS(const float *data, unsigned int nr_points,
   initialized_ = true;
   return (initialized_);
 }
+#endif
 
 template <typename T>
 bool VoxelGridXY<T>::Set(const T *data, unsigned int nr_points,

--- a/modules/perception/inference/onnx/onnx_obstacle_detector.h
+++ b/modules/perception/inference/onnx/onnx_obstacle_detector.h
@@ -42,7 +42,7 @@ class Logger : public nvinfer1::ILogger {
   explicit Logger(Severity severity = Severity::kWARNING)
       : reportable_severity(severity) {}
 
-  void log(Severity severity, const char* msg) override {
+  void log(Severity severity, const char* msg) noexcept override {
     // suppress messages with severity enum value greater than the reportable
     if (severity > reportable_severity) return;
 

--- a/modules/perception/inference/tensorrt/batch_stream.h
+++ b/modules/perception/inference/tensorrt/batch_stream.h
@@ -42,7 +42,7 @@ class BatchStream {
   float *getBatch() { return &mBatch[0]; }
   int getBatchesRead() const { return mBatchCount; }
   int getBatchSize() const { return mBatchSize; }
-  nvinfer1::DimsNCHW getDims() const { return mDims; }
+  nvinfer1::Dims4 getDims() const { return mDims; }
 
  private:
   float *getFileBatch() { return &mFileBatch[0]; }
@@ -57,7 +57,7 @@ class BatchStream {
   int mFileBatchPos{0};
   int mImageSize{0};
 
-  nvinfer1::DimsNCHW mDims;
+  nvinfer1::Dims4 mDims;
   std::vector<float> mBatch;
   std::vector<float> mFileBatch;
   std::string mPath;

--- a/modules/perception/inference/tensorrt/batch_stream_test.cc
+++ b/modules/perception/inference/tensorrt/batch_stream_test.cc
@@ -45,10 +45,10 @@ TEST(BatchStreamTest, test_init) {
         "modules/perception/inference/inference_test_data/tensorrt/bs_1x1x1x1");
     auto dims = batch_stream.getDims();
     batch_stream.reset(0);
-    EXPECT_EQ(1, dims.n());
-    EXPECT_EQ(1, dims.c());
-    EXPECT_EQ(1, dims.h());
-    EXPECT_EQ(1, dims.w());
+    EXPECT_EQ(1, dims.d[0]);
+    EXPECT_EQ(1, dims.d[1]);
+    EXPECT_EQ(1, dims.d[2]);
+    EXPECT_EQ(1, dims.d[3]);
   }
 }
 

--- a/modules/perception/inference/tensorrt/entropy_calibrator.cc
+++ b/modules/perception/inference/tensorrt/entropy_calibrator.cc
@@ -25,8 +25,8 @@ Int8EntropyCalibrator::Int8EntropyCalibrator(
     const apollo::perception::inference::BatchStream &stream, int first_batch,
     bool read_cache, std::string network)
     : stream_(stream), read_cache_(read_cache), network_(network) {
-  DimsNCHW dims = stream_.getDims();
-  input_count_ = stream_.getBatchSize() * dims.c() * dims.h() * dims.w();
+  Dims4 dims = stream_.getDims();
+  input_count_ = stream_.getBatchSize() * dims.d[1] * dims.d[2] * dims.d[3];
   cudaMalloc(&device_input_, input_count_ * sizeof(float));
   stream_.reset(first_batch);
 }
@@ -38,7 +38,7 @@ Int8EntropyCalibrator::~Int8EntropyCalibrator() {
 }
 
 bool Int8EntropyCalibrator::getBatch(void *bindings[], const char *names[],
-                                     int nbBindings) {
+                                     int nbBindings) noexcept {
   if (!stream_.next()) {
     return false;
   }
@@ -49,7 +49,8 @@ bool Int8EntropyCalibrator::getBatch(void *bindings[], const char *names[],
   return true;
 }
 
-const void *Int8EntropyCalibrator::readCalibrationCache(size_t &length) {
+const void *Int8EntropyCalibrator::readCalibrationCache(
+    size_t &length) noexcept {
   calibration_cache_.clear();
   std::ifstream input(
       apollo::perception::inference::locateFile(network_, "CalibrationTable"),
@@ -65,7 +66,7 @@ const void *Int8EntropyCalibrator::readCalibrationCache(size_t &length) {
 }
 
 void Int8EntropyCalibrator::writeCalibrationCache(const void *cache,
-                                                  size_t length) {
+                                                  size_t length) noexcept {
   std::ofstream output(
       apollo::perception::inference::locateFile(network_, "CalibrationTable"),
       std::ios::binary);

--- a/modules/perception/inference/tensorrt/entropy_calibrator.h
+++ b/modules/perception/inference/tensorrt/entropy_calibrator.h
@@ -33,13 +33,15 @@ class Int8EntropyCalibrator : public IInt8EntropyCalibrator {
       bool read_cache, std::string network);
 
   virtual ~Int8EntropyCalibrator();
-  int getBatchSize() const override { return stream_.getBatchSize(); }
+  int getBatchSize() const noexcept override { return stream_.getBatchSize(); }
 
-  bool getBatch(void *bindings[], const char *names[], int nbBindings) override;
+  bool getBatch(void *bindings[], const char *names[],
+                int nbBindings) noexcept override;
 
-  const void *readCalibrationCache(size_t &length) override;
+  const void *readCalibrationCache(size_t &length) noexcept override;
 
-  void writeCalibrationCache(const void *cache, size_t length) override;
+  void writeCalibrationCache(const void *cache,
+                             size_t length) noexcept override;
 
  private:
   apollo::perception::inference::BatchStream stream_;

--- a/modules/perception/inference/tensorrt/plugins/argmax_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/argmax_plugin.cu
@@ -52,9 +52,9 @@ __global__ void cmp(const int nthreads, const float *in_data,
     }
   }
 }
-int ArgMax1Plugin::enqueue(int batchSize, const void *const *inputs,
-                           void **outputs, void *workspace,
-                           cudaStream_t stream) {
+int32_t ArgMax1Plugin::enqueue(int32_t batchSize, const void *const *inputs,
+                               void *const *outputs, void *workspace,
+                               cudaStream_t stream) noexcept {
   const int thread_size = 512;
   int block_size =
       (input_dims_.d[0] * input_dims_.d[1] * input_dims_.d[2] * batchSize +

--- a/modules/perception/inference/tensorrt/plugins/dfmb_psroi_align_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/dfmb_psroi_align_plugin.cu
@@ -140,9 +140,10 @@ __global__ void DFMBPSROIAlignForward(
   }
 }
 
-int DFMBPSROIAlignPlugin::enqueue(int batchSize, const void *const *inputs,
-                                  void **outputs, void *workspace,
-                                  cudaStream_t stream) {
+int32_t DFMBPSROIAlignPlugin::enqueue(int32_t batchSize,
+                                      const void *const *inputs,
+                                      void *const *outputs, void *workspace,
+                                      cudaStream_t stream) noexcept {
   const float *bottom_data = reinterpret_cast<const float *>(inputs[0]);
   const float *bottom_rois = reinterpret_cast<const float *>(inputs[1]);
   const float *bottom_trans =

--- a/modules/perception/inference/tensorrt/plugins/dfmb_psroi_align_plugin.h
+++ b/modules/perception/inference/tensorrt/plugins/dfmb_psroi_align_plugin.h
@@ -28,7 +28,7 @@ namespace inference {
 // i.e. DeForMaBle Position Sensitive ROI Align.
 // input0 dims: [C, H, W], input1 dims: [num_rois, 5, 1, 1]
 // input2 dims: [N, C2, H2, W2]
-class DFMBPSROIAlignPlugin : public nvinfer1::IPlugin {
+class DFMBPSROIAlignPlugin : public nvinfer1::IPluginV2 {
  public:
   DFMBPSROIAlignPlugin(
       const DFMBPSROIAlignParameter &dfmb_psroi_align_parameter,
@@ -82,31 +82,62 @@ class DFMBPSROIAlignPlugin : public nvinfer1::IPlugin {
 
   virtual ~DFMBPSROIAlignPlugin() {}
 
-  virtual int initialize() { return 0; }
-  virtual void terminate() {}
-  int getNbOutputs() const override { return 1; }
+  int32_t initialize() noexcept override { return 0; }
+  void terminate() noexcept override {}
+  int32_t getNbOutputs() const noexcept override { return 1; }
 
-  nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
-                                     int nbInputDims) override {
+  nvinfer1::Dims getOutputDimensions(int32_t index,
+                                     const nvinfer1::Dims *inputs,
+                                     int32_t nbInputDims) noexcept override {
     // TODO(chenjiahao): complete input dims assertion
     return output_dims_;
   }
 
-  void configure(const nvinfer1::Dims *inputDims, int nbInputs,
-                 const nvinfer1::Dims *outputDims, int nbOutputs,
-                 int maxBatchSize) override {}
+  void configureWithFormat(const nvinfer1::Dims *inputDims, int32_t nbInputs,
+                           const nvinfer1::Dims *outputDims, int32_t nbOutputs,
+                           nvinfer1::DataType type,
+                           nvinfer1::PluginFormat format,
+                           int32_t maxBatchSize) noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int32_t maxBatchSize) const noexcept override {
+    return 0;
+  }
 
-  virtual int enqueue(int batchSize, const void *const *inputs, void **outputs,
-                      void *workspace, cudaStream_t stream);
+  int32_t enqueue(int32_t batchSize, const void *const *inputs,
+                  void *const *outputs, void *workspace,
+                  cudaStream_t stream) noexcept override;
 
-  size_t getSerializationSize() override { return 0; }
+  size_t getSerializationSize() const noexcept override { return 0; }
 
-  void serialize(void *buffer) override {
+  void serialize(void *buffer) const noexcept override {
     char *d = reinterpret_cast<char *>(buffer), *a = d;
     size_t size = getSerializationSize();
     CHECK_EQ(d, a + size);
+  }
+
+  IPluginV2 *clone() const noexcept override {
+    return const_cast<DFMBPSROIAlignPlugin *>(this);
+  }
+
+  void destroy() noexcept override {}
+
+  const nvinfer1::AsciiChar *getPluginNamespace() const noexcept override {
+    return "apollo::perception::inference";
+  }
+
+  const nvinfer1::AsciiChar *getPluginType() const noexcept override {
+    return "default";
+  }
+
+  const nvinfer1::AsciiChar *getPluginVersion() const noexcept override {
+    return "1.0";
+  }
+
+  void setPluginNamespace(const nvinfer1::AsciiChar *) noexcept override {}
+
+  bool supportsFormat(nvinfer1::DataType,
+                      nvinfer1::PluginFormat) const noexcept override {
+    return true;
   }
 
  private:

--- a/modules/perception/inference/tensorrt/plugins/leakyReLU_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/leakyReLU_plugin.cu
@@ -34,8 +34,9 @@ __global__ void ReLU(const int nthreads, const Dtype *in_data,
   }
 }
 
-int ReLUPlugin::enqueue(int batchSize, const void *const *inputs,
-                        void **outputs, void *workspace, cudaStream_t stream) {
+int32_t ReLUPlugin::enqueue(int32_t batchSize, const void *const *inputs,
+                            void *const *outputs, void *workspace,
+                            cudaStream_t stream) noexcept {
   const int thread_size = 512;
   const int block_size =
       (input_dims_.d[0] * input_dims_.d[1] * input_dims_.d[2] * batchSize +

--- a/modules/perception/inference/tensorrt/plugins/leakyReLU_plugin.h
+++ b/modules/perception/inference/tensorrt/plugins/leakyReLU_plugin.h
@@ -25,47 +25,77 @@ namespace apollo {
 namespace perception {
 namespace inference {
 
-class ReLUPlugin : public nvinfer1::IPlugin {
+class ReLUPlugin : public nvinfer1::IPluginV2 {
  public:
   ReLUPlugin(const ReLUParameter &param, const nvinfer1::Dims &in_dims) {
     input_dims_.nbDims = in_dims.nbDims;
     CHECK_GT(input_dims_.nbDims, 0);
     for (int i = 0; i < in_dims.nbDims; i++) {
       input_dims_.d[i] = in_dims.d[i];
-      input_dims_.type[i] = in_dims.type[i];
     }
     negative_slope_ = param.negative_slope();
   }
 
   ReLUPlugin() {}
   ~ReLUPlugin() {}
-  virtual int initialize() { return 0; }
-  virtual void terminate() {}
-  int getNbOutputs() const override { return 1; }
+  int32_t initialize() noexcept override { return 0; }
+  void terminate() noexcept override {}
+  int32_t getNbOutputs() const noexcept override { return 1; }
 
-  nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
-                                     int nbInputDims) override {
+  nvinfer1::Dims getOutputDimensions(int32_t index,
+                                     const nvinfer1::Dims *inputs,
+                                     int32_t nbInputDims) noexcept override {
     nvinfer1::Dims out_dims = inputs[0];
     return out_dims;
   }
 
-  void configure(const nvinfer1::Dims *inputDims, int nbInputs,
-                 const nvinfer1::Dims *outputDims, int nbOutputs,
-                 int maxBatchSize) override {
+  void configureWithFormat(const nvinfer1::Dims *inputDims, int32_t nbInputs,
+                           const nvinfer1::Dims *outputDims, int32_t nbOutputs,
+                           nvinfer1::DataType type,
+                           nvinfer1::PluginFormat format,
+                           int32_t maxBatchSize) noexcept override {
     input_dims_ = inputDims[0];
   }
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int32_t maxBatchSize) const noexcept override {
+    return 0;
+  }
 
-  virtual int enqueue(int batchSize, const void *const *inputs, void **outputs,
-                      void *workspace, cudaStream_t stream);
+  int32_t enqueue(int32_t batchSize, const void *const *inputs,
+                  void *const *outputs, void *workspace,
+                  cudaStream_t stream) noexcept override;
 
-  size_t getSerializationSize() override { return 0; }
+  size_t getSerializationSize() const noexcept override { return 0; }
 
-  void serialize(void *buffer) override {
+  void serialize(void *buffer) const noexcept override {
     char *d = reinterpret_cast<char *>(buffer), *a = d;
     size_t size = getSerializationSize();
     CHECK_EQ(d, a + size);
+  }
+
+  IPluginV2 *clone() const noexcept override {
+    return const_cast<ReLUPlugin *>(this);
+  }
+
+  void destroy() noexcept override {}
+
+  const nvinfer1::AsciiChar *getPluginNamespace() const noexcept override {
+    return "apollo::perception::inference";
+  }
+
+  const nvinfer1::AsciiChar *getPluginType() const noexcept override {
+    return "default";
+  }
+
+  const nvinfer1::AsciiChar *getPluginVersion() const noexcept override {
+    return "1.0";
+  }
+
+  void setPluginNamespace(const nvinfer1::AsciiChar *) noexcept override {}
+
+  bool supportsFormat(nvinfer1::DataType,
+                      nvinfer1::PluginFormat) const noexcept override {
+    return true;
   }
 
  private:

--- a/modules/perception/inference/tensorrt/plugins/rcnn_proposal_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/rcnn_proposal_plugin.cu
@@ -103,9 +103,10 @@ __global__ void get_max_score_kernel(const int nthreads, const float *bbox_pred,
   }
 }
 
-int RCNNProposalPlugin::enqueue(int batchSize, const void *const *inputs,
-                                void **outputs, void *workspace,
-                                cudaStream_t stream) {
+int32_t RCNNProposalPlugin::enqueue(int32_t batchSize,
+                                    const void *const *inputs,
+                                    void *const *outputs, void *workspace,
+                                    cudaStream_t stream) noexcept {
   // cls_score_softmax dims: [num_rois, 4, 1, 1]
   const float *cls_score_softmax = reinterpret_cast<const float *>(inputs[0]);
   // bbox_pred dims: [num_rois, 4 * 4 (num_class * box_dim), 1, 1]

--- a/modules/perception/inference/tensorrt/plugins/rcnn_proposal_plugin.h
+++ b/modules/perception/inference/tensorrt/plugins/rcnn_proposal_plugin.h
@@ -25,7 +25,7 @@ namespace perception {
 namespace inference {
 
 // TODO(chenjiahao): complete member functions
-class RCNNProposalPlugin : public nvinfer1::IPlugin {
+class RCNNProposalPlugin : public nvinfer1::IPluginV2 {
  public:
   RCNNProposalPlugin(
       const BBoxRegParameter &bbox_reg_param,
@@ -65,32 +65,63 @@ class RCNNProposalPlugin : public nvinfer1::IPlugin {
 
   virtual ~RCNNProposalPlugin() {}
 
-  virtual int initialize() { return 0; }
-  virtual void terminate() {}
-  int getNbOutputs() const override { return 1; }
+  int32_t initialize() noexcept override { return 0; }
+  void terminate() noexcept override {}
+  int32_t getNbOutputs() const noexcept override { return 1; }
 
-  nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
-                                     int nbInputDims) override {
+  nvinfer1::Dims getOutputDimensions(int32_t index,
+                                     const nvinfer1::Dims *inputs,
+                                     int32_t nbInputDims) noexcept override {
     // TODO(chenjiahao): complete input dims assertion
     // TODO(chenjiahao): batch size is hard coded to 1 here
     return nvinfer1::Dims4(top_n_ * 1, out_channel_, 1, 1);
   }
 
-  void configure(const nvinfer1::Dims *inputDims, int nbInputs,
-                 const nvinfer1::Dims *outputDims, int nbOutputs,
-                 int maxBatchSize) override {}
+  void configureWithFormat(const nvinfer1::Dims *inputDims, int32_t nbInputs,
+                           const nvinfer1::Dims *outputDims, int32_t nbOutputs,
+                           nvinfer1::DataType type,
+                           nvinfer1::PluginFormat format,
+                           int32_t maxBatchSize) noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int32_t maxBatchSize) const noexcept override {
+    return 0;
+  }
 
-  virtual int enqueue(int batchSize, const void *const *inputs, void **outputs,
-                      void *workspace, cudaStream_t stream);
+  int32_t enqueue(int32_t batchSize, const void *const *inputs,
+                  void *const *outputs, void *workspace,
+                  cudaStream_t stream) noexcept override;
 
-  size_t getSerializationSize() override { return 0; }
+  size_t getSerializationSize() const noexcept override { return 0; }
 
-  void serialize(void *buffer) override {
+  void serialize(void *buffer) const noexcept override {
     char *d = reinterpret_cast<char *>(buffer), *a = d;
     size_t size = getSerializationSize();
     CHECK_EQ(d, a + size);
+  }
+
+  IPluginV2 *clone() const noexcept override {
+    return const_cast<RCNNProposalPlugin *>(this);
+  }
+
+  void destroy() noexcept override {}
+
+  const nvinfer1::AsciiChar *getPluginNamespace() const noexcept override {
+    return "apollo::perception::inference";
+  }
+
+  const nvinfer1::AsciiChar *getPluginType() const noexcept override {
+    return "default";
+  }
+
+  const nvinfer1::AsciiChar *getPluginVersion() const noexcept override {
+    return "1.0";
+  }
+
+  void setPluginNamespace(const nvinfer1::AsciiChar *) noexcept override {}
+
+  bool supportsFormat(nvinfer1::DataType,
+                      nvinfer1::PluginFormat) const noexcept override {
+    return true;
   }
 
  private:

--- a/modules/perception/inference/tensorrt/plugins/rpn_proposal_ssd_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/rpn_proposal_ssd_plugin.cu
@@ -105,9 +105,10 @@ __global__ void reshape_scores_kernel(const int nthreads,
   }
 }
 
-int RPNProposalSSDPlugin::enqueue(int batchSize, const void *const *inputs,
-                                  void **outputs, void *workspace,
-                                  cudaStream_t stream) {
+int32_t RPNProposalSSDPlugin::enqueue(int32_t batchSize,
+                                      const void *const *inputs,
+                                      void *const *outputs, void *workspace,
+                                      cudaStream_t stream) noexcept {
   // dimsNCHW: [N, 2 * num_anchor_per_point, H, W]
   const float *rpn_cls_prob_reshape =
       reinterpret_cast<const float *>(inputs[0]);

--- a/modules/perception/inference/tensorrt/plugins/rpn_proposal_ssd_plugin.h
+++ b/modules/perception/inference/tensorrt/plugins/rpn_proposal_ssd_plugin.h
@@ -27,7 +27,7 @@ namespace inference {
 // TODO(chenjiahao): complete member functions
 // Custom layer for RPNProposalSSD operation, i.e.
 // anchor generation and nms filtering
-class RPNProposalSSDPlugin : public nvinfer1::IPlugin {
+class RPNProposalSSDPlugin : public nvinfer1::IPluginV2 {
  public:
   RPNProposalSSDPlugin(
       const BBoxRegParameter &bbox_reg_param,
@@ -71,32 +71,63 @@ class RPNProposalSSDPlugin : public nvinfer1::IPlugin {
 
   virtual ~RPNProposalSSDPlugin() {}
 
-  virtual int initialize() { return 0; }
-  virtual void terminate() {}
-  int getNbOutputs() const override { return 1; }
+  int32_t initialize() noexcept override { return 0; }
+  void terminate() noexcept override {}
+  int32_t getNbOutputs() const noexcept override { return 1; }
 
-  nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
-                                     int nbInputDims) override {
+  nvinfer1::Dims getOutputDimensions(int32_t index,
+                                     const nvinfer1::Dims *inputs,
+                                     int32_t nbInputDims) noexcept override {
     // TODO(chenjiahao): complete inputs dims assertion
     // TODO(chenjiahao): batch size is hard coded to 1 here
     return nvinfer1::Dims4(top_n_ * 1, 5, 1, 1);
   }
 
-  void configure(const nvinfer1::Dims *inputDims, int nbInputs,
-                 const nvinfer1::Dims *outputDims, int nbOutputs,
-                 int maxBatchSize) override {}
+  void configureWithFormat(const nvinfer1::Dims *inputDims, int32_t nbInputs,
+                           const nvinfer1::Dims *outputDims, int32_t nbOutputs,
+                           nvinfer1::DataType type,
+                           nvinfer1::PluginFormat format,
+                           int32_t maxBatchSize) noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int32_t maxBatchSize) const noexcept override {
+    return 0;
+  }
 
-  virtual int enqueue(int batchSize, const void *const *inputs, void **outputs,
-                      void *workspace, cudaStream_t stream);
+  int32_t enqueue(int32_t batchSize, const void *const *inputs,
+                  void *const *outputs, void *workspace,
+                  cudaStream_t stream) noexcept override;
 
-  size_t getSerializationSize() override { return 0; }
+  size_t getSerializationSize() const noexcept override { return 0; }
 
-  void serialize(void *buffer) override {
+  void serialize(void *buffer) const noexcept override {
     char *d = reinterpret_cast<char *>(buffer), *a = d;
     size_t size = getSerializationSize();
     CHECK_EQ(d, a + size);
+  }
+
+  IPluginV2 *clone() const noexcept override {
+    return const_cast<RPNProposalSSDPlugin *>(this);
+  }
+
+  void destroy() noexcept override {}
+
+  const nvinfer1::AsciiChar *getPluginNamespace() const noexcept override {
+    return "apollo::perception::inference";
+  }
+
+  const nvinfer1::AsciiChar *getPluginType() const noexcept override {
+    return "default";
+  }
+
+  const nvinfer1::AsciiChar *getPluginVersion() const noexcept override {
+    return "1.0";
+  }
+
+  void setPluginNamespace(const nvinfer1::AsciiChar *) noexcept override {}
+
+  bool supportsFormat(nvinfer1::DataType,
+                      nvinfer1::PluginFormat) const noexcept override {
+    return true;
   }
 
  private:

--- a/modules/perception/inference/tensorrt/plugins/slice_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/slice_plugin.cu
@@ -41,8 +41,9 @@ __global__ void Slice(const int nthreads, const Dtype *in_data,
   }
 }
 
-int SLICEPlugin::enqueue(int batchSize, const void *const *inputs,
-                         void **outputs, void *workspace, cudaStream_t stream) {
+int32_t SLICEPlugin::enqueue(int32_t batchSize, const void *const *inputs,
+                             void *const *outputs, void *workspace,
+                             cudaStream_t stream) noexcept {
   int slice_size = 1;
   for (size_t index = axis_ + 1; index < input_dims_.nbDims; index++) {
     slice_size *= input_dims_.d[index];

--- a/modules/perception/inference/tensorrt/plugins/softmax_plugin.cu
+++ b/modules/perception/inference/tensorrt/plugins/softmax_plugin.cu
@@ -22,9 +22,9 @@ namespace apollo {
 namespace perception {
 namespace inference {
 
-int SoftmaxPlugin::enqueue(int batch_size, const void *const *inputs,
-                           void **outputs, void *workspace,
-                           cudaStream_t stream) {
+int32_t SoftmaxPlugin::enqueue(int32_t batch_size, const void *const *inputs,
+                               void *const *outputs, void *workspace,
+                               cudaStream_t stream) noexcept {
   const float *in_data = reinterpret_cast<const float *>(inputs[0]);
   float *out_data = reinterpret_cast<float *>(outputs[0]);
   int w = 1;

--- a/modules/perception/inference/tensorrt/rt_common.cc
+++ b/modules/perception/inference/tensorrt/rt_common.cc
@@ -24,9 +24,9 @@ namespace apollo {
 namespace perception {
 namespace inference {
 
-nvinfer1::DimsCHW ReshapeDims(const nvinfer1::DimsCHW &dims,
-                              const nvinfer1::DimsCHW &inputDims) {
-  nvinfer1::DimsCHW outDims = inputDims;
+nvinfer1::Dims3 ReshapeDims(const nvinfer1::Dims3 &dims,
+                              const nvinfer1::Dims3 &inputDims) {
+  nvinfer1::Dims3 outDims = inputDims;
   int count = inputDims.d[0] * inputDims.d[1] * inputDims.d[2];
   int constant = 1;
   int axis_inference = -1;
@@ -54,7 +54,7 @@ void ParseNetParam(const NetParameter &net_param,
     if (tensorrt_layer_param.type() == "Input") {
       InputParameter input = tensorrt_layer_param.input_param();
       for (int j = 0; j < tensorrt_layer_param.top().size(); ++j) {
-        nvinfer1::DimsCHW dims{static_cast<int>(input.shape(j).dim(1)),
+        nvinfer1::Dims3 dims{static_cast<int>(input.shape(j).dim(1)),
                                static_cast<int>(input.shape(j).dim(2)),
                                static_cast<int>(input.shape(j).dim(3))};
         auto name = tensorrt_layer_param.top(j);

--- a/modules/perception/inference/tensorrt/rt_common.h
+++ b/modules/perception/inference/tensorrt/rt_common.h
@@ -35,10 +35,10 @@ namespace inference {
 
 typedef std::map<std::string, std::vector<nvinfer1::Weights>> WeightMap;
 typedef std::map<std::string, nvinfer1::ITensor *> TensorMap;
-typedef std::map<std::string, nvinfer1::DimsCHW> TensorDimsMap;
+typedef std::map<std::string, nvinfer1::Dims3> TensorDimsMap;
 
-nvinfer1::DimsCHW ReshapeDims(const nvinfer1::DimsCHW &dims,
-                              const nvinfer1::DimsCHW &inputDims);
+nvinfer1::Dims3 ReshapeDims(const nvinfer1::Dims3 &dims,
+                            const nvinfer1::Dims3 &inputDims);
 void ParseNetParam(const NetParameter &net_param,
                    TensorDimsMap *tensor_dims_map,
                    std::map<std::string, std::string> *tensor_modify_map,
@@ -59,10 +59,10 @@ struct ConvParam {
 
 bool ParserConvParam(const ConvolutionParameter &conv, ConvParam *param);
 
-inline nvinfer1::DimsCHW getCHW(const nvinfer1::Dims &d) {
+inline nvinfer1::Dims3 getCHW(const nvinfer1::Dims &d) {
   assert(d.nbDims >= 3);
-  return nvinfer1::DimsCHW(d.d[d.nbDims - 3], d.d[d.nbDims - 2],
-                           d.d[d.nbDims - 1]);
+  return nvinfer1::Dims3(d.d[d.nbDims - 3], d.d[d.nbDims - 2],
+                         d.d[d.nbDims - 1]);
 }
 
 }  // namespace inference

--- a/modules/perception/inference/tensorrt/rt_common_test.cc
+++ b/modules/perception/inference/tensorrt/rt_common_test.cc
@@ -23,8 +23,8 @@ namespace perception {
 namespace inference {
 
 TEST(RTReshapeDimsTest, test) {
-  nvinfer1::DimsCHW dims;
-  nvinfer1::DimsCHW input_dims;
+  nvinfer1::Dims3 dims;
+  nvinfer1::Dims3 input_dims;
   dims.d[2] = -1;
   dims.d[1] = 0;
   dims.d[0] = 3;

--- a/modules/perception/inference/tensorrt/rt_net.h
+++ b/modules/perception/inference/tensorrt/rt_net.h
@@ -39,7 +39,7 @@ class SoftmaxPlugin;
 
 typedef std::map<std::string, std::vector<nvinfer1::Weights>> WeightMap;
 typedef std::map<std::string, nvinfer1::ITensor *> TensorMap;
-typedef std::map<std::string, nvinfer1::DimsCHW> TensorDimsMap;
+typedef std::map<std::string, nvinfer1::Dims3> TensorDimsMap;
 typedef std::map<std::string, std::string> TensorModifyMap;
 
 const std::map<EltwiseParameter::EltwiseOp, nvinfer1::ElementWiseOperation>
@@ -220,6 +220,7 @@ class RTNet : public Inference {
   bool is_own_calibrator_ = true;
   std::string model_root_;
   nvinfer1::IBuilder *builder_ = nullptr;
+  nvinfer1::IBuilderConfig *config_ = nullptr;
   nvinfer1::INetworkDefinition *network_ = nullptr;
   std::vector<std::shared_ptr<float>> weights_mem_;
   BlobMap blobs_;

--- a/modules/perception/lidar/lib/detector/point_pillars_detection/point_pillars.h
+++ b/modules/perception/lidar/lib/detector/point_pillars_detection/point_pillars.h
@@ -74,7 +74,7 @@ class Logger : public nvinfer1::ILogger {
   explicit Logger(Severity severity = Severity::kWARNING)
       : reportable_severity(severity) {}
 
-  void log(Severity severity, const char* msg) override {
+  void log(Severity severity, const char* msg) noexcept override {
     // suppress messages with severity enum value greater than the reportable
     if (severity > reportable_severity) return;
 

--- a/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/BUILD
+++ b/modules/perception/lidar/lib/ground_detector/spatio_temporal_ground_detector/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//tools:cpplint.bzl", "cpplint")
+load("//tools/platform:build_defs.bzl", "if_x86_64")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,7 +8,7 @@ cc_library(
     name = "spatio_temporal_ground_detector",
     srcs = ["spatio_temporal_ground_detector.cc"],
     hdrs = ["spatio_temporal_ground_detector.h"],
-    copts = ["-msse4.1"],
+    copts = if_x86_64(["-msse4.1"]),
     deps = [
         "//cyber",
         "//modules/perception/base",


### PR DESCRIPTION
These changes make possible to run apollo on Jetson Xavier AGX with Jetson r32.6.

1. Use of tensorrt api updated according to changes at tensorrt 8.2.
Biggest changes are switch IPlugin -> IPluginV2, DimsNCHW -> Dims4, DimsCHW -> Dims3
See [1](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-723/api/c_api/classnvinfer1_1_1_i_plugin.html), [2](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_plugin_v2.html).
2. Little arch conditionals addition to make it compile on aarch64 like remove SSE opt, add `#ifdef __aarch64__`, and include to build inside conditional `if_x86_64()`.