### PR TITLE
correct jerk boundary estimate in planning module

### DIFF
--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.cc
@@ -166,7 +166,7 @@ common::Status PiecewiseJerkPathOptimizer::Process(
     }
 
     bool res_opt = OptimizePath(
-        init_frenet_state.second, end_state, std::move(path_reference_l),
+        init_frenet_state, end_state, std::move(path_reference_l),
         path_reference_size, path_boundary.delta_s(), is_valid_path_reference,
         path_boundary.boundary(), ddl_bounds, w, max_iter, &opt_l, &opt_dl,
         &opt_ddl);
@@ -233,7 +233,7 @@ PiecewiseJerkPathOptimizer::ConvertPathPointRefFromFrontAxeToRearAxe(
 }
 
 bool PiecewiseJerkPathOptimizer::OptimizePath(
-    const std::array<double, 3>& init_state,
+    const std::pair<std::array<double, 3>, std::array<double, 3>>& init_state,
     const std::array<double, 3>& end_state,
     std::vector<double> path_reference_l_ref, const size_t path_reference_size,
     const double delta_s, const bool is_valid_path_reference,
@@ -244,7 +244,7 @@ bool PiecewiseJerkPathOptimizer::OptimizePath(
   // num of knots
   const size_t kNumKnots = lat_boundaries.size();
   PiecewiseJerkPathProblem piecewise_jerk_problem(kNumKnots, delta_s,
-                                                  init_state);
+                                                  init_state.second);
 
   // TODO(Hongyi): update end_state settings
   piecewise_jerk_problem.set_end_state_ref({1000.0, 0.0, 0.0}, end_state);
@@ -303,7 +303,7 @@ bool PiecewiseJerkPathOptimizer::OptimizePath(
   const double axis_distance = veh_param.wheel_base();
   const double max_yaw_rate =
       veh_param.max_steer_angle_rate() / veh_param.steer_ratio() / 2.0;
-  const double jerk_bound = EstimateJerkBoundary(std::fmax(init_state[1], 1.0),
+  const double jerk_bound = EstimateJerkBoundary(std::fmax(init_state.first[1], 1.0),
                                                  axis_distance, max_yaw_rate);
   piecewise_jerk_problem.set_dddx_bound(jerk_bound);
 

--- a/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.h
+++ b/modules/planning/tasks/optimizers/piecewise_jerk_path/piecewise_jerk_path_optimizer.h
@@ -70,7 +70,7 @@ class PiecewiseJerkPathOptimizer : public PathOptimizer {
    * @return false
    */
   bool OptimizePath(
-      const std::array<double, 3>& init_state,
+      const std::pair<std::array<double, 3>, std::array<double, 3>>& init_state,
       const std::array<double, 3>& end_state,
       std::vector<double> path_reference_l_ref,
       const size_t path_reference_size, const double delta_s,


### PR DESCRIPTION
Planning: replace the first input of EstimateJerkBoundary, from dl/ds to ds/dt.

this fix refers to the issue [EstimateJerkBoundary input value error #14208
](https://github.com/ApolloAuto/apollo/issues/14208)
