### PR TITLE
fix fd leak in RecordFileReader

### DIFF
--- a/cyber/record/file/record_file_reader.cc
+++ b/cyber/record/file/record_file_reader.cc
@@ -45,7 +45,12 @@ bool RecordFileReader::Open(const std::string& path) {
   return true;
 }
 
-void RecordFileReader::Close() { close(fd_); }
+void RecordFileReader::Close() {
+  if (fd_ >= 0) {
+    close(fd_);
+    fd_ = -1;
+  }
+}
 
 bool RecordFileReader::Reset() {
   if (!SetPosition(sizeof(struct Section) + HEADER_LENGTH)) {
@@ -140,6 +145,10 @@ bool RecordFileReader::SkipSection(int64_t size) {
     return false;
   }
   return true;
+}
+
+RecordFileReader::~RecordFileReader() {
+  Close();
 }
 
 }  // namespace record

--- a/cyber/record/file/record_file_reader.h
+++ b/cyber/record/file/record_file_reader.h
@@ -45,7 +45,7 @@ using google::protobuf::io::ZeroCopyInputStream;
 class RecordFileReader : public RecordFileBase {
  public:
   RecordFileReader() = default;
-  virtual ~RecordFileReader() = default;
+  virtual ~RecordFileReader();
   bool Open(const std::string& path) override;
   void Close() override;
   bool Reset();


### PR DESCRIPTION
RecordFileReader doesn't automatically close underlying fd on destructing, this will cause a fd leak.