### PR TITLE
[BUILD] update rules_proto for arm build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,11 +24,11 @@ versions.check(minimum_bazel_version = "3.7.0")
 
 http_archive(
     name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+    strip_prefix = "rules_proto-4.0.0",
     urls = [
-        "https://apollo-system.cdn.bcebos.com/archive/6.0/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
when starting arm build, the following error occurs
```
(10:14:38) INFO: Repository zlib instantiated at:
  /github/apollo/WORKSPACE:37:25: in <toplevel>
  /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/rules_proto/proto/repositories.bzl:23:21: in rules_proto_dependencies
Repository rule http_archive defined at:
  /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
(10:14:38) WARNING: Download from https://zlib.net/zlib-1.2.11.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 97d68927eb038640a8b02434a83ff6818d420bda2a5170efca38a2d1bc78fc1c but wanted c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
(10:14:38) ERROR: An error occurred during the fetch of repository 'zlib':
   Traceback (most recent call last):
	File "/github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://zlib.net/zlib-1.2.11.tar.gz] to /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/zlib/temp1170[256](https://github.com/xixioba/mirror-bitbucket-omnisense/runs/5317100243?check_suite_focus=true#step:4:256)05[273](https://github.com/xixioba/mirror-bitbucket-omnisense/runs/5317100243?check_suite_focus=true#step:4:273)69557736/zlib-1.2.11.tar.gz: Checksum was 97d68927eb038640a8b02434a83ff6818d420bda2a5170efca38a2d1bc78fc1c but wanted c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
(10:14:38) INFO: Repository com_google_absl instantiated at:
  /github/apollo/WORKSPACE:6:20: in <toplevel>
  /github/apollo/tools/workspace.bzl:89:27: in apollo_repositories
  /github/apollo/tools/workspace.bzl:46:9: in initialize_third_party
  /github/apollo/third_party/absl/workspace.bzl:6:17: in repo
Repository rule http_archive defined at:
  /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
(10:14:38) INFO: Repository eigen instantiated at:
  /github/apollo/WORKSPACE:6:20: in <toplevel>
  /github/apollo/tools/workspace.bzl:89:27: in apollo_repositories
  /github/apollo/tools/workspace.bzl:55:10: in initialize_third_party
  /github/apollo/third_party/eigen3/workspace.bzl:11:17: in repo
Repository rule http_archive defined at:
  /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
(10:14:38) INFO: Repository com_github_jbeder_yaml_cpp instantiated at:
  /github/apollo/WORKSPACE:6:20: in <toplevel>
  /github/apollo/tools/workspace.bzl:89:27: in apollo_repositories
  /github/apollo/tools/workspace.bzl:79:13: in initialize_third_party
  /github/apollo/third_party/yaml_cpp/workspace.bzl:11:17: in repo
Repository rule http_archive defined at:
  /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
(10:14:38) ERROR: /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/com_google_protobuf/BUILD:210:11: @com_google_protobuf//:protobuf depends on @zlib//:zlib in repository @zlib which failed to fetch. no such package '@zlib//': java.io.IOException: Error downloading [https://zlib.net/zlib-1.2.11.tar.gz] to /github/apollo/.cache/bazel/feda08f968dc018e7ae44a2f4374273a/external/zlib/temp11702560527369557736/zlib-1.2.11.tar.gz: Checksum was 97d68927eb038640a8b02434a83ff6818d420bda2a5170efca38a2d1bc78fc1c but wanted c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
```
After this [issue](https://github.com/ApolloAuto/apollo/issues/14313#issuecomment-1046642440) is discussed and tested, no more errors occur