### PR TITLE
[cyber] refactoy func LoadLibrary

### DIFF
--- a/cyber/class_loader/class_loader_manager.cc
+++ b/cyber/class_loader/class_loader_manager.cc
@@ -59,7 +59,7 @@ bool ClassLoaderManager::LoadLibrary(const std::string& library_path) {
     libpath_loader_map_[library_path] =
         new class_loader::ClassLoader(library_path);
   }
-  return IsLibraryValid(library_path);
+  return true;
 }
 
 int ClassLoaderManager::UnloadLibrary(const std::string& library_path) {


### PR DESCRIPTION
this func must will set the key,  why not just return 'true'  ?