### PR TITLE
Fix missing reader /apollo/prediction/adccontainer in prediction_lego.dag

### DIFF
--- a/modules/prediction/dag/prediction_lego.dag
+++ b/modules/prediction/dag/prediction_lego.dag
@@ -26,6 +26,12 @@ module_config {
             flag_file_path: "/apollo/modules/prediction/conf/prediction.conf"
             readers: [
                 {
+                    channel:"/apollo/prediction/adccontainer"
+                    qos_profile: {
+                        depth : 1
+                    }
+                },
+                {
                     channel:"/apollo/prediction/container"
                     qos_profile: {
                         depth : 1


### PR DESCRIPTION
Class *EvaluatorSubmodule* should actually take two message *ADCTrajectoryContainer* and *SubmoduleOutput* as input to trigger *Proc()*, but in **prediction_lego.dag** only the channel for the latter is specified in the readers section, missing the "/apollo/prediction/adccontainer" one. 
This leads to failure in launching **prediction_lego.dag**