### PR TITLE
correct start timestamp of planning component (elegant version)

### DIFF
--- a/modules/planning/planning_component.cc
+++ b/modules/planning/planning_component.cc
@@ -187,10 +187,10 @@ bool PlanningComponent::Proc(
 
   ADCTrajectory adc_trajectory_pb;
   planning_base_->RunOnce(local_view_, &adc_trajectory_pb);
+  auto start_time = adc_trajectory_pb.header().timestamp_sec();
   common::util::FillHeader(node_->Name(), &adc_trajectory_pb);
 
   // modify trajectory relative time due to the timestamp change in header
-  auto start_time = adc_trajectory_pb.header().timestamp_sec();
   const double dt = start_time - adc_trajectory_pb.header().timestamp_sec();
   for (auto& p : *adc_trajectory_pb.mutable_trajectory_point()) {
     p.set_relative_time(p.relative_time() + dt);


### PR DESCRIPTION
planning start timestamp is supposed to be caught before  `common::util::FillHeader`