### PR TITLE
Navi Planning: update vehicle states before the InitFrame

### DIFF
--- a/modules/planning/navi_planning.cc
+++ b/modules/planning/navi_planning.cc
@@ -199,6 +199,7 @@ void NaviPlanning::RunOnce(const LocalView& local_view,
       FLAGS_trajectory_stitching_preserved_length, true,
       last_publishable_trajectory_.get(), &replan_reason);
 
+  injector_->ego_info()->Update(stitching_trajectory.back(), vehicle_state);
   const uint32_t frame_num = static_cast<uint32_t>(seq_num_++);
   status = InitFrame(frame_num, stitching_trajectory.back(), vehicle_state);
 
@@ -212,8 +213,6 @@ void NaviPlanning::RunOnce(const LocalView& local_view,
     FillPlanningPb(start_timestamp, trajectory_pb);
     return;
   }
-
-  injector_->ego_info()->Update(stitching_trajectory.back(), vehicle_state);
 
   if (FLAGS_enable_record_debug) {
     frame_->RecordInputDebug(trajectory_pb->mutable_debug());


### PR DESCRIPTION
It may cause an error if not know the current vehicle states before getting the reference line in the InitFrame method