### PR TITLE
Cyber: fixed a bug for TimerComponent.

### DIFF
--- a/cyber/component/timer_component.cc
+++ b/cyber/component/timer_component.cc
@@ -45,7 +45,7 @@ bool TimerComponent::Initialize(const TimerComponentConfig& config) {
 
   std::shared_ptr<TimerComponent> self =
       std::dynamic_pointer_cast<TimerComponent>(shared_from_this());
-  auto func = [self]() { self->Proc(); };
+  auto func = [self]() { self->Process(); };
   timer_.reset(new Timer(config.interval(), func, false));
   timer_->Start();
   return true;


### PR DESCRIPTION
The old message callback handler for TimerComponent didn't take the termination condition into account. It is fixed now.