### PR TITLE
planning osqp P matrix is incorrectly formated

### DIFF
--- a/modules/planning/math/piecewise_jerk/piecewise_jerk_path_problem.cc
+++ b/modules/planning/math/piecewise_jerk/piecewise_jerk_path_problem.cc
@@ -67,6 +67,16 @@ void PiecewiseJerkPathProblem::CalculateKernel(std::vector<c_float>* P_data,
                               (weight_ddx_ + weight_dddx_ / delta_s_square) /
                                   (scale_factor_[2] * scale_factor_[2]));
   ++value_index;
+
+  // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
+  // OSQP needs only the elements in its upper triangle
+  for (int i = 1; i < n; ++i) {
+    columns[2 * n + i].emplace_back(2 * n + i - 1,
+                                    (-1.0 * weight_dddx_ / delta_s_square) /
+                                        (scale_factor_[2] * scale_factor_[2]));
+    ++value_index;
+  }
+
   for (int i = 1; i < n - 1; ++i) {
     columns[2 * n + i].emplace_back(
         2 * n + i, (weight_ddx_ + 2.0 * weight_dddx_ / delta_s_square) /
@@ -78,14 +88,6 @@ void PiecewiseJerkPathProblem::CalculateKernel(std::vector<c_float>* P_data,
       (weight_ddx_ + weight_dddx_ / delta_s_square + weight_end_state_[2]) /
           (scale_factor_[2] * scale_factor_[2]));
   ++value_index;
-
-  // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
-  for (int i = 0; i < n - 1; ++i) {
-    columns[2 * n + i].emplace_back(2 * n + i + 1,
-                                    (-2.0 * weight_dddx_ / delta_s_square) /
-                                        (scale_factor_[2] * scale_factor_[2]));
-    ++value_index;
-  }
 
   CHECK_EQ(value_index, num_of_nonzeros);
 

--- a/modules/planning/math/piecewise_jerk/piecewise_jerk_speed_problem.cc
+++ b/modules/planning/math/piecewise_jerk/piecewise_jerk_speed_problem.cc
@@ -82,6 +82,14 @@ void PiecewiseJerkSpeedProblem::CalculateKernel(std::vector<c_float>* P_data,
                                   (scale_factor_[2] * scale_factor_[2]));
   ++value_index;
 
+  // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
+  for (int i = 1; i < n; ++i) {
+    columns[2 * n + i].emplace_back(2 * n + i - 1,
+                                    -1.0 * weight_dddx_ / delta_s_square /
+                                        (scale_factor_[2] * scale_factor_[2]));
+    ++value_index;
+  }
+
   for (int i = 1; i < n - 1; ++i) {
     columns[2 * n + i].emplace_back(
         2 * n + i, (weight_ddx_ + 2.0 * weight_dddx_ / delta_s_square) /
@@ -94,14 +102,6 @@ void PiecewiseJerkSpeedProblem::CalculateKernel(std::vector<c_float>* P_data,
       (weight_ddx_ + weight_dddx_ / delta_s_square + weight_end_state_[2]) /
           (scale_factor_[2] * scale_factor_[2]));
   ++value_index;
-
-  // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
-  for (int i = 0; i < n - 1; ++i) {
-    columns[2 * n + i].emplace_back(2 * n + i + 1,
-                                    -2.0 * weight_dddx_ / delta_s_square /
-                                        (scale_factor_[2] * scale_factor_[2]));
-    ++value_index;
-  }
 
   CHECK_EQ(value_index, kNumValue);
 


### PR DESCRIPTION
OSQP needs only the elements in its upper triangle part for the P matrix