### PR TITLE
Fix perception.velocity direction bug and perception frequency bug

### DIFF
--- a/modules/tools/perception/replay_perception.py
+++ b/modules/tools/perception/replay_perception.py
@@ -231,7 +231,7 @@ def linear_project_perception(description, prev_perception):
                 get_point(trace[i - 1], trace[i], ratio))
             perception.theta = math.atan2(trace[i][1] - trace[i - 1][1],
                                           trace[i][0] - trace[i - 1][0])
-
+            perception.velocity.CopyFrom(get_velocity(perception.theta, description["speed"]))
             perception.ClearField("polygon_point")
             perception.polygon_point.extend(generate_polygon(perception.position, perception.theta,
                                                              perception.length, perception.width))

--- a/modules/tools/perception/replay_perception.py
+++ b/modules/tools/perception/replay_perception.py
@@ -272,9 +272,9 @@ def perception_publisher(perception_channel, files, period):
     node = cyber.Node("perception")
     writer = node.create_writer(perception_channel, PerceptionObstacles)
     perception_description = load_descrptions(files)
-    sleep_time = int(1.0 / period)  # 10Hz
+    sleep_time = float(period)  # 10Hz
     global _s_delta_t
-    _s_delta_t = period
+    _s_delta_t = sleep_time
     perception = None
     while not cyber.is_shutdown():
         perception = generate_perception(perception_description, perception)


### PR DESCRIPTION
When using the _garage_perception.bash_ script to register the obstacles, the green arrow of obstacle velocity direction doesn't change in the Dreamview because the `perception.velocity` is not updated in the `linear_project_perception` function. Here we add a line of code to update the `perception.velocity`.