### PR TITLE
make Rate run in Hz when its argument is a float

### DIFF
--- a/cyber/python/cyber_py3/cyber_time.py
+++ b/cyber/python/cyber_py3/cyber_time.py
@@ -216,7 +216,7 @@ class Rate(object):
         if isinstance(other, int):
             self.rate_ = _CYBER_TIME.new_PyRate(other)
         elif isinstance(other, float):
-            self.rate_ = _CYBER_TIME.new_PyRate(int(1.0 / other))
+            self.rate_ = _CYBER_TIME.new_PyRate(int(1e9 / other))
         elif isinstance(other, Duration):
             self.rate_ = _CYBER_TIME.new_PyRate(other.to_nsec())
 


### PR DESCRIPTION
The Rate API controls the time interval, and it's unit should be Hz when a float argument is received. But in python API, it seems that its rate is in unit of cycle/nanosecond, which can be solved by a factor of 1e9. 