### PR TITLE
Fix/roi decider/check boundary heading change

### DIFF
--- a/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.cc
+++ b/modules/planning/tasks/deciders/open_space_decider/open_space_roi_decider.cc
@@ -546,8 +546,10 @@ void OpenSpaceRoiDecider::GetRoadBoundary(
         std::abs(common::math::NormalizeAngle(check_point_heading -
                                               last_check_point_heading)) >
         config_.open_space_roi_decider_config().roi_line_segment_min_angle();
-    last_check_point_heading = check_point_heading;
-
+    if (is_center_lane_heading_change) {
+      last_check_point_heading = check_point_heading;
+    }
+    
     ADEBUG << "is is_center_lane_heading_change: "
            << is_center_lane_heading_change;
     // Check if the current center-lane checking-point is start point || end


### PR DESCRIPTION
fix bug: 
if  VALET_PARKING and PARK_AND_GO nearby curved lane, we decide  * is_center_lane_heading_change * by compute angle diff between  a point and its last point, if the angle diff is small than *config_.open_space_roi_decider_config().roi_line_segment_min_angle()*, much point will be dropped. 

so 
```c++
    bool is_center_lane_heading_change =
        std::abs(common::math::NormalizeAngle(check_point_heading -
                                              last_check_point_heading)) >
        config_.open_space_roi_decider_config().roi_line_segment_min_angle();

   last_check_point_heading = check_point_heading;
```
should be changed to 
```c++
    bool is_center_lane_heading_change =
        std::abs(common::math::NormalizeAngle(check_point_heading -
                                              last_check_point_heading)) >
        config_.open_space_roi_decider_config().roi_line_segment_min_angle();
    if (is_center_lane_heading_change) {
      last_check_point_heading = check_point_heading;
    }
```
