### PR TITLE
change P to upper triangular for OSQP

### DIFF
--- a/modules/planning/math/piecewise_jerk/piecewise_jerk_speed_problem.cc
+++ b/modules/planning/math/piecewise_jerk/piecewise_jerk_speed_problem.cc
@@ -97,8 +97,8 @@ void PiecewiseJerkSpeedProblem::CalculateKernel(std::vector<c_float>* P_data,
 
   // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
   for (int i = 0; i < n - 1; ++i) {
-    columns[2 * n + i].emplace_back(2 * n + i + 1,
-                                    -2.0 * weight_dddx_ / delta_s_square /
+    columns[2 * n + i + 1].emplace_back(2 * n + i,
+                                    -1.0 * weight_dddx_ / delta_s_square /
                                         (scale_factor_[2] * scale_factor_[2]));
     ++value_index;
   }


### PR DESCRIPTION
 The OSQP solver requires that P is a symmetric matrix in order for it to function, and before it was just silently dropping the lower triangular portion of P and reflecting the upper triangular portion into the lower triangular portion to make a symmetric matrix - so if you were providing a non-symmetric P matrix in 0.4, it was actually not solving the problem you were expecting but instead a different one. This is now fixed in 0.6, so the solver will always solve the problem you are providing because it no longer drops part of the P matrix with no warning.