### PR TITLE
Fix 'A protocol message was rejected because it was too big' error when reading a large record file

### DIFF
--- a/cyber/record/file/record_file_reader.h
+++ b/cyber/record/file/record_file_reader.h
@@ -70,6 +70,7 @@ bool RecordFileReader::ReadSection(int64_t size, T* message) {
   }
   FileInputStream raw_input(fd_, static_cast<int>(size));
   CodedInputStream coded_input(&raw_input);
+  coded_input.SetTotalBytesLimit(size, size);
   CodedInputStream::Limit limit = coded_input.PushLimit(static_cast<int>(size));
   if (!message->ParseFromCodedStream(&coded_input)) {
     AERROR << "Parse section message failed.";


### PR DESCRIPTION
The following error happens when reading a large record file:

[libprotobuf ERROR google/protobuf/io/coded_stream.cc:207] A protocol message was rejected because it was too big (more than 67108864 bytes).  To increase the limit (or to disable these warnings), see CodedInputStream::SetTotalBytesLimit() in google/protobuf/io/coded_stream.h.
E0315 13:39:47.062335 19757 record_file_reader.h:80] []Parse section message failed.
E0315 13:39:47.070521 19757 record_reader.cc:159] []Failed to read chunk body section.

This fixes the issue.