### PR TITLE
Inclusion of functionality from an untrusted source

### DIFF
--- a/modules/tools/mobileye_viewer/location_monitor.html
+++ b/modules/tools/mobileye_viewer/location_monitor.html
@@ -4,9 +4,9 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <title>Google Maps - pygmaps </title>
     <script type="text/javascript"
-            src="http://maps.google.com/maps/api/js?sensor=false"></script>
+            src="https://maps.google.com/maps/api/js?sensor=false"></script>
     <script type="text/javascript"
-            src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+            src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
     <script type="text/javascript">
 
         var symbolCar = {


### PR DESCRIPTION
Using an untrusted channel may allow an attacker to include arbitrary code in the response.  
When including external resources, it is possible to verify that the responding server is the intended one by using an https URL.  This prevents a MITM (man-in-the-middle) attack where an attacker might have been able to spoof a server response.