### PR TITLE
fix:fix fprintf parameter count mismatch

### DIFF
--- a/modules/control/controller/lon_controller.cc
+++ b/modules/control/controller/lon_controller.cc
@@ -386,7 +386,7 @@ Status LonController::ComputeControlCommand(
   if (FLAGS_enable_csv_debug && speed_log_file_ != nullptr) {
     fprintf(speed_log_file_,
             "%.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f,"
-            "%.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %d,\r\n",
+            "%.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %d,\r\n",
             debug->station_reference(), debug->station_error(),
             station_error_limited, debug->preview_station_error(),
             debug->speed_reference(), debug->speed_error(),


### PR DESCRIPTION
The fprintf call in the function was passing 19 arguments but the format string only had placeholders for 18 arguments. This could result in undefined behavior or a crash. This commit fixes the issue by adding a missing placeholder for the 19th argument.