### PR TITLE
fix: adjusted the bazel building job count to 80% of the $(nproc)

### DIFF
--- a/scripts/apollo_base.sh
+++ b/scripts/apollo_base.sh
@@ -676,7 +676,7 @@ function run_bazel() {
 
   local sp="    "
   local spaces="    "
-  local count=$(nproc)
+  local count=$(echo "scale=0; ($(nproc) * 0.8) / 1" | bc)
   if [ "$1" == "Coverage" ]; then
     count="$(($(nproc) / 2))"
     spaces="       "


### PR DESCRIPTION
Hello, while attempting to build Apollo on my Ubuntu 22, I encountered numerous build failures due to an error similar to the one described in [issue 14478](https://github.com/ApolloAuto/apollo/issues/14478). After following the guidance provided in the discussion and making several adjustments, I discovered that using 80% of the total $(nproc) as the number of jobs in Bazel building yields better results. This approach maintains a relatively fast build process and prevents the exhaustion of CPU resources, except in extreme cases.