### PR TITLE
fix: fixed frontend hotstart issue and dreamview_sidebar overflow issue

### DIFF
--- a/modules/dreamview/frontend/package.json
+++ b/modules/dreamview/frontend/package.json
@@ -97,6 +97,7 @@
     "webpack-dev-server": "^4.9.2",
     "worker-loader": "^3.0.8",
     "yaml-loader": "^0.8.0",
+    "yaml": "2.0.1",
     "favicons": "6.2.2"
   },
   "resolutions": {

--- a/modules/dreamview/frontend/src/styles/main.scss
+++ b/modules/dreamview/frontend/src/styles/main.scss
@@ -518,6 +518,7 @@ body {
       overflow-x: hidden;
       overflow-y: auto;
       height: 89%;
+      padding-bottom: 40px;
     }
   }
 


### PR DESCRIPTION
Hello, I have identified two issues that may impact the testing and usability of Dreamview.

1. While using 'npm install' and 'npm start' for warm booting the frontend, there is an issue caused by Webpack, which is identical to the problem mentioned in https://github.com/eemeli/yaml/issues/394. This can be resolved by specifying the yarn version to be 2.0.1 in the package.json file.

2. When users click on the layer menu under the sim control mode, the bottom of the perception and map menu may not be displayed due to CSS-related issues. I have introduced additional padding to accommodate screen size variations. The attached images demonstrate the differences before and after implementing the changes.
Before change:
![before changing](https://github.com/ApolloAuto/apollo/assets/42943196/8e847914-e3aa-43fc-a400-92b7e9204818)
After change:
![after changing](https://github.com/ApolloAuto/apollo/assets/42943196/6dc4d5ee-0283-4e6a-9cec-99d092dfc8ab)