### PR TITLE
fix(tools): added missing line in manual traffic light build file

### DIFF
--- a/modules/tools/manual_traffic_light/BUILD
+++ b/modules/tools/manual_traffic_light/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "//modules/map/hdmap:hdmap_util",
         "//modules/common_msgs/perception_msgs:traffic_light_detection_cc_proto",
     ],
+    alwayslink = True,
 )
 
 cc_binary(


### PR DESCRIPTION
Discussed in https://github.com/ApolloAuto/apollo/issues/14860#issuecomment-1487860852
The original comment suggested this was going to be added ASAP but no PR has been opened yet.

Line `alwayslink = True,` is missing from `modules/tools/manual_traffic_light/BUILD`, causing manual traffic control launch failure. 

```
[manual_traffic_light]  E0328 10:10:54.422791  1467 class_loader_manager.h:70] [mainboard]Invalid class name: ManualTrafficLight
[manual_traffic_light]  E0328 10:10:54.422816  1467 module_controller.cc:67] [mainboard]Failed to load module: /apollo/modules/tools/manual_traffic_light/manual_traffic_light.dag
[manual_traffic_light]  E0328 10:10:54.422824  1467 mainboard.cc:39] [mainboard]module start error.
[manual_traffic_light]  
[cyber_launch_1460] ERROR Process [manual_traffic_light] has died [pid 1467, exit code 255, cmd mainboard -d /apollo/modules/tools/manual_traffic_light/manual_traffic_light.dag -p manual_traffic_light -s CYBER_DEFAULT].
```