### PR TITLE
remove unnecessary vector in class_loader_utility

### DIFF
--- a/cyber/class_loader/utility/class_loader_utility.cc
+++ b/cyber/class_loader/utility/class_loader_utility.cc
@@ -179,14 +179,13 @@ bool IsLibraryLoaded(const std::string& library_path,
     return true;
   }
 
-  ClassFactoryVector lib_loader_class_factory_objs;
+  size_t num_lib_loader_class_factory_objs = 0;
   for (auto& class_factory_obj : lib_class_factory_objs) {
     if (class_factory_obj->IsOwnedBy(class_loader)) {
-      lib_loader_class_factory_objs.emplace_back(class_factory_obj);
+      ++num_lib_loader_class_factory_objs;
     }
   }
 
-  auto num_lib_loader_class_factory_objs = lib_loader_class_factory_objs.size();
   return (is_lib_loaded_by_anyone &&
           (num_lib_loader_class_factory_objs <= num_lib_class_factory_objs));
 }


### PR DESCRIPTION
hi, I am currently looking the implementation of the class_loader, it seems there's no need to allocate a vector and get the size.