### PR TITLE
Prediction Bug [fixed]

### DIFF
--- a/modules/prediction/evaluator/vehicle/jointly_prediction_planning_evaluator.cc
+++ b/modules/prediction/evaluator/vehicle/jointly_prediction_planning_evaluator.cc
@@ -325,7 +325,7 @@ bool JointlyPredictionPlanningEvaluator::Evaluate(
   torch::Tensor adc_trajectory = torch::zeros({1, 30, 6});
   const auto& adc_traj = adc_trajectory_container->adc_trajectory();
   size_t adc_traj_points_num = adc_traj.trajectory_point().size();
-  if (adc_traj_points_num < 1) {
+  if (adc_traj_points_num < 2) {
     AERROR << "adc_traj points num is " << adc_traj_points_num
            << " adc traj points are not enough";
     return false;


### PR DESCRIPTION
**Describe the bug**

While testing, we found that the prediction module sometimes crashed due to out-of-range access. The log of the prediction module is as follows.
![111](https://github.com/ApolloAuto/apollo/assets/87695978/dff84054-307a-40d2-815d-c99f1fe2146b)


**System information**

OS Platform and Distribution: Ubuntu 18.04

Apollo installed from (source or binary): source

Apollo version : master (master branch -commit e373b20）

**To Reproduce**

The cyber record link: https://drive.google.com/file/d/1fgo5Tz2XXT8VTuH2FazXTdXe-lRcLSWn/view?usp=sharing 

**Additional context**

We found that the crash occurred in function `JointlyPredictionPlanningEvaluator::ExtractADCTrajectory`.

When the size of the input `trajectory_points` is 0, when accessing the `trajectory_points- >at(i).path_point().x()` **at line 547** (the i is 0), an out_of_range error occurs and causes a crash.
![222](https://github.com/ApolloAuto/apollo/assets/87695978/01c682ab-97e3-4cb6-b877-78de6d4a14bd)
Further, we found that the `JointlyPredictionPlanningEvaluator::Evaluate` function incorrectly called `ExtractADCTrajectory`, which caused the crash. When the size of `adc_traj.trajectory_point()` is 1, the judgment **on line 328** can be passed, but the size of `adc_traj_curr_pos` will be 0, causing the above crash. 

**Solution**
Therefore, we recommend setting the threshold for judgment **on line 328** to 2. This modification can avoid the above errors and will not affect the functionality of thisfunction.
![333](https://github.com/ApolloAuto/apollo/assets/87695978/2b6e555c-d54e-4a48-b77a-40ade5d0fc20)
