### PR TITLE
fix: fix the outdated paths of local_tool of msf localization in scripts.

### DIFF
--- a/scripts/msf_local_evaluation.sh
+++ b/scripts/msf_local_evaluation.sh
@@ -32,7 +32,7 @@ ODOMETRY_LOC_FILE="odometry_loc.txt"
 function data_exporter() {
   local BAG_FILE=$1
   local OUT_FOLDER=$2
-  $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/data_extraction/cyber_record_parser \
+  $APOLLO_BIN_PREFIX/modules/localization/msf/cyber_record_parser \
     --bag_file $BAG_FILE \
     --out_folder $OUT_FOLDER \
     --cloud_topic $CLOUD_TOPIC \
@@ -44,20 +44,20 @@ function data_exporter() {
 
 function compare_poses() {
   local IN_FOLDER=$1
-  $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/data_extraction/compare_poses \
+  $APOLLO_BIN_PREFIX/modules/localization/msf/compare_poses \
     --in_folder $IN_FOLDER \
     --loc_file_a $GNSS_LOC_FILE \
     --loc_file_b $ODOMETRY_LOC_FILE \
     --imu_to_ant_offset_file "$ANT_IMU_FILE" \
     --compare_file "compare_gnss_odometry.txt"
 
-  $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/data_extraction/compare_poses \
+  $APOLLO_BIN_PREFIX/modules/localization/msf/compare_poses \
     --in_folder $IN_FOLDER \
     --loc_file_a $LIDAR_LOC_FILE \
     --loc_file_b $ODOMETRY_LOC_FILE \
     --compare_file "compare_lidar_odometry.txt"
 
-  $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/data_extraction/compare_poses \
+  $APOLLO_BIN_PREFIX/modules/localization/msf/compare_poses \
     --in_folder $IN_FOLDER \
     --loc_file_a $FUSION_LOC_FILE \
     --loc_file_b $ODOMETRY_LOC_FILE \

--- a/scripts/msf_local_map_creator.sh
+++ b/scripts/msf_local_map_creator.sh
@@ -9,7 +9,7 @@ cd "${DIR}/.."
 
 source "${DIR}/apollo_base.sh"
 
-$APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/map_creation/lossless_map_creator --use_plane_inliers_only true \
+$APOLLO_BIN_PREFIX/modules/localization/msf/lossless_map_creator --use_plane_inliers_only true \
   --pcd_folders $1 \
   --pose_files $2 \
   --map_folder $4 \
@@ -17,7 +17,7 @@ $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/map_creation/lossless_map
   --coordinate_type UTM \
   --map_resolution_type single
 
-$APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/map_creation/lossless_map_to_lossy_map \
+$APOLLO_BIN_PREFIX/modules/localization/msf/lossless_map_to_lossy_map \
   --srcdir $4/lossless_map \
   --dstdir $4
 

--- a/scripts/msf_offline_local_visualizer.sh
+++ b/scripts/msf_offline_local_visualizer.sh
@@ -9,5 +9,5 @@ cd "${DIR}/.."
 
 source "${DIR}/apollo_base.sh"
 
-$APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/local_visualization/offline_visual/offline_local_visualizer \
+$APOLLO_BIN_PREFIX/modules/localization/msf/offline_local_visualizer \
   --basedir $1

--- a/scripts/msf_poses_interpolation.sh
+++ b/scripts/msf_poses_interpolation.sh
@@ -9,7 +9,7 @@ cd "${DIR}/.."
 
 source "${DIR}/apollo_base.sh"
 
-$APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/map_creation/poses_interpolator \
+$APOLLO_BIN_PREFIX/modules/localization/msf/poses_interpolator \
   --input_poses_path $1 \
   --ref_timestamps_path $2 \
   --extrinsic_path $3 \

--- a/scripts/msf_record_parser.sh
+++ b/scripts/msf_record_parser.sh
@@ -26,7 +26,7 @@ OUT_FOLDER=$2
 function data_exporter() {
   local BAG_FILE=$1
   local OUT_FOLDER=$2
-  $APOLLO_BIN_PREFIX/modules/localization/msf/local_tool/data_extraction/cyber_record_parser \
+  $APOLLO_BIN_PREFIX/modules/localization/msf/cyber_record_parser \
     --bag_file $BAG_FILE \
     --out_folder $OUT_FOLDER \
     --cloud_topic $CLOUD_TOPIC \

--- a/scripts/msf_simple_map_creator.sh
+++ b/scripts/msf_simple_map_creator.sh
@@ -31,7 +31,7 @@ CLOUD_TOPIC="/apollo/sensor/$LIDAR_TYPE/compensator/PointCloud2"
 function data_exporter() {
   local BAG_FILE=$1
   local OUT_FOLDER=$2
-  /apollo/bazel-bin/modules/localization/msf/local_tool/data_extraction/cyber_record_parser \
+  /apollo/bazel-bin/modules/localization/msf/cyber_record_parser \
     --bag_file $BAG_FILE \
     --out_folder $OUT_FOLDER \
     --cloud_topic $CLOUD_TOPIC \
@@ -46,7 +46,7 @@ function poses_interpolation() {
   local REF_TIMESTAMPS_PATH=$2
   local EXTRINSIC_PATH=$3
   local OUTPUT_POSES_PATH=$4
-  /apollo/bazel-bin/modules/localization/msf/local_tool/map_creation/poses_interpolator \
+  /apollo/bazel-bin/modules/localization/msf/poses_interpolator \
     --input_poses_path $INPUT_POSES_PATH \
     --ref_timestamps_path $REF_TIMESTAMPS_PATH \
     --extrinsic_path $EXTRINSIC_PATH \
@@ -54,7 +54,7 @@ function poses_interpolation() {
 }
 
 function create_lossless_map() {
-  /apollo/bazel-bin/modules/localization/msf/local_tool/map_creation/lossless_map_creator \
+  /apollo/bazel-bin/modules/localization/msf/lossless_map_creator \
     --use_plane_inliers_only true \
     --pcd_folders $1 \
     --pose_files $2 \
@@ -65,7 +65,7 @@ function create_lossless_map() {
 }
 
 function create_lossy_map() {
-  /apollo/bazel-bin/modules/localization/msf/local_tool/map_creation/lossless_map_to_lossy_map \
+  /apollo/bazel-bin/modules/localization/msf/lossless_map_to_lossy_map \
     --srcdir $OUT_MAP_FOLDER/lossless_map \
     --dstdir $OUT_MAP_FOLDER
 


### PR DESCRIPTION
The BUILD files under localization/msf has been change since v9.0.0. After the change, the paths of the built local tools (except for online_visualizer) have been changed from `bazel-bin/modules/localization/msf/local_tool/*/*` to `bazel-bin/modules/localization/msf/`. 

This PR fixes the outdated paths in the related scripts

