### PR TITLE
docs: Update path to demo record for cyber_recorder

### DIFF
--- a/docs/01_Installation Instructions/how_to_launch_and_run_apollo.md
+++ b/docs/01_Installation Instructions/how_to_launch_and_run_apollo.md
@@ -63,7 +63,7 @@ cd docs/02_Quick\ Start/demo_guide/
 python3 record_helper.py demo_3.5.record
 
 # You can now replay this demo "record" in a loop with the '-l' flag
-cyber_recorder play -f docs/demo_guide/demo_3.5.record -l
+cyber_recorder play -f docs/02_Quick\ Start/demo_guide/demo_3.5.record -l
 ```
 
 Dreamview should show a running vehicle now. (The following image might be


### PR DESCRIPTION
Follow up on #15312 

The path for the subsequent command in the documentation did not get updated.