### PR TITLE
docs: Add apt update command before installing aem

### DIFF
--- a/docs/03_Package Management/apollo_env_manager.md
+++ b/docs/03_Package Management/apollo_env_manager.md
@@ -17,7 +17,7 @@ $ exit
 Then, use apt to install aem:
 
 ```shell
-$ sudo apt install apollo-neo-env-manager-dev
+$ sudo apt update && sudo apt install apollo-neo-env-manager-dev
 ```
 
 When the installation is completed, you can enter the following command to check whether buildtool has been installed correctly:


### PR DESCRIPTION
If I don't do an `sudo apt update` after adding the repo and key I get this error

```
sudo apt install apollo-neo-env-manager-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package apollo-neo-env-manager-dev
```

Adding `sudo apt update` and then installing `apollo-neo-env-manager-dev` fixes this on my machine.