### PR TITLE
docs: Fix broken link to the prediction predictor module

### DIFF
--- a/docs/03_Package Management/introduction_to_package_of_apollo.md
+++ b/docs/03_Package Management/introduction_to_package_of_apollo.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This article briefly introduces how to develop an Apollo extension module, with a simple example of how to create the project code of an extension module and the role of the necessary files contained in it. It alos explains how to use the buildtool to compile the extension module.
+This article briefly introduces how to develop an Apollo extension module, with a simple example of how to create the project code of an extension module and the role of the necessary files contained in it. It also explains how to use the buildtool to compile the extension module.
 
 To read this article you need a preliminary grasp of
 

--- a/docs/07_Prediction/prediction_predictor.md
+++ b/docs/07_Prediction/prediction_predictor.md
@@ -20,7 +20,7 @@ Here, we mainly introduce three typical predictors，extrapolation predictor, mo
 
 # Where is the code
 
-Please refer [prediction predictor](https://github.com/ApolloAuto/apollo/modules/prediction/predictor).
+Please refer [prediction predictor](../../../apollo/modules/prediction/predictor/).
 
 # Code Reading
 


### PR DESCRIPTION
Fixes broken link on github by providing relative path to implementation of the `predictor` implementation. Relative path is also better so that this works offline and doesn't depend on github.