### PR TITLE
docs: fix document codeblock's indent & language type

### DIFF
--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT入门/Cyber RT 实践之 Hello Apollo.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT入门/Cyber RT 实践之 Hello Apollo.md
@@ -30,15 +30,15 @@ https://apollo.baidu.com/community/course/19
 
 1. 在终端中，执行 DreamView+ 启动指令，执行成功后，点击菜单栏 dreamview+ 按钮，进入 dreamview+ 界面。
 
-   ```bash
-   aem bootstrap start --plus
-   ```
+    ```bash
+    aem bootstrap start --plus
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_1563a05.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_1563a05.png)
 
-   当出现如下，即表示 dreamview+ 启动成功了。
+    当出现如下，即表示 dreamview+ 启动成功了。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_023df8d.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_023df8d.png)
 
 2. 点击左下角 **个人中心** > **设置** > **通用设置** ，可以选择界面语言类型。
 
@@ -76,31 +76,31 @@ https://apollo.baidu.com/community/course/19
 
 1. 打开新的终端窗口，输入配置参数同步指令，系统将自动将 planning 模块的 Traffic_light 配置参数复制到 profile 的 default 目录中：
 
-   ```bash
-   buildtool profile config init --package planning-traffic-rules-traffic-light --profile=default
-   ```
+    ```bash
+    buildtool profile config init --package planning-traffic-rules-traffic-light --profile=default
+    ```
 
-   使用 default 目录这份配置：
+    使用 default 目录这份配置：
 
-   ```bash
+    ```bash
     # 使用名字叫default的这份配置
     aem profile use default
-   ```
+    ```
 
-   查看 profile 插件目录结构：
+    查看 profile 插件目录结构：
 
-   ```bash
-   tree profiles/default/modules/planning/traffic_rules/
-   ```
+    ```bash
+    tree profiles/default/modules/planning/traffic_rules/
+    ```
 
-   目录结构：
+    目录结构：
 
-   ```bash
-   profiles/default/modules/planning/traffic_rules/
-   `-- traffic_light
+    ```bash
+    profiles/default/modules/planning/traffic_rules/
+    `-- traffic_light
     `-- conf
         `-- default_conf.pb.txt
-   ```
+    ```
 
 ### 调整交通灯场景停止距离
 
@@ -112,11 +112,11 @@ https://apollo.baidu.com/community/course/19
 
 2. 在 apollo_workspace 工作目录找到`profiles/default/modules/planning/traffic_rules/traffic_light/conf/default_conf.pb.txt`配置文件，调整红绿灯场景停止配置参数，达到我们期望停车效果。
 
-```bash
- #原始
- stop_distance: 1.0
- #修改后
- stop_distance: 2.2
+```
+#原始
+stop_distance: 1.0
+#修改后
+stop_distance: 2.2
 ```
 
 3. 保存修改后，回到 dreamview+，在 Modules 中重启 Planning 模块（让系统重新加载 Planing 参数)，重新选择红绿灯场景场景，观察主车遇到红灯场景时调整前后停车距离的变化。

--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT组件机制/Cyber RT 之 Component 实践.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT组件机制/Cyber RT 之 Component 实践.md
@@ -20,21 +20,21 @@ https://apollo.baidu.com/community/course/42
 
 1. 使用以下命令解压 TimerCoponent 源码压缩文件
 
-   ```bash
-   tar -zxvf component.tar.gz
-   ```
+    ```bash
+    tar -zxvf component.tar.gz
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_58eeec9.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_58eeec9.png)
 
 2. 使用以下命令编译解压的 TimerComponent 实验源码：
 
-   ```bash
-   buildtool build -p component/timer_component_sensor/
-   ```
+    ```bash
+    buildtool build -p component/timer_component_sensor/
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d222781.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d222781.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_8c56f76.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_8c56f76.png)
 
 3. 修改`timer_component_sensor`配置文件，产生一路新的消息：
 
@@ -51,7 +51,7 @@ sensor_topic:"/sensor/second"
 
 2）新增`timer_component_sensor_second.dag`文件。复制`timer_component_sensor.dag`文件，并重命名为`timer_component_sensor_second.dag`，修改该文件内的配置项。
 
-```bash
+```proto
 module_config {
   module_library : "component/timer_component_sensor/libtimer_component_sensor_component.so"
   timer_components {
@@ -76,7 +76,7 @@ module_config {
 
 3）新增`timer_component_sensor_second.launch`文件，复制`timer_component_sensor.launch`文件，并重命名为`timer_component_sensor_second.launch`，修改该文件内的配置项。
 
-```bash
+```xml
 <cyber>
   <module>
     <name>timer_component_sensor</name>
@@ -92,19 +92,19 @@ module_config {
 
 4. 使用以下命令，运行`timer_component_sensor_second.launch`文件。
 
-   ```bash
-   cyber_launch start component/timer_component_sensor/launch/timer_component_sensor_second.launch
-   ```
+    ```bash
+    cyber_launch start component/timer_component_sensor/launch/timer_component_sensor_second.launch
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_2e0d265.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_2e0d265.png)
 
 5. 使用 cyber_monitor 工具验证，配置是否生效。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_bf22ba3.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_bf22ba3.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d2cf9b1.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d2cf9b1.png)
 
-   若 /sensor/second channel 有数据、数据帧率为 1.25、且数据内容与配置的一致，表示配置成功。
+    若 /sensor/second channel 有数据、数据帧率为 1.25、且数据内容与配置的一致，表示配置成功。
 
 6. 最后，在终端中，使用 **Ctrl+C** 组合键，结束程序运行。
 
@@ -112,24 +112,24 @@ module_config {
 
 1. 在终端中，执行以下指令，在 component 文件夹下生成 component_fusion_message 模板实例（功能包）。
 
-   ```bash
-   buildtool create --template component component/component_fusion_message
-   ```
+    ```bash
+    buildtool create --template component component/component_fusion_message
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d97f121.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d97f121.png)
 
 2. 切换目录到生成的`component_fusion_message`目录下，使用 tree 命令查看生成的 component 功能包的目录结构。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_e5320f8.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_e5320f8.png)
 
-   其中，`BUILD`、`component_fusion_message.cc`和`component_fusion_message.h`三个文件分别为 component_fusion_message 功能包的源码编译规则文件、源文件和头文件；conf 目录下，`component_fusion_message.conf`为全局变量配置文件，`component_fusion_message.pb.txt`为用户在`protobuffer`文件中定义的可配置项的配置文件；`cyberfile.xml`为`component_fusion_message`功能包的描述文件；dag 目录下的`component_fusion_message.dag`文件中描述了`component_fusion_message`功能包的依赖关系；launch 文件夹下的`component_fusion_message.launch`为`component_fusion_message`功能包的 launch 启动文件；proto 文件夹下的 BUILD 为用户在 proto 文件夹下定义的`protobuffer`文件的编译规则文件，`component_fusion_message.proto`文件中用户可以定义自己的消息结构。
+    其中，`BUILD`、`component_fusion_message.cc`和`component_fusion_message.h`三个文件分别为 component_fusion_message 功能包的源码编译规则文件、源文件和头文件；conf 目录下，`component_fusion_message.conf`为全局变量配置文件，`component_fusion_message.pb.txt`为用户在`protobuffer`文件中定义的可配置项的配置文件；`cyberfile.xml`为`component_fusion_message`功能包的描述文件；dag 目录下的`component_fusion_message.dag`文件中描述了`component_fusion_message`功能包的依赖关系；launch 文件夹下的`component_fusion_message.launch`为`component_fusion_message`功能包的 launch 启动文件；proto 文件夹下的 BUILD 为用户在 proto 文件夹下定义的`protobuffer`文件的编译规则文件，`component_fusion_message.proto`文件中用户可以定义自己的消息结构。
 
 ### 3. 定义Component消息结构
 
 1. 在`component_fusion_message.proto`中，添加以下消息数据结构。
 
-   ```bash
-   syntax = "proto2";
+    ```bash
+    syntax = "proto2";
 
     package apollo;
 
@@ -146,16 +146,16 @@ module_config {
       optional string name = 1;
       optional string fusion_topic = 2;
     };
-   ```
+    ```
 
-   在`ComponentFusionMessageMsg`中添加 fusion_content、fusion_msg_id 和 timestamp 3 项，分别表示消息内容，消息编号和消息发出时的时间戳。
+    在`ComponentFusionMessageMsg`中添加 fusion_content、fusion_msg_id 和 timestamp 3 项，分别表示消息内容，消息编号和消息发出时的时间戳。
 
-   在`ComponentFusionMessageConfig`中添加可配置项 name 和 fusion_topic ，用来配置 `ComponentFusionMessageConfig`的名称标识和输出数据的 channel。
+    在`ComponentFusionMessageConfig`中添加可配置项 name 和 fusion_topic ，用来配置 `ComponentFusionMessageConfig`的名称标识和输出数据的 channel。
 
 2. 在 proto 文件夹下的 BUILD 文件中，添加`protobuffer`文件的编译规则。
 
-   ```bash
-   load("//tools:apollo_package.bzl", "apollo_package")
+    ```bash
+    load("//tools:apollo_package.bzl", "apollo_package")
     load("//tools/proto:proto.bzl", "proto_library")
     load("//tools:cpplint.bzl", "cpplint")
 
@@ -169,9 +169,9 @@ module_config {
     apollo_package()
 
     cpplint()
-   ```
+    ```
 
-   由于没有新增`protobuffer`文件，这里无需修改 BUILD 文件，如若新增`protobuffer`文件，可参考 BUILD 文件中已有的配置规则，添加对应`protobuffer`的编译规则。
+    由于没有新增`protobuffer`文件，这里无需修改 BUILD 文件，如若新增`protobuffer`文件，可参考 BUILD 文件中已有的配置规则，添加对应`protobuffer`的编译规则。
 
 ### 4. 配置Component的配置文件
 
@@ -188,8 +188,8 @@ fusion_topic: "/fusion/message"
 
 1. 修改`component_fusion_message.h`文件。
 
-   ```bash
-   #pragma once
+    ```cpp
+    #pragma once
     #include <memory>
 
     #include "cyber/cyber.h"
@@ -216,22 +216,22 @@ fusion_topic: "/fusion/message"
     CYBER_REGISTER_COMPONENT(ComponentFusionMessage)
 
     } // namespace apollo
-   ```
+    ```
 
-   由于 component 要融合的消息类型是`TimerComponentSensorMsg`，这里需要包含（include）定义`TimerComponentSensorMsg`的头文件（timer_component_sensor.pb.h）。
+    由于 component 要融合的消息类型是`TimerComponentSensorMsg`，这里需要包含（include）定义`TimerComponentSensorMsg`的头文件（timer_component_sensor.pb.h）。
 
-   使用 **using** 引入将 **apollo::cyber** 命名空间下的 **Time** 和 **Write** 注入当前作用域中；
+    使用 **using** 引入将 **apollo::cyber** 命名空间下的 **Time** 和 **Write** 注入当前作用域中；
 
-   修改类继承 component 的模板参数；将模板参数改为要融合的消息类型，两个参数。
+    修改类继承 component 的模板参数；将模板参数改为要融合的消息类型，两个参数。
 
-   修改 Proc 函数的输入参数；将 Proc 函数的输入参数修改为 **TimerComponentSensorMsg** 的指针。
+    修改 Proc 函数的输入参数；将 Proc 函数的输入参数修改为 **TimerComponentSensorMsg** 的指针。
 
-   ComponentFusionMessage 类增加私有成员 fusion*writer*，fusion*writer* 是智能指针，指向 Writer 对象，Writer 对象可以写出`ComponentFusionMessageMsg`数据。
+    ComponentFusionMessage 类增加私有成员 fusion*writer*，fusion*writer* 是智能指针，指向 Writer 对象，Writer 对象可以写出`ComponentFusionMessageMsg`数据。
 
 2. 修改`component_fusion_message.cc`文件。
 
-   ```bash
-   #include "component/component_fusion_message/component_fusion_message_component.h"
+    ```cpp
+    #include "component/component_fusion_message/component_fusion_message_component.h"
 
     namespace apollo {
 
@@ -266,17 +266,17 @@ fusion_topic: "/fusion/message"
     }
 
     } // namespace apollo
-   ```
+    ```
 
-   在 Init 函数中增加智能指针 fusion*write* 的初始化；
+    在 Init 函数中增加智能指针 fusion*write* 的初始化；
 
-   修改 Proc 函数的输入参数与头文件中的定义一致；
+    修改 Proc 函数的输入参数与头文件中的定义一致；
 
-   在 Proc 函数中创建`ComponentFusionMessageMsg`消息，并通过 fusion*writer* 发出消息到对应的 channel。
+    在 Proc 函数中创建`ComponentFusionMessageMsg`消息，并通过 fusion*writer* 发出消息到对应的 channel。
 
 3. 修改`BUILD`文件。
 
-   ```bash
+    ```bash
     load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
     load("//tools:cpplint.bzl", "cpplint")
 
@@ -311,7 +311,7 @@ fusion_topic: "/fusion/message"
     apollo_package()
 
     cpplint()
-   ```
+    ```
 
    由于源文件中由于包含了`timer_component_sensor.pb.h`，需要在编译的依赖项中添加对应的依赖项。
 
@@ -333,7 +333,7 @@ buildtool build -p  component/component_fusion_message/
 
 在`component_fusion_message.dag`文件中，将第一个 readers 相中的 channel 值改为 component 中融合的主 channel， 在主 channel readers下面添加需要融合的其它 readers 配置，并配置正确的 channel。
 
-```bash
+```proto
 module_config {
   module_library : "component/component_fusion_message/libcomponent_fusion_message_component.so"
   components {
@@ -357,7 +357,7 @@ module_config {
 
 ### 8. 修改Component的launch文件
 
-```bash
+```xml
 <cyber>
   <module>
     <name>component_fusion_message</name>
@@ -405,7 +405,7 @@ module_config {
 
 复制`component_fusion_message.launch`文件，并重命名为`component_fusion_message_all.launch`，将`timer_component_sensor.launch`文件和`timer_component_sensor_second.launch`文件中的 <module> 标签内容拷贝到`component_fusion_message_all.launch`中的 <cyber> 标签内。这样，就可以只启动此`component_fusion_message_all.launch`文件即可一次启动 3 个 component 了。
 
-```bash
+```xml
 <cyber>
   <module>
     <name>timer_component_sensor</name>

--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT组件机制/Cyber RT 之 Timer Component 实践.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT组件机制/Cyber RT 之 Timer Component 实践.md
@@ -18,24 +18,24 @@ https://apollo.baidu.com/community/course/36
 
 1. 在终端中，执行以下指令，在 component 文件夹下生成 timer_component_sensor 模板实例（功能包）。
 
-   ```bash
-   buildtool create --template timer_component component/timer_component_sensor
-   ```
+    ```bash
+    buildtool create --template timer_component component/timer_component_sensor
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3bc1b05.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3bc1b05.png)
 
 2. 使用 cd 指令，切换目录到生成的`timer_component_sensor`目录下，使用 tree 命令查看生成的 component 功能包的目录结构。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_b89bc55.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_b89bc55.png)
 
-   其中，BUILD 文件为 TimerComponent 的源码编译的规则文件；conf 目录下，`timer_component_sensor.conf`为全局变量配置文件，`timer_component_sensor.pb.txt`为用户在 proto 文件中定义的可配置项的配置文件；`cyberfile.xml`为`timer_component_sensor`功能包的描述文件；dag 目录下的`timer_component_sensor.dag`文件中描述了`timer_component_sensor`功能包的依赖关系；launch 文件夹下的`timer_component_sensor.launch`为`timer_component_sensor`功能包的 launch 启动文件；proto 文件夹下的 BUILD 为用户在 proto 文件夹下定义的 protobuffer 文件的编译规则文件，`timer_component_sensor.proto`文件中用户可以定义自己的消息结构；`timer_component_sensor.cc`和`timer_component_sensor.h`两个文件为 TimerComponent 的源文件和头文件。
+    其中，BUILD 文件为 TimerComponent 的源码编译的规则文件；conf 目录下，`timer_component_sensor.conf`为全局变量配置文件，`timer_component_sensor.pb.txt`为用户在 proto 文件中定义的可配置项的配置文件；`cyberfile.xml`为`timer_component_sensor`功能包的描述文件；dag 目录下的`timer_component_sensor.dag`文件中描述了`timer_component_sensor`功能包的依赖关系；launch 文件夹下的`timer_component_sensor.launch`为`timer_component_sensor`功能包的 launch 启动文件；proto 文件夹下的 BUILD 为用户在 proto 文件夹下定义的 protobuffer 文件的编译规则文件，`timer_component_sensor.proto`文件中用户可以定义自己的消息结构；`timer_component_sensor.cc`和`timer_component_sensor.h`两个文件为 TimerComponent 的源文件和头文件。
 
 ### 2. 定义TimerComponent消息结构
 
 1. 在`timer_component_sensor.proto`中，添加以下消息数据结构。
 
-   ```bash
-   syntax = "proto2";
+    ```proto
+    syntax = "proto2";
 
     package apollo;
 
@@ -52,16 +52,16 @@ https://apollo.baidu.com/community/course/36
       optional string name = 1;
       optional string sensor_topic = 2;
     };
-   ```
+    ```
 
-   在 **TimerComponentSensorMsg** 中添加 content、msg_id 和 timestamp 3 项，分别表示消息内容，消息编号和消息发出时的时间戳。
+    在 **TimerComponentSensorMsg** 中添加 content、msg_id 和 timestamp 3 项，分别表示消息内容，消息编号和消息发出时的时间戳。
 
-   在 **TimerComponentSensorConfig** 中添加可配置项 name 和 sensor_topic，用来配置`timer_component_sensor`的名称和输出数据的 channel。
+    在 **TimerComponentSensorConfig** 中添加可配置项 name 和 sensor_topic，用来配置`timer_component_sensor`的名称和输出数据的 channel。
 
 2. 在 proto 文件夹下的 BUILD 文件中，添加 protobuffer 文件的编译规则。
 
-   ```bash
-       load("//tools:apollo_package.bzl", "apollo_package")
+    ```bash
+    load("//tools:apollo_package.bzl", "apollo_package")
     load("//tools/proto:proto.bzl", "proto_library")
     load("//tools:cpplint.bzl", "cpplint")
 
@@ -75,9 +75,9 @@ https://apollo.baidu.com/community/course/36
     apollo_package()
 
     cpplint()
-   ```
+    ```
 
-   由于没有新增 proto 文件，这里无需修改 BUILD 文件，如若新增 proto 文件，可参考 BUILD 文件中已有的配置规则，添加对应 proto 的编译规则。
+    由于没有新增 proto 文件，这里无需修改 BUILD 文件，如若新增 proto 文件，可参考 BUILD 文件中已有的配置规则，添加对应 proto 的编译规则。
 
 ### 3. 配置TimerComponent的配置文件
 
@@ -94,75 +94,75 @@ sensor_topic:"/sensor/first"
 
 1.  修改`timer_component_sensor.h`文件：
 
-    ```bash
+    ```cpp
     #pragma once
-     #include <memory>
+    #include <memory>
 
-     #include "cyber/common/macros.h"
-     #include "cyber/component/component.h"
-     #include "cyber/component/timer_component.h"
-     #include "cyber/cyber.h"
-     #include "component/timer_component_sensor/proto/timer_component_sensor.pb.h"
+    #include "cyber/common/macros.h"
+    #include "cyber/component/component.h"
+    #include "cyber/component/timer_component.h"
+    #include "cyber/cyber.h"
+    #include "component/timer_component_sensor/proto/timer_component_sensor.pb.h"
 
-     using apollo::cyber::Time;
-     using apollo::cyber::Writer;
+    using apollo::cyber::Time;
+    using apollo::cyber::Writer;
 
-     namespace apollo {
+    namespace apollo {
 
-     class TimerComponentSensor final
-       : public apollo::cyber::TimerComponent {
-      public:
-       bool Init() override;
-       bool Proc() override;
+    class TimerComponentSensor final
+      : public apollo::cyber::TimerComponent {
+    public:
+      bool Init() override;
+      bool Proc() override;
 
-      private:
-       apollo::TimerComponentSensorConfig config_;
-       std::shared_ptr<Writer<TimerComponentSensorMsg>> sensor_writer_ = nullptr;
-     };
+    private:
+      apollo::TimerComponentSensorConfig config_;
+      std::shared_ptr<Writer<TimerComponentSensorMsg>> sensor_writer_ = nullptr;
+    };
 
-     CYBER_REGISTER_COMPONENT(TimerComponentSensor)
+    CYBER_REGISTER_COMPONENT(TimerComponentSensor)
 
-     } // namespace apollo
+    } // namespace apollo
     ```
 
-        在`timer_component_sensor.h`文件中使用 **using** 引入将 **apollo::cyber** 命名空间下的 **Time** 和 **Write** 注入当前作用域中，在 **TimerComponentSensor** 类的中增加私有成员 **sensor_write**，**sensor_write** 是智能指针，指向 **Writer** 对象，**Writer** 对象可以写出 **TimerComponentSensorMsg** 数据。
+    在`timer_component_sensor.h`文件中使用 **using** 引入将 **apollo::cyber** 命名空间下的 **Time** 和 **Write** 注入当前作用域中，在 **TimerComponentSensor** 类的中增加私有成员 **sensor_write**，**sensor_write** 是智能指针，指向 **Writer** 对象，**Writer** 对象可以写出 **TimerComponentSensorMsg** 数据。
 
 2.  修改`timer_component_sensor.cc`文件。
 
-    ```bash
+    ```cpp
     #include "component/timer_component_sensor/timer_component_sensor_component.h"
 
-     namespace apollo {
+    namespace apollo {
 
-     bool TimerComponentSensor::Init() {
+    bool TimerComponentSensor::Init() {
 
-       ACHECK(ComponentBase::GetProtoConfig(&config_))
-           << "failed to load timer_component_sensor config file "
-           << ComponentBase::ConfigFilePath();
+      ACHECK(ComponentBase::GetProtoConfig(&config_))
+          << "failed to load timer_component_sensor config file "
+          << ComponentBase::ConfigFilePath();
 
-       AINFO << "Load config succedded.\n" << config_.DebugString();
-       // TODO: add your own init code here.
-       sensor_writer_ = node_->CreateWriter<TimerComponentSensorMsg>(config_.sensor_topic().c_str());
+      AINFO << "Load config succedded.\n" << config_.DebugString();
+      // TODO: add your own init code here.
+      sensor_writer_ = node_->CreateWriter<TimerComponentSensorMsg>(config_.sensor_topic().c_str());
 
-       AINFO << "Init TimerComponentSensor succedded.";
-       return true;
-     }
+      AINFO << "Init TimerComponentSensor succedded.";
+      return true;
+    }
 
-     bool TimerComponentSensor::Proc() {
-       AINFO << "Proc TimerComponentSensor triggered.";
+    bool TimerComponentSensor::Proc() {
+      AINFO << "Proc TimerComponentSensor triggered.";
 
-       // TODO: add your own proc code here.
-       static int i = 0;
-       auto out_msg = std::make_shared<TimerComponentSensorMsg>();
-       out_msg->set_msg_id(i++);
-       out_msg->set_content(config_.name());
-       out_msg->set_timestamp(Time::Now().ToNanosecond());
-       sensor_writer_->Write(out_msg);
+      // TODO: add your own proc code here.
+      static int i = 0;
+      auto out_msg = std::make_shared<TimerComponentSensorMsg>();
+      out_msg->set_msg_id(i++);
+      out_msg->set_content(config_.name());
+      out_msg->set_timestamp(Time::Now().ToNanosecond());
+      sensor_writer_->Write(out_msg);
 
-       return true;
-     }
+      return true;
+    }
 
-     } // namespace apollo
+    } // namespace apollo
     ```
 
     在 Init 函数中增加智能指针 **sensor_write** 的初始化，
@@ -172,39 +172,39 @@ sensor_topic:"/sensor/first"
 3.  修改 BUILD 文件。
 
     ```bash
-        load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
-     load("//tools:cpplint.bzl", "cpplint")
+    load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
+    load("//tools:cpplint.bzl", "cpplint")
 
-     package(default_visibility = ["//visibility:public"])
+    package(default_visibility = ["//visibility:public"])
 
-     filegroup(
-         name = "timer_component_sensor_files",
-         srcs = glob([
-             "dag/**",
-             "launch/**",
-             "conf/**",
-         ]),
-     )
+    filegroup(
+        name = "timer_component_sensor_files",
+        srcs = glob([
+            "dag/**",
+            "launch/**",
+            "conf/**",
+        ]),
+    )
 
-     apollo_component(
-         name = "libtimer_component_sensor_component.so",
-         srcs = [
-             "timer_component_sensor_component.cc",
-         ],
-         hdrs = [
-             "timer_component_sensor_component.h",
-         ],
-         linkstatic = True,
-         deps = [
-             "//cyber",
-             "//component/timer_component_sensor/proto:timer_component_sensor_proto",
+    apollo_component(
+        name = "libtimer_component_sensor_component.so",
+        srcs = [
+            "timer_component_sensor_component.cc",
+        ],
+        hdrs = [
+            "timer_component_sensor_component.h",
+        ],
+        linkstatic = True,
+        deps = [
+            "//cyber",
+            "//component/timer_component_sensor/proto:timer_component_sensor_proto",
 
-         ],
-     )
+        ],
+    )
 
-     apollo_package()
+    apollo_package()
 
-     cpplint()
+    cpplint()
     ```
 
     由于没有包含其它 proto 文件或者头文件，这里的 BUILD 文件无需修改。
@@ -227,7 +227,7 @@ buildtool build -p  component/timer_component_sensor
 
 在`timer_component_sensor.dag`文件中，将 interval 项的值改为 500，即每 500ms 运行一次。interval 值为 TimerComponent 的运行时间间隔。
 
-```bash
+```proto
 module_config {
   module_library : "component/timer_component_sensor/libtimer_component_sensor_component.so"
   timer_components {
@@ -246,7 +246,7 @@ module_config {
 
 在<dag_conf>标签内的 dag 文件路径前加上“ ./ ” 。由于目前 cyber 与 apollo 绑定的比较紧密，编译完成后，系统会把编译产出及配置文件拷贝到 apollo 相应目录下，且执行文件时，系统会优先执行 apollo 目录下的文件，这样就会导致此处的配置无法起作用，这里加上“ ./ ”，就是告诉系统使用此处的 dag 文件来运行 component。
 
-```bash
+```xml
 <cyber>
   <module>
     <name>timer_component_sensor</name>

--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT调度机制/Cyber调度实践之优先级策略配置.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT调度机制/Cyber调度实践之优先级策略配置.md
@@ -32,140 +32,140 @@ https://apollo.baidu.com/community/course/41#
 
 1. 修改`/apollo/cyber/conf/example_sched_choreography.conf`，通过更改配置可以设置任务的优先级。这里面设置了 common0，common1，common2，common3 四个任务，以及对应的优先级，tasks：这里是对 task 任务进行配置，name 表示 task 的名字，prio 表示任务的优先级，值越大表明优先级越高，这四个任务的优先级顺序，从高到低依次为 common3，common2，common1，common0。
 
-   ```bash
-   scheduler_conf {
-    policy: "choreography"
-    process_level_cpuset: "0"  # all threads in the process are on the cpuset
+    ```proto
+    scheduler_conf {
+        policy: "choreography"
+        process_level_cpuset: "0"  # all threads in the process are on the cpuset
 
-    choreography_conf {
-        choreography_processor_num: 4
-        choreography_affinity: "range"
-        choreography_cpuset: "0"
-        choreography_processor_policy: "SCHED_FIFO" # policy: SCHED_OTHER,SCHED_RR,SCHED_FIFO
-        choreography_processor_prio: 10
+        choreography_conf {
+            choreography_processor_num: 4
+            choreography_affinity: "range"
+            choreography_cpuset: "0"
+            choreography_processor_policy: "SCHED_FIFO" # policy: SCHED_OTHER,SCHED_RR,SCHED_FIFO
+            choreography_processor_prio: 10
 
-        pool_processor_num: 4
-        pool_affinity: "range"
-        pool_cpuset: "0"
-        pool_processor_policy: "SCHED_OTHER"
-        pool_processor_prio: 0
+            pool_processor_num: 4
+            pool_affinity: "range"
+            pool_cpuset: "0"
+            pool_processor_policy: "SCHED_OTHER"
+            pool_processor_prio: 0
 
-        tasks: [
-            {
-                name: "common0"
-                processor: 0
-                prio: 1
-            },
-            {
-                name: "common1"
-                processor: 0
-                prio: 2
-            },
-            {
-                name: "common2"
-                processor: 0
-                prio: 3
-            },
-            {
-                name: "common3"
-                processor: 0
-                prio: 4
-            }
-        ]
+            tasks: [
+                {
+                    name: "common0"
+                    processor: 0
+                    prio: 1
+                },
+                {
+                    name: "common1"
+                    processor: 0
+                    prio: 2
+                },
+                {
+                    name: "common2"
+                    processor: 0
+                    prio: 3
+                },
+                {
+                    name: "common3"
+                    processor: 0
+                    prio: 4
+                }
+            ]
+        }
     }
-   }
-   ```
+    ```
 
 2. 在`/apollo/cyber/examples/common_component_example`路径下新建 common0.dag，common1.dag，common2.dag，common3.dag，修改common.launch。
 
-   命令为：
+    命令为：
 
-   ```bash
-   touch common0.dag common1.dag common2.dag common3.dag
-   ```
+    ```bash
+    touch common0.dag common1.dag common2.dag common3.dag
+    ```
 
-   四个文件的内容分别如下：
+    四个文件的内容分别如下：
 
-   ```bash
+    ```proto
     # Define all coms in DAG streaming.
     module_config {
-    module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
-    components {
-        class_name : "CommonComponentSample"
-        config {
-            name : "common0"
-            readers {
-                channel: "/apollo/prediction"
-            }
-            readers {
-                channel: "/apollo/test"
+        module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
+        components {
+            class_name : "CommonComponentSample"
+            config {
+                name : "common0"
+                readers {
+                    channel: "/apollo/prediction"
+                }
+                readers {
+                    channel: "/apollo/test"
+                }
             }
         }
-      }
     }
-   ```
+    ```
 
-   ```bash
+    ```proto
     # Define all coms in DAG streaming.
     module_config {
-    module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
-    components {
-        class_name : "CommonComponentSample"
-        config {
-            name : "common1"
-            readers {
-                channel: "/apollo/prediction"
-            }
-            readers {
-                channel: "/apollo/test"
+        module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
+        components {
+            class_name : "CommonComponentSample"
+            config {
+                name : "common1"
+                readers {
+                    channel: "/apollo/prediction"
+                }
+                readers {
+                    channel: "/apollo/test"
+                }
             }
         }
-      }
     }
-   ```
+    ```
 
-   ```bash
-   # Define all coms in DAG streaming.
+    ```proto
+    # Define all coms in DAG streaming.
     module_config {
-    module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
-    components {
-        class_name : "CommonComponentSample"
-        config {
-            name : "common2"
-            readers {
-                channel: "/apollo/prediction"
-            }
-            readers {
-                channel: "/apollo/test"
+        module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
+        components {
+            class_name : "CommonComponentSample"
+            config {
+                name : "common2"
+                readers {
+                    channel: "/apollo/prediction"
+                }
+                readers {
+                    channel: "/apollo/test"
+                }
             }
         }
-      }
     }
-   ```
+    ```
 
-   ```bash
-   # Define all coms in DAG streaming.
+    ```proto
+    # Define all coms in DAG streaming.
     module_config {
-    module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
-    components {
-        class_name : "CommonComponentSample"
-        config {
-            name : "common3"
-            readers {
-                channel: "/apollo/prediction"
-            }
-            readers {
-                channel: "/apollo/test"
+        module_library : "cyber/examples/common_component_example/libcommon_component_example.so"
+        components {
+            class_name : "CommonComponentSample"
+            config {
+                name : "common3"
+                readers {
+                    channel: "/apollo/prediction"
+                }
+                readers {
+                    channel: "/apollo/test"
+                }
             }
         }
-      }
     }
-   ```
+    ```
 
-   common.launch 配置如下：
+    common.launch 配置如下：
 
-   ```bash
-   <cyber>
+    ```xml
+    <cyber>
     <module>
         <name>common</name>
         <dag_conf>/apollo/cyber/examples/common_component_example/common0.dag</dag_conf>
@@ -174,39 +174,39 @@ https://apollo.baidu.com/community/course/41#
         <dag_conf>/apollo/cyber/examples/common_component_example/common3.dag</dag_conf>
         <process_name>example_sched_choreography</process_name>
     </module>
-   </cyber>
-   ```
+    </cyber>
+    ```
 
 3. 执行：
 
-   ```bash
-   channel_prediction_writer &
-   channel_test_writer &
-   ```
+    ```bash
+    channel_prediction_writer &
+    channel_test_writer &
+    ```
 
-   往 channel /apollo/prediction 和 /apollo/test 发送消息。
+    往 channel /apollo/prediction 和 /apollo/test 发送消息。
 
 4. 启动
 
-   ```bash
-   cyber_launch start /apollo/cyber/examples/common_component_example/common.launch
-   ```
+    ```bash
+    cyber_launch start /apollo/cyber/examples/common_component_example/common.launch
+    ```
 
-   用于消费 channel 中的消息。
+    用于消费 channel 中的消息。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_7874cef.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_7874cef.png)
 
 5. 新打开一个 Terminal，进入`/apollo/data/log`目录中，查看 mainboard.INFO 日志，可以看到任务的执行顺序，依次是 common3，common2，common1，common0，符合预期。
 
-   ```bash
-   cd /apollo/data/log
-   ll
-   ```
+    ```bash
+    cd /apollo/data/log
+    ll
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_08e9f94.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_08e9f94.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_4632854.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_4632854.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_37aa354.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_37aa354.png)
 
-   至此，实验结束。
+    至此，实验结束。

--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT通信机制/Cyber通信机制实践之Listener-Talker通信（C++）.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT通信机制/Cyber通信机制实践之Listener-Talker通信（C++）.md
@@ -60,7 +60,7 @@ https://apollo.baidu.com/community/course/37
 
 2. 定义此次通信消息的数据结构，编写`proto/communication.proto`文件，内容如下：
 
-   ```bash
+   ```proto
    syntax = "proto2";
 
    package apollo.communication.proto;
@@ -77,8 +77,8 @@ https://apollo.baidu.com/community/course/37
 
 3. 编写发送方 talker 代码，talker.cc 代码如下：
 
-   ```bash
-   #include "communication/proto/communication.pb.h"
+    ```cpp
+    #include "communication/proto/communication.pb.h"
     #include "cyber/cyber.h"
     #include "cyber/time/rate.h"
 
@@ -106,12 +106,12 @@ https://apollo.baidu.com/community/course/37
       }
       return 0;
     }
-   ```
+    ```
 
 4. 编写接受方 listener 代码，listener.cc 代码如下：
 
-   ```bash
-   #include "communication/proto/communication.pb.h"
+    ```cpp
+    #include "communication/proto/communication.pb.h"
     #include "cyber/cyber.h"
 
     using apollo::communication::proto::Car;
@@ -133,12 +133,12 @@ https://apollo.baidu.com/community/course/37
         apollo::cyber::WaitForShutdown();
         return 0;
     }
-   ```
+    ```
 
 5. 修改 BUILD 文件，将新写的代码加入到编译中，`communication/BUILD`文件修改如下：
 
-   ```bash
-       load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
+    ```bash
+    load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
     load("//tools:cpplint.bzl", "cpplint")
 
     package(default_visibility = ["//visibility:public"])

--- a/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT通信机制/Cyber通信机制实践之Listener-Talker通信（python）.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/Cyber RT通信机制/Cyber通信机制实践之Listener-Talker通信（python）.md
@@ -22,16 +22,16 @@ https://apollo.baidu.com/community/course/38
 
 1. 创建代码结构目录。
 
-   ```bash
+    ```bash
     buildtool create --template component communication
     touch /apollo_workspace/communication/listener.py
     touch /apollo_workspace/communication/talker.py
-   ```
+    ```
 
-   检验目录结构是否正确：
+    检验目录结构是否正确：
 
-   ```bash
-   communication
+    ```bash
+    communication
     ├── BUILD <必须有>
     ├── communication.cc
     ├── communication.h
@@ -48,14 +48,14 @@ https://apollo.baidu.com/community/course/38
     │   ├── BUILD <必须有>
     │   └── communication.proto <必须有>
     └── talker.py <必须有>
-   ```
+    ```
 
 2. 定义此次通信消息的数据结构，编写proto/communication.proto文件，内容如下：
 
-   ```bash
-   syntax = "proto2";
+    ```proto
+    syntax = "proto2";
 
-   package apollo.communication.proto;
+    package apollo.communication.proto;
 
     //定义一个车的消息，车的型号，车主，车的车牌号,已跑公里数,车速
     message Car{
@@ -65,12 +65,12 @@ https://apollo.baidu.com/community/course/38
         optional uint64 kilometers = 4;
         optional uint64 speed = 5;
     };
-   ```
+    ```
 
 3. 编写发送方 talker 代码，talker.py 代码如下：
 
-   ```bash
-   import time
+    ```python
+    import time
     from cyber.python.cyber_py3 import cyber
     from communication.proto.communication_pb2 import Car
 
@@ -97,39 +97,39 @@ https://apollo.baidu.com/community/course/38
 
     if __name__ == '__main__':
         main()
-   ```
+    ```
 
 4. 编写接受方 listener 代码，listener.py 代码如下：
 
-   ```bash
-   import time
-   from cyber.python.cyber_py3 import cyber
-   from communication.proto.communication_pb2 import Car
+    ```python
+    import time
+    from cyber.python.cyber_py3 import cyber
+    from communication.proto.communication_pb2 import Car
 
-   # 接收到消息后的回调函数
-   def message_callback(msg):
-       print("now speed is:", msg.speed)
+    # 接收到消息后的回调函数
+    def message_callback(msg):
+        print("now speed is:", msg.speed)
 
-   def main():
-       # 初始化 Cyber
-       cyber.init()
+    def main():
+        # 初始化 Cyber
+        cyber.init()
 
-       # 创建监听节点
-       listener_node = cyber.Node("listener")
+        # 创建监听节点
+        listener_node = cyber.Node("listener")
 
-       # 创建消息监听器并指定回调函数
-       listener = listener_node.create_reader("/car_speed", Car, message_callback)
+        # 创建消息监听器并指定回调函数
+        listener = listener_node.create_reader("/car_speed", Car, message_callback)
 
-       while not cyber.is_shutdown():
-           time.sleep(0.2)
+        while not cyber.is_shutdown():
+            time.sleep(0.2)
 
-   if __name__ == '__main__':
-       main()
-   ```
+    if __name__ == '__main__':
+        main()
+    ```
 
 5. 将`communication/BUILD`修改为以下内容：
 
-   ```bash
+    ```bash
     load("//tools:apollo_package.bzl", "apollo_cc_library", "apollo_cc_binary", "apollo_package", "apollo_component")
     load("//tools:cpplint.bzl", "cpplint")
 
@@ -138,7 +138,7 @@ https://apollo.baidu.com/community/course/38
     apollo_package()
 
     cpplint()
-   ```
+    ```
 
 ### 2. 编译程序
 

--- a/docs/应用实践/开发调试教程/Cyber RT实践/应用Cyber RT开发自动驾驶调试工具/Apollo工具开发之交通灯仿真控制工具制作.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/应用Cyber RT开发自动驾驶调试工具/Apollo工具开发之交通灯仿真控制工具制作.md
@@ -19,27 +19,27 @@ https://apollo.baidu.com/community/course/39
 
 1. 在终端中，执行 DreamView+ 启动指令，执行成功后，点击菜单栏 dreamview+ 按钮，进入 dreamview+ 界面。
 
-   ```bash
-   aem bootstrap start --plus
-   ```
+    ```bash
+    aem bootstrap start --plus
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_372016d.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_372016d.png)
 
-   当出现如下，即表示 dreamview+ 启动成功了。
+    当出现如下，即表示 dreamview+ 启动成功了。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_bf50bff.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_bf50bff.png)
 
 2. 左侧导航栏打开 **Mode Settings** 面板，模式选择 **PnC** Mode，操作选择 **Sim_Control**，进入仿真模式。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3f6490d.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3f6490d.png)
 
 3. 选择地图。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c93b265.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c93b265.png)
 
 4. 从左侧 **Modules** 模块种启动 Planning 模块。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_badef52.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_badef52.png)
 
 ### 步骤二：编辑代码实现任务功能
 
@@ -53,82 +53,82 @@ touch cyber_trafficlight.py
 
 1. 导入必要的库和模块。
 
-   首先，导入所需的 Python 库和 Apollo Cyber RT 模块。这些库和模块将帮助我们初始化 Cyber 框架并使用 Cyber RT 工具。
+    首先，导入所需的 Python 库和 Apollo Cyber RT 模块。这些库和模块将帮助我们初始化 Cyber 框架并使用 Cyber RT 工具。
 
-   ```bash
-   import argparse
+    ```python
+    import argparse
     from cyber.python.cyber_py3 import cyber
     from cyber.python.cyber_py3 import cyber_time
     import modules.common_msgs.perception_msgs.traffic_light_detection_pb2 as traffic_light_detection_pb2
     import threading
     import time
-   ```
+    ```
 
 2. 定义相关功能函数。
 
-   在这一步中，我们将定义几个功能函数，用于实现脚本的不同功能。
+    在这一步中，我们将定义几个功能函数，用于实现脚本的不同功能。
 
-   1）添加交通灯信息的函数。
+    1）添加交通灯信息的函数。
 
-   ```bash
-   def add_traffic_light(color, traffic_light_pb):
-    light = traffic_light_pb.traffic_light.add()
-    light.color = color
-    light.id = "红绿灯ID"  # 需要自行设置，这是交通灯的唯一标识
-    light.tracking_time = 10.0  # 设置跟踪时间，单位秒
-   ```
+    ```python
+    def add_traffic_light(color, traffic_light_pb):
+        light = traffic_light_pb.traffic_light.add()
+        light.color = color
+        light.id = "红绿灯ID"  # 需要自行设置，这是交通灯的唯一标识
+        light.tracking_time = 10.0  # 设置跟踪时间，单位秒
+    ```
 
-   2）添加消息头信息的函数。
+    2）添加消息头信息的函数。
 
-   ```bash
-   seq_num = 0
+    ```python
+    seq_num = 0
 
-   def add_header(msg):
-    global seq_num
-    msg.header.sequence_num = seq_num
-    msg.header.timestamp_sec = cyber_time.Time.now().to_sec()
-    msg.header.module_name = "manual_traffic_light"
-    seq_num += 1  # 递增序列号
-   ```
+    def add_header(msg):
+        global seq_num
+        msg.header.sequence_num = seq_num
+        msg.header.timestamp_sec = cyber_time.Time.now().to_sec()
+        msg.header.module_name = "manual_traffic_light"
+        seq_num += 1  # 递增序列号
+    ```
 
-   3）发布交通灯消息的函数。
+    3）发布交通灯消息的函数。
 
-   ```bash
-   def publish_traffic_light(writer, traffic_light_msg):
-    while not cyber.is_shutdown():
-        add_header(traffic_light_msg)  # 添加消息头信息
-        writer.write(traffic_light_msg)  # 发布交通灯消息
-        time.sleep(0.1)  # 控制消息发布速率
-   ```
+    ```python
+    def publish_traffic_light(writer, traffic_light_msg):
+        while not cyber.is_shutdown():
+            add_header(traffic_light_msg)  # 添加消息头信息
+            writer.write(traffic_light_msg)  # 发布交通灯消息
+            time.sleep(0.1)  # 控制消息发布速率
+    ```
 
 3. 初始化 Cyber 框架和相关对象。
 
    在主函数中，我们需要初始化 Cyber 框架和相关对象，以便使用 Cyber RT 工具。
 
-   ```bash
-   if __name__ == '__main__':
-    # 初始化交通灯检测消息对象
-    traffic_light_msg = traffic_light_detection_pb2.TrafficLightDetection()
+    ```python
+    if __name__ == '__main__':
+        # 初始化交通灯检测消息对象
+        traffic_light_msg = traffic_light_detection_pb2.TrafficLightDetection()
 
-    # 初始化Cyber框架
-    cyber.init()
-    node = cyber.Node("traffic_light_command")
+        # 初始化Cyber框架
+        cyber.init()
+        node = cyber.Node("traffic_light_command")
 
-    # 创建消息写入器
-    writer = node.create_writer(
-        "/apollo/perception/traffic_light", traffic_light_detection_pb2.TrafficLightDetection)
+        # 创建消息写入器
+        writer = node.create_writer(
+            "/apollo/perception/traffic_light", traffic_light_detection_pb2.TrafficLightDetection)
 
-    # 创建发布交通灯消息的线程
-    thread = threading.Thread(target=publish_traffic_light, args=(writer, traffic_light_msg))
-    thread.start()
-   ```
+        # 创建发布交通灯消息的线程
+        thread = threading.Thread(target=publish_traffic_light, args=(writer, traffic_light_msg))
+        thread.start()
+    ```
 
 4. 进入用户输入循环。
 
    在一个无限循环中，等待用户的输入。用户可以输入不同的命令，执行相应的操作。
 
-   ```bash
-   while not cyber.is_shutdown():
+    ```python
+    while not cyber.is_shutdown():
         user_input = input(
             "1: 设置交通灯为红色 2: 设置交通灯为绿色 3: 退出\n")
         traffic_light_msg.ClearField('traffic_light')  # 清空交通灯信息
@@ -146,118 +146,118 @@ touch cyber_trafficlight.py
 
     # 关闭Cyber框架
     cyber.shutdown()
-   ```
+    ```
 
-   总体：
+    总体：
 
-   ```bash
-   from cyber.python.cyber_py3 import cyber
-   from cyber.python.cyber_py3 import cyber_time
-   import modules.common_msgs.perception_msgs.traffic_light_detection_pb2 as traffic_light_detection_pb2
-   import threading
-   import time
+    ```python
+    from cyber.python.cyber_py3 import cyber
+    from cyber.python.cyber_py3 import cyber_time
+    import modules.common_msgs.perception_msgs.traffic_light_detection_pb2 as traffic_light_detection_pb2
+    import threading
+    import time
 
-   def add_forward_light(color, traffic_light_pb):
-       light = traffic_light_pb.traffic_light.add()
-       light.color = color
-       light.id = "红绿灯ID" #需要自行设置
-       light.tracking_time = 10.0
+    def add_forward_light(color, traffic_light_pb):
+        light = traffic_light_pb.traffic_light.add()
+        light.color = color
+        light.id = "红绿灯ID" #需要自行设置
+        light.tracking_time = 10.0
 
-   seq_num = 0
+    seq_num = 0
 
-   def add_header(msg):
-       global seq_num
-       msg.header.sequence_num = seq_num
-       msg.header.timestamp_sec = cyber_time.Time.now().to_sec()
-       msg.header.module_name = "manual_traffic_light"
-       seq_num = seq_num + 1
+    def add_header(msg):
+        global seq_num
+        msg.header.sequence_num = seq_num
+        msg.header.timestamp_sec = cyber_time.Time.now().to_sec()
+        msg.header.module_name = "manual_traffic_light"
+        seq_num = seq_num + 1
 
-   def pub_func(writer):
-       while not cyber.is_shutdown():
-           global traffic_light_msg
-           add_header(traffic_light_msg)
-           writer.write(traffic_light_msg)
-           time.sleep(0.1)
+    def pub_func(writer):
+        while not cyber.is_shutdown():
+            global traffic_light_msg
+            add_header(traffic_light_msg)
+            writer.write(traffic_light_msg)
+            time.sleep(0.1)
 
-   traffic_light_msg = None
+    traffic_light_msg = None
 
-   if __name__ == '__main__':
-       traffic_light_msg = traffic_light_detection_pb2.TrafficLightDetection()
-       cyber.init()
-       node = cyber.Node("traffic_light_command")
-       writer = node.create_writer(
-           "/apollo/perception/traffic_light", traffic_light_detection_pb2.TrafficLightDetection)
-       thread = threading.Thread(target=pub_func, args=(writer,))
-       thread.start()
-       while not cyber.is_shutdown():
-           m = input(
-               "1: forward red 2: forward green\n")
-           traffic_light_msg.ClearField('traffic_light')
-           print(m)
-           if m == '1':
-               add_forward_light(
-                   traffic_light_detection_pb2.TrafficLight.RED, traffic_light_msg)
-           elif m == "2":
-               add_forward_light(
-                   traffic_light_detection_pb2.TrafficLight.GREEN, traffic_light_msg)
+    if __name__ == '__main__':
+        traffic_light_msg = traffic_light_detection_pb2.TrafficLightDetection()
+        cyber.init()
+        node = cyber.Node("traffic_light_command")
+        writer = node.create_writer(
+            "/apollo/perception/traffic_light", traffic_light_detection_pb2.TrafficLightDetection)
+        thread = threading.Thread(target=pub_func, args=(writer,))
+        thread.start()
+        while not cyber.is_shutdown():
+            m = input(
+                "1: forward red 2: forward green\n")
+            traffic_light_msg.ClearField('traffic_light')
+            print(m)
+            if m == '1':
+                add_forward_light(
+                    traffic_light_detection_pb2.TrafficLight.RED, traffic_light_msg)
+            elif m == "2":
+                add_forward_light(
+                    traffic_light_detection_pb2.TrafficLight.GREEN, traffic_light_msg)
 
-       cyber.shutdown()
-   ```
+        cyber.shutdown()
+    ```
 
 ### 步骤三：路径设置工具的使用
 
 1. 打开 Dreamview+ routing editing。
 
-   在地图上选择起点、终点并保存。
+    在地图上选择起点、终点并保存。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_43361d3.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_43361d3.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_55e489f.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_55e489f.png)
 
-   点击播放按钮，车辆启动：
+    点击播放按钮，车辆启动：
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_1b1a0ee.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_1b1a0ee.png)
 
 2. 查看红绿灯 ID。
 
-   回到终端，打开 cyber_monitor
+    回到终端，打开 cyber_monitor
 
-   ```bash
-   cyber_monitor
-   ```
+    ```bash
+    cyber_monitor
+    ```
 
-   找到 planning 的 channel。
+    找到 planning 的 channel。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_a1fa25f.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_a1fa25f.png)
 
-   通过键盘的 PgUp 键进行翻页找到车辆停止原因。
+    通过键盘的 PgUp 键进行翻页找到车辆停止原因。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_7165b76.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_7165b76.png)
 
-   > 注意：TL\_后面的数字就是红绿灯的ID。
+    > 注意：TL\_后面的数字就是红绿灯的ID。
 
 3. 修改红绿灯 ID。
 
-   在工具中添加交通灯 ID：
+    在工具中添加交通灯 ID：
 
-   ```bash
+    ```python
     def add_traffic_light(color, traffic_light_pb):
         light = traffic_light_pb.traffic_light.add()
         light.color = color
         #light.id = "红绿灯ID" #修改前
         light.id = "451089196 #修改后
         light.tracking_time = 10.0
-   ```
+    ```
 
 4. 运行交通灯仿真控制工具。
 
-   ```bash
-   python cyber_trafficlight.py
-   ```
+    ```bash
+    python cyber_trafficlight.py
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_02a8989.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_02a8989.png)
 
-   > 注意：数字 1 是控制交通灯为红灯；数字 2 是控制交通灯为绿灯。
+    > 注意：数字 1 是控制交通灯为红灯；数字 2 是控制交通灯为绿灯。
 
 数字 1：
 

--- a/docs/应用实践/开发调试教程/Cyber RT实践/应用Cyber RT开发自动驾驶调试工具/Apollo工具开发之路径设置工具制作.md
+++ b/docs/应用实践/开发调试教程/Cyber RT实践/应用Cyber RT开发自动驾驶调试工具/Apollo工具开发之路径设置工具制作.md
@@ -20,27 +20,27 @@ https://apollo.baidu.com/community/course/40
 
 1. 在终端中，执行 DreamView+ 启动指令，执行成功后，点击菜单栏 dreamview+ 按钮，进入 dreamview+ 界面。
 
-   ```bash
-   aem bootstrap start --plus
-   ```
+    ```bash
+    aem bootstrap start --plus
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_9b5696d.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_9b5696d.png)
 
-   当出现如下，即表示 dreamview+ 启动成功了。
+    当出现如下，即表示 dreamview+ 启动成功了。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_204edc0.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_204edc0.png)
 
 2. 左侧导航栏打开 **Mode Settings** 面板，模式选择 **PnC** Mode，操作选择 **Sim_Control**，进入仿真模式。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c8bc6e9.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c8bc6e9.png)
 
 3. 选择地图。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_984ecea.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_984ecea.png)
 
 4. 从左侧 **Modules** 模块种启动 Planning 模块。
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c4c0ba6.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_c4c0ba6.png)
 
 ### 步骤二：编辑代码实现任务功能
 
@@ -50,58 +50,58 @@ https://apollo.baidu.com/community/course/40
 
 1. 导入必要的库和模块。
 
-   首先，导入所需的 Python 库和 Apollo Cyber RT 模块。这些库和模块将帮助我们初始化 Cyber 框架并创建路由请求消息。
+     首先，导入所需的 Python 库和 Apollo Cyber RT 模块。这些库和模块将帮助我们初始化 Cyber 框架并创建路由请求消息。
 
-   ```bash
-   import argparseimport time
-   from cyber.python.cyber_py3 import cyber
-   from cyber.python.cyber_py3 import cyber_time
-   from modules.common_msgs.external_command_msgs import lane_follow_command_pb2
-   from modules.common_msgs.external_command_msgs import command_status_pb2
-   ```
+    ```python
+    import argparseimport time
+    from cyber.python.cyber_py3 import cyber
+    from cyber.python.cyber_py3 import cyber_time
+    from modules.common_msgs.external_command_msgs import lane_follow_command_pb2
+    from modules.common_msgs.external_command_msgs import command_status_pb2
+    ```
 
 2. 初始化 Cyber 框架。
 
    在主函数中，我们需要初始化Cyber框架，以便与Cyber节点进行通信。这是实现与其他模块交互的第一步。
 
-   ```bash
-   def main():
-    # 初始化Cyber
-    cyber.init()
-    node = cyber.Node("mock_routing_requester")
-    sequence_num = 1
-   ```
+    ```python
+    def main():
+        # 初始化Cyber
+        cyber.init()
+        node = cyber.Node("mock_routing_requester")
+        sequence_num = 1
+    ```
 
 3. 创建路由请求消息。
 
    在此步骤中，我们将创建一个路由请求消息（LaneFollowCommand），并设置一些必要的属性，如时间戳、模块名称和序列号。
 
-   ```bash
+    ```python
     routing_request = lane_follow_command_pb2.LaneFollowCommand()
     routing_request.header.timestamp_sec = cyber_time.Time.now().to_sec()
     routing_request.header.module_name = 'cyber_routing'
     routing_request.header.sequence_num = sequence_num
     routing_request.is_start_pose_set = True
-   ```
+    ```
 
 4. 输入起点和终点坐标。
 
    设置从命令行获取用户输入的起点和终点坐标信息，包括起始航向、起始 X 坐标、起始 Y 坐标、终点航向、终点 X 坐标和终点 Y 坐标。
 
-   ```bash
+    ```python
     start_heading = float(input("start_heading : "))
     start_x = float(input("start_x : "))
     start_y = float(input("start_y : "))
     end_heading = float(input("end_heading: "))
     end_x = float(input("end_x : "))
     end_y = float(input("end_y: "))
-   ```
+    ```
 
 5. 添加路径信息。
 
-   在这一步中，输入的起点和终点坐标信息添加到路由请求消息中，包括起点和终点的坐标信息。
+    在这一步中，输入的起点和终点坐标信息添加到路由请求消息中，包括起点和终点的坐标信息。
 
-   ```bash
+    ````python
     waypoint = routing_request.way_point.add()
     waypoint.heading = start_heading
     waypoint.x = start_x
@@ -111,23 +111,23 @@ https://apollo.baidu.com/community/course/40
     waypoint1.heading = end_heading
     waypoint1.x = end_x
     waypoint1.y = end_y
-   ```
+    ```
 
 6. 创建 Cyber Writer 并发送路由请求。
 
-   最后，创建一个 Cyber Writer，并使用它来将路由请求消息发送到"/apollo/external_command/lane_follow"。
+    最后，创建一个 Cyber Writer，并使用它来将路由请求消息发送到"/apollo/external_command/lane_follow"。
 
-   ```bash
-   writer = node.create_client('/apollo/external_command/lane_follow', lane_follow_command_pb2.LaneFollowCommand, command_status_pb2.CommandStatus)
+    ```python
+    writer = node.create_client('/apollo/external_command/lane_follow', lane_follow_command_pb2.LaneFollowCommand, command_status_pb2.CommandStatus)
     time.sleep(2.0)
     print("routing", routing_request)
     writer.send_request(routing_request)
-   ```
+    ```
 
-   cyber 工具代码：
+    cyber 工具代码：
 
-   ```bash
-   from cyber.python.cyber_py3 import cyber
+    ```python
+    from cyber.python.cyber_py3 import cyber
     from cyber.python.cyber_py3 import cyber_time
     from modules.common_msgs.external_command_msgs import lane_follow_command_pb2
     from modules.common_msgs.external_command_msgs import command_status_pb2
@@ -181,41 +181,41 @@ https://apollo.baidu.com/community/course/40
 
     if __name__ == '__main__':
         main()
-   ```
+    ```
 
 ### 步骤三：路径设置工具的使用
 
 1. 运行路径设置工具。
 
-   ```bash
-   python cyber_routing.py
-   ```
+    ```bash
+    python cyber_routing.py
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_efc8ef9.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_efc8ef9.png)
 
 2. 打开 Dreamview+ routing editing。
 
-   在地图上找任意两点作为起点、终点：
+    在地图上找任意两点作为起点、终点：
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_cccb399.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_cccb399.png)
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_5d65e9e.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_5d65e9e.png)
 
 3. 在工具中输入起点坐标和终点坐标以及朝向。
 
-   ```bash
-   start_heading : 0.03
+    ```bash
+    start_heading : 0.03
     start_x : 752517.91
     start_y : 2563962.54
     end_heading: 0.00
     end_x : 752754.52
     end_y: 2563960.03
-   ```
+    ```
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d1a0429.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_d1a0429.png)
 
-   【车辆运行】
+    【车辆运行】
 
-   ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3919a2f.png)
+    ![image.png](https://bce.bdstatic.com/doc/Apollo-Homepage-Document/Apollo_Beta_Doc/image_3919a2f.png)
 
 【车辆运行】


### PR DESCRIPTION
To maintain consistency, I updated all markdown files under `docs/应用实践/开发调试教程/Cyber RT实践`, changing all indentations to 4 spaces (previously mixed 3- and 4-space indents).