### PR TITLE
Fix non-sequential reading of path_loc.

### DIFF
--- a/modules/external_command/external_command_demo/external_command_demo.cc
+++ b/modules/external_command/external_command_demo/external_command_demo.cc
@@ -302,6 +302,7 @@ void ExternalCommandDemo::SendPathFollowCommandWithLocationRecord(
           std::make_shared<apollo::external_command::PathFollowCommand>();
   std::vector<std::string> record_files =
       apollo::cyber::common::ListSubPaths(record_dir, DT_REG);
+  std::sort(record_files.begin(), record_files.end()); // Sort file names.
   std::string dir_prefix = record_dir + '/';
   for (const auto file_name : record_files) {
     ReadPathFromLocationRecord(dir_prefix + file_name,


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where `path_loc` could be read in a non-sequential order, which may lead to incorrect path indexing or unexpected behavior during path processing.

### Why is this needed?
When generating paths, the recorded path data is created in a strictly sequential order.  
However, the original reading logic does not guarantee that `path_loc` is accessed sequentially, which may cause a mismatch between the recording order and the reading order.  
In some scenarios, this mismatch can result in vehicles failing to follow the path correctly or being unable to proceed as expected.

### How was it tested?
- Verified the fix through local testing  
- Confirmed that `path_loc` is read sequentially after the change  
- No negative impact observed on existing logic

### Additional notes
This change is minimal and only affects the path reading logic, without modifying external interfaces or path data formats.
