### PR TITLE
fix: the calculation error in the P matrix in the piecewise_jerk_path_problem

### DIFF
--- a/modules/planning/planning_base/math/piecewise_jerk/piecewise_jerk_path_problem.cc
+++ b/modules/planning/planning_base/math/piecewise_jerk/piecewise_jerk_path_problem.cc
@@ -67,6 +67,14 @@ void PiecewiseJerkPathProblem::CalculateKernel(std::vector<c_float>* P_data,
                               (weight_ddx_ + weight_dddx_ / delta_s_square) /
                                   (scale_factor_[2] * scale_factor_[2]));
   ++value_index;
+
+  for (int i = 0; i < n - 1; ++i) {
+    columns[2 * n + i + 1].emplace_back(
+        2 * n + i, (-weight_dddx_ / delta_s_square) /
+                       (scale_factor_[2] * scale_factor_[2]));
+    ++value_index;
+  }
+
   for (int i = 1; i < n - 1; ++i) {
     columns[2 * n + i].emplace_back(
         2 * n + i, (weight_ddx_ + 2.0 * weight_dddx_ / delta_s_square) /
@@ -77,15 +85,7 @@ void PiecewiseJerkPathProblem::CalculateKernel(std::vector<c_float>* P_data,
       3 * n - 1,
       (weight_ddx_ + weight_dddx_ / delta_s_square + weight_end_state_[2]) /
           (scale_factor_[2] * scale_factor_[2]));
-  ++value_index;
-
-  // -2 * w_dddx / delta_s^2 * x(i)'' * x(i + 1)''
-  for (int i = 0; i < n - 1; ++i) {
-    columns[2 * n + i].emplace_back(2 * n + i + 1,
-                                    (-2.0 * weight_dddx_ / delta_s_square) /
-                                        (scale_factor_[2] * scale_factor_[2]));
-    ++value_index;
-  }
+  ++value_index; 
 
   CHECK_EQ(value_index, num_of_nonzeros);
 


### PR DESCRIPTION
Fix the P matrix calculation error in piecewise_jerk_path_problem. This bug causes the weight on l''' (jerk) in the cost function to not work