### PR TITLE
fix(docker): restore timezone-based CN geo detection

### DIFF
--- a/docker/scripts/dev_start.sh
+++ b/docker/scripts/dev_start.sh
@@ -276,17 +276,15 @@ function check_target_arch() {
 
 function check_timezone_cn() {
   # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  # time_zone=$(timedatectl | grep "Time zone" | xargs)
-  # time_zone=$(date +"%z")
+  time_zone=$(timedatectl | grep "Time zone" | xargs)
+  time_zone=$(date +"%z")
 
-  # for tz in "${TIMEZONE_CN[@]}"; do
-  #   if [[ "${time_zone}" == "${tz}" ]]; then
-  #     GEOLOC="cn"
-  #     return 0
-  #   fi
-  # done
-  # disable docker.io image source
-  GEOLOC="cn" 
+  for tz in "${TIMEZONE_CN[@]}"; do
+    if [[ "${time_zone}" == "${tz}" ]]; then
+      GEOLOC="cn"
+      return 0
+    fi
+  done
 }
 
 function setup_devices_and_mount_local_volumes() {


### PR DESCRIPTION
Detect CN geo from timezone instead of always defaulting to CN