### PR TITLE
[fix] cuda_configure: support newer GPU archs like compute_120 (Black…

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -303,7 +303,7 @@ def compute_capabilities(repository_ctx):
         for prefix in ["compute_", "sm_"]:
             if not capability.startswith(prefix):
                 continue
-            if len(capability) == len(prefix) + 2 and capability[-2:].isdigit():
+            if len(capability) <= len(prefix) + 3 and capability[len(prefix):].isdigit():
                 continue
             auto_configure_fail("Invalid compute capability: %s" % capability)
 


### PR DESCRIPTION
Fix build failure on new NVIDIA GPUs (e.g., RTX 5080/Blackwell) by updating cuda_configure to support 3-digit compute capabilities.