### PR TITLE
Perception: initialize static camera location refinement calibration

### DIFF
--- a/modules/perception/camera_location_refinement/BUILD
+++ b/modules/perception/camera_location_refinement/BUILD
@@ -61,6 +61,19 @@ apollo_component(
         "//modules/perception/common/camera:apollo_perception_common_camera",
         "//modules/perception/common/lib:apollo_perception_common_lib",
         "//modules/perception/common/onboard:apollo_perception_common_onboard",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+apollo_cc_test(
+    name = "camera_location_refinement_component_test",
+    size = "small",
+    srcs = [
+        "camera_location_refinement_component_test.cc",
+    ],
+    deps = [
+        ":libcamera_location_refinement_component_camera.so",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/modules/perception/camera_location_refinement/camera_location_refinement_component.cc
+++ b/modules/perception/camera_location_refinement/camera_location_refinement_component.cc
@@ -89,6 +89,33 @@ void CameraLocationRefinementComponent::SetCameraHeightAndPitch(
       pitch_angle_calibrator_working_sensor);
 }
 
+bool CameraLocationRefinementComponent::InitStaticCalibration(
+    const CameraLocationRefinement& location_refinement_param) {
+  if (calibration_service_ == nullptr) {
+    AERROR << "Calibration service is not available";
+    return false;
+  }
+  const float camera_height = location_refinement_param.default_camera_height();
+  if (camera_height <= 0.0f) {
+    AERROR << "default_camera_height must be positive, got: "
+           << camera_height;
+    return false;
+  }
+  std::map<std::string, float> name_camera_ground_height_map = {
+      {location_refinement_param.camera_name(), camera_height}};
+  std::map<std::string, float> name_camera_pitch_angle_diff_map = {
+      {location_refinement_param.camera_name(), 0.0f}};
+  SetCameraHeightAndPitch(name_camera_ground_height_map,
+                          name_camera_pitch_angle_diff_map,
+                          location_refinement_param.default_camera_pitch());
+  if (!calibration_service_->BuildIndex()) {
+    AERROR << "Failed to build calibration service index for "
+           << location_refinement_param.camera_name();
+    return false;
+  }
+  return true;
+}
+
 bool CameraLocationRefinementComponent::Init() {
   CameraLocationRefinement location_refinement_param;
   if (!GetProtoConfig(&location_refinement_param)) {
@@ -97,9 +124,9 @@ bool CameraLocationRefinementComponent::Init() {
   }
 
   InitPostprocessor(location_refinement_param);
-
-  // todo(daohu527): need complete
-  // SetCameraHeightAndPitch();
+  if (!InitStaticCalibration(location_refinement_param)) {
+    return false;
+  }
 
   writer_ = node_->CreateWriter<onboard::CameraFrame>(
       location_refinement_param.channel().output_obstacles_channel_name());

--- a/modules/perception/camera_location_refinement/camera_location_refinement_component.h
+++ b/modules/perception/camera_location_refinement/camera_location_refinement_component.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+#include "gtest/gtest_prod.h"
+
 #include "modules/perception/camera_location_refinement/proto/camera_location_refinement.pb.h"
 
 #include "cyber/cyber.h"
@@ -57,12 +59,20 @@ class CameraLocationRefinementComponent final
   void InitPostprocessor(
       const CameraLocationRefinement& location_refinement_param);
 
+  bool InitStaticCalibration(
+      const CameraLocationRefinement& location_refinement_param);
+
   void SetCameraHeightAndPitch(
       const std::map<std::string, float>& name_camera_ground_height_map,
       const std::map<std::string, float>& name_camera_pitch_angle_diff_map,
       const float& pitch_angle_calibrator_working_sensor);
 
  private:
+  FRIEND_TEST(CameraLocationRefinementComponentTest,
+              init_static_calibration_builds_ground_plane_test);
+  FRIEND_TEST(CameraLocationRefinementComponentTest,
+              init_static_calibration_rejects_non_positive_height_test);
+
   std::shared_ptr<BasePostprocessor> postprocessor_;
   std::shared_ptr<BaseCalibrationService> calibration_service_;
 

--- a/modules/perception/camera_location_refinement/camera_location_refinement_component_test.cc
+++ b/modules/perception/camera_location_refinement/camera_location_refinement_component_test.cc
@@ -1,0 +1,96 @@
+/******************************************************************************
+ * Copyright 2026 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/perception/camera_location_refinement/camera_location_refinement_component.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace perception {
+namespace camera {
+
+class RecordingCalibrationService : public BaseCalibrationService {
+ public:
+  bool Init(const CalibrationServiceInitOptions &options =
+                CalibrationServiceInitOptions()) override {
+    return true;
+  }
+
+  bool BuildIndex() override {
+    build_index_called = true;
+    return build_index_result;
+  }
+
+  void SetCameraHeightAndPitch(
+      const std::map<std::string, float> &name_camera_ground_height_map,
+      const std::map<std::string, float> &name_camera_pitch_angle_diff_map,
+      const float &pitch_angle_master_sensor) override {
+    camera_ground_height_map = name_camera_ground_height_map;
+    camera_pitch_angle_diff_map = name_camera_pitch_angle_diff_map;
+    master_sensor_pitch = pitch_angle_master_sensor;
+  }
+
+  std::string Name() const override { return "RecordingCalibrationService"; }
+
+  bool build_index_called = false;
+  bool build_index_result = true;
+  float master_sensor_pitch = 0.0f;
+  std::map<std::string, float> camera_ground_height_map;
+  std::map<std::string, float> camera_pitch_angle_diff_map;
+};
+
+class CameraLocationRefinementComponentTest : public ::testing::Test {};
+
+TEST_F(CameraLocationRefinementComponentTest,
+       init_static_calibration_builds_ground_plane_test) {
+  CameraLocationRefinementComponent component;
+  auto calibration_service = std::make_shared<RecordingCalibrationService>();
+  component.calibration_service_ = calibration_service;
+
+  CameraLocationRefinement config;
+  config.set_camera_name("front_6mm");
+  config.set_default_camera_pitch(0.12f);
+  config.set_default_camera_height(1.8f);
+
+  EXPECT_TRUE(component.InitStaticCalibration(config));
+  EXPECT_TRUE(calibration_service->build_index_called);
+  ASSERT_EQ(calibration_service->camera_ground_height_map.size(), 1u);
+  ASSERT_EQ(calibration_service->camera_pitch_angle_diff_map.size(), 1u);
+  EXPECT_FLOAT_EQ(
+      calibration_service->camera_ground_height_map.at("front_6mm"), 1.8f);
+  EXPECT_FLOAT_EQ(
+      calibration_service->camera_pitch_angle_diff_map.at("front_6mm"), 0.0f);
+  EXPECT_FLOAT_EQ(calibration_service->master_sensor_pitch, 0.12f);
+}
+
+TEST_F(CameraLocationRefinementComponentTest,
+       init_static_calibration_rejects_non_positive_height_test) {
+  CameraLocationRefinementComponent component;
+  auto calibration_service = std::make_shared<RecordingCalibrationService>();
+  component.calibration_service_ = calibration_service;
+
+  CameraLocationRefinement config;
+  config.set_camera_name("front_6mm");
+  config.set_default_camera_height(0.0f);
+
+  EXPECT_FALSE(component.InitStaticCalibration(config));
+  EXPECT_FALSE(calibration_service->build_index_called);
+  EXPECT_TRUE(calibration_service->camera_ground_height_map.empty());
+}
+
+}  // namespace camera
+}  // namespace perception
+}  // namespace apollo

--- a/modules/perception/camera_location_refinement/conf/camera_location_refinement_config.pb.txt
+++ b/modules/perception/camera_location_refinement/conf/camera_location_refinement_config.pb.txt
@@ -1,4 +1,6 @@
 camera_name: "front_6mm"
+default_camera_pitch: 0.0
+default_camera_height: 1.5
 postprocessor_param {
   plugin_param {
     name: "LocationRefinerPostprocessor"

--- a/modules/perception/camera_location_refinement/conf/camera_location_refinement_front_config.pb.txt
+++ b/modules/perception/camera_location_refinement/conf/camera_location_refinement_front_config.pb.txt
@@ -1,4 +1,6 @@
 camera_name: "front_6mm"
+default_camera_pitch: 0.0
+default_camera_height: 1.5
 postprocessor_param {
   plugin_param {
     name: "LocationRefinerPostprocessor"

--- a/modules/perception/camera_location_refinement/conf/camera_location_refinement_rear_config.pb.txt
+++ b/modules/perception/camera_location_refinement/conf/camera_location_refinement_rear_config.pb.txt
@@ -1,4 +1,6 @@
 camera_name: "front_12mm"
+default_camera_pitch: 0.0
+default_camera_height: 1.5
 postprocessor_param {
   plugin_param {
     name: "LocationRefinerPostprocessor"

--- a/modules/perception/camera_location_refinement/proto/camera_location_refinement.proto
+++ b/modules/perception/camera_location_refinement/proto/camera_location_refinement.proto
@@ -8,6 +8,8 @@ message CameraLocationRefinement {
   optional PostprocessorParam postprocessor_param = 2;
   optional CalibrationServiceParam calibration_service_param = 3;
   optional RefinementChannel channel = 4;
+  optional float default_camera_pitch = 5 [default = 0.0];
+  optional float default_camera_height = 6 [default = 1.5];
 }
 
 message RefinementChannel {


### PR DESCRIPTION
## Summary
- add explicit default camera height and pitch config for camera location refinement
- initialize the calibration service with a static single-camera ground plane during component init
- add a focused regression test for the static calibration setup

## Testing
- git diff --check
- bazel test --config=cpu --repo_env=PYTHON_BIN_PATH=/usr/bin/python3 --copt=-msse4.1 --host_copt=-msse4.1 //modules/perception/camera_location_refinement:camera_location_refinement_component_test (fails in workspace fetch because local_config_cuda cannot resolve cuda_toolkit_path on this host)