### PR TITLE
Perception: fix camera location refinement ROI symmetry

### DIFF
--- a/modules/perception/camera_location_refinement/BUILD
+++ b/modules/perception/camera_location_refinement/BUILD
@@ -38,6 +38,19 @@ apollo_cc_library(
         "//modules/perception/common/camera:apollo_perception_common_camera",
         "//modules/perception/common/lib:apollo_perception_common_lib",
         "//modules/perception/common/onboard:apollo_perception_common_onboard",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+apollo_cc_test(
+    name = "location_refiner_postprocessor_test",
+    size = "small",
+    srcs = [
+        "location_refiner/location_refiner_postprocessor_test.cc",
+    ],
+    deps = [
+        ":apollo_perception_camera_location_refinement",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/modules/perception/camera_location_refinement/location_refiner/location_refiner_postprocessor.h
+++ b/modules/perception/camera_location_refinement/location_refiner/location_refiner_postprocessor.h
@@ -18,6 +18,8 @@
 #include <memory>
 #include <string>
 
+#include "gtest/gtest_prod.h"
+
 #include "modules/perception/camera_location_refinement/location_refiner/proto/location_refiner.pb.h"
 
 #include "modules/perception/camera_location_refinement/interface/base_postprocessor.h"
@@ -68,11 +70,13 @@ class LocationRefinerPostprocessor : public BasePostprocessor {
     float img_w_half = img_w / 2.0f;
     float slope = img_w_half * algorithm::IRec(img_h - h_down - v);
     float left = img_w_half - slope * (y - v);
-    float right = img_w_half + slope * (y - h_down);
+    float right = img_w_half + slope * (y - v);
     return x > left && x < right;
   }
 
  private:
+  FRIEND_TEST(LocationRefinerPostprocessorTest, roi_is_symmetric_test);
+
   std::unique_ptr<ObjPostProcessor> postprocessor_;
   std::shared_ptr<BaseCalibrationService> calibration_service_;
   location_refiner::LocationRefinerParam location_refiner_param_;

--- a/modules/perception/camera_location_refinement/location_refiner/location_refiner_postprocessor_test.cc
+++ b/modules/perception/camera_location_refinement/location_refiner/location_refiner_postprocessor_test.cc
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Copyright 2026 The Apollo Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include "modules/perception/camera_location_refinement/location_refiner/location_refiner_postprocessor.h"
+
+#include "gtest/gtest.h"
+
+namespace apollo {
+namespace perception {
+namespace camera {
+
+class LocationRefinerPostprocessorTest : public ::testing::Test {};
+
+TEST_F(LocationRefinerPostprocessorTest, roi_is_symmetric_test) {
+  LocationRefinerPostprocessor postprocessor;
+
+  constexpr float kImageWidth = 1920.0f;
+  constexpr float kImageHeight = 1080.0f;
+  constexpr float kVanishingRow = 540.0f;
+  constexpr float kBottomMargin = 270.0f;
+  constexpr float kSampleRow = 675.0f;
+
+  const float inside_left[2] = {500.0f, kSampleRow};
+  const float inside_right[2] = {kImageWidth - inside_left[0], kSampleRow};
+  const float outside_left[2] = {420.0f, kSampleRow};
+  const float outside_right[2] = {kImageWidth - outside_left[0], kSampleRow};
+
+  EXPECT_TRUE(postprocessor.is_in_roi(inside_left, kImageWidth, kImageHeight,
+                                      kVanishingRow, kBottomMargin));
+  EXPECT_TRUE(postprocessor.is_in_roi(inside_right, kImageWidth, kImageHeight,
+                                      kVanishingRow, kBottomMargin));
+  EXPECT_FALSE(postprocessor.is_in_roi(outside_left, kImageWidth,
+                                       kImageHeight, kVanishingRow,
+                                       kBottomMargin));
+  EXPECT_FALSE(postprocessor.is_in_roi(outside_right, kImageWidth,
+                                       kImageHeight, kVanishingRow,
+                                       kBottomMargin));
+}
+
+}  // namespace camera
+}  // namespace perception
+}  // namespace apollo


### PR DESCRIPTION
## Summary
- fix the camera location refinement ROI trapezoid so the right boundary mirrors the left boundary
- add a regression test that checks symmetric points around the image center at the same row

## Testing
- git diff --check
- bazel test --config=cpu --repo_env=PYTHON_BIN_PATH=/usr/bin/python3 --copt=-msse4.1 --host_copt=-msse4.1 //modules/perception/camera_location_refinement:location_refiner_postprocessor_test (fails in workspace fetch because local_config_cuda cannot resolve cuda_toolkit_path on this host)