### PR TITLE
fix(scripts): update script for routing topo graph generation

### DIFF
--- a/scripts/generate_routing_topo_graph.sh
+++ b/scripts/generate_routing_topo_graph.sh
@@ -21,6 +21,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${DIR}/apollo_base.sh"
 
 # generate routing_map.bin in map directory.
-${APOLLO_BIN_PREFIX}/modules/routing/topo_creator/topo_creator \
-  --flagfile=modules/routing/conf/routing.conf \
+${APOLLO_BIN_PREFIX}/modules/routing/topo_creator \
+  --flagfile=/apollo/modules/routing/conf/routing.conf \
   $@


### PR DESCRIPTION
Fixes #15788.

<img width="1245" height="271" alt="image" src="https://github.com/user-attachments/assets/59f50b59-e603-4f79-8850-b919e4e4bc5e" />

The user can follow the documentation and use the fixed script to import a new HD map to Apollo.