### PR TITLE
fix: skip yuv2rgb.cu compilation in CPU-only builds

### DIFF
--- a/modules/drivers/camera/format/BUILD
+++ b/modules/drivers/camera/format/BUILD
@@ -1,14 +1,21 @@
 load("//tools:cpplint.bzl", "cpplint")
 
-load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "if_cuda")
 
 load("//tools:apollo_package.bzl", "apollo_package")
 
 package(default_visibility = ["//visibility:public"])
 
+# yuv2rgb.cu can only be compiled with the CUDA toolchain. Since this
+# package's generated `:install` target is unconditionally pulled in by
+# //modules/drivers/camera's own `:install` aggregation (via
+# apollo_package()'s automatic subpackage deps), simply excluding this
+# package from CPU builds isn't enough to keep it from being built. Instead,
+# drop the CUDA source when CUDA isn't configured so `:convert` degrades to
+# an empty (but buildable) library on CPU-only builds.
 cuda_library(
     name = "convert",
-    srcs = ["yuv2rgb.cu"],
+    srcs = if_cuda(["yuv2rgb.cu"], []),
     hdrs = ["yuv2rgb.h"],
     deps = [
         "//cyber",


### PR DESCRIPTION
modules/drivers/camera/format:convert is a cuda_library, but its generated `:install` target is unconditionally pulled in by //modules/drivers/camera's own `:install` aggregation (apollo_package() adds a hard dependency on every subpackage's `:install`, regardless of platform). This forces yuv2rgb.cu to be compiled even for `bash apollo.sh build_cpu`, where it fails because gcc doesn't recognize .cu files without the CUDA toolchain.

Gate the .cu source with if_cuda() so the library degrades to an empty target when CUDA isn't configured, instead of failing to compile.